### PR TITLE
Fix misused clang flag on macOS

### DIFF
--- a/.github/workflows/build_wheels.yml
+++ b/.github/workflows/build_wheels.yml
@@ -233,6 +233,7 @@ jobs:
         continue-on-error: false
       - name: Run libchdb stub in examples dir
         run: |
+          nm libchdb.so | grep query_result
           bash -x ./examples/runStub.sh
       - name: Keep killall ccache and wait for ccache to finish
         if: always()


### PR DESCRIPTION
Sorry, I made a mistake. Maybe you need to re-release the 1.1.0 @auxten 