### PR TITLE
Fix nullptr caused core dump

### DIFF
--- a/programs/local/LocalChdb.cpp
+++ b/programs/local/LocalChdb.cpp
@@ -34,8 +34,23 @@ public:
         delete memview;
     }
 
-    char * data() { return result->buf; }
-    size_t size() { return result->len; }
+    char * data()
+    {
+        if (result == nullptr)
+        {
+            return nullptr;
+        }
+        return result->buf;
+    }
+
+    size_t size()
+    {
+        if (result == nullptr)
+        {
+            return 0;
+        }
+        return result->len;
+    }
     py::memoryview get_memview() { return *memview; }
 };
 


### PR DESCRIPTION
```bash
python3 -m chdb "INSERT INTO FUNCTION url('https://urleng.com/xxx', JSONEachRow, 'key String, value UInt64') VALUES ('hello', 2)" Pretty
```
got `Aborted (core dumped)`