### PR TITLE
Strip library/wheels

### DIFF
--- a/chdb/build.sh
+++ b/chdb/build.sh
@@ -130,10 +130,10 @@ file ${LIBCHDB}
 
 rm -f ${CHDB_DIR}/*.so
 mv ${LIBCHDB} ${CHDB_DIR}/${CHDB_PY_MODULE}
-# strip ${CHDB_DIR}/${CHDB_PY_MODULE} || true
 
-# # strip the binary (no debug info at all)
-# strip ${CHDB_DIR}/${CHDB_PY_MODULE} || true
+# strip the binary (no debug info at all)
+strip ${CHDB_DIR}/${CHDB_PY_MODULE} || true
+
 # echo -e "\nAfter strip:"
 # echo -e "\nLIBCHDB: ${LIBCHDB}"
 # ls -lh ${CHDB_DIR}


### PR DESCRIPTION
As we grow in arch coverage and versions, space matters. 

Stripping the library could save 100+ megabytes per release/package and the impact on our ability to troubleshoot should be limited since we can easily rebuild locally as needed or bind this to an ENV variable if required.

### Changelog category (leave one):
- Build/Testing/Packaging Improvement

### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Strip distribution library used by wheels

