### PR TITLE
Make DBAPI implementation use session, fix execute for none-returning queries

### DIFF
--- a/chdb/dbapi/connections.py
+++ b/chdb/dbapi/connections.py
@@ -123,7 +123,7 @@ class Connection(object):
         if DEBUG:
             print("DEBUG: query:", sql)
         try:
-            self._resp = self._session.query(sql, output_format="JSON").data()
+            self._resp = self._session.query(sql, fmt="JSON").data()
         except Exception as error:
             raise err.InterfaceError("query err: %s" % error)
 

--- a/tests/test_dbapi.py
+++ b/tests/test_dbapi.py
@@ -27,20 +27,22 @@ class TestDBAPI(unittest.TestCase):
     def test_insert_and_read_data(self):
         conn = dbapi.connect()
         cur = conn.cursor()
+        cur.execute("CREATE DATABASE IF NOT EXISTS test_db ENGINE = Atomic")
+        cur.execute("USE test_db")
         cur.execute("""
         CREATE TABLE rate (
             day Date,
             value Int32
-        ) ENGINE = Memory""")
+        ) ENGINE = Log""")
 
         # Insert values
         cur.execute("INSERT INTO rate VALUES ('2024-01-01', 24)")
         cur.execute("INSERT INTO rate VALUES ('2024-01-02', 72)")
 
         # Read values
-        cur.execute("SELECT value FROM rate ORDER BY DAY DESC")
+        cur.execute("SELECT value FROM rate ORDER BY day DESC")
         rows = cur.fetchall()
-        self.assertEqual(rows, [(72,), (24,)])
+        self.assertEqual(rows, ((72,), (24,)))
 
     def test_select_chdb_version(self):
         ver = dbapi.get_client_info()  # chDB version liek '0.12.0'

--- a/tests/test_dbapi.py
+++ b/tests/test_dbapi.py
@@ -24,6 +24,24 @@ class TestDBAPI(unittest.TestCase):
         print(data)
         self.assertRegex(data[0], expected_clickhouse_version_pattern)
 
+    def test_insert_and_read_data(self):
+        conn = dbapi.connect()
+        cur = conn.cursor()
+        cur.execute("""
+        CREATE TABLE rate (
+            day Date,
+            value Int32
+        )""")
+
+        # Insert values
+        cur.execute("INSERT INTO rate VALUES ('2024-01-01', 24)")
+        cur.execute("INSERT INTO rate VALUES ('2024-01-02', 72)")
+
+        # Read values
+        cur.execute("SELECT value FROM rate ORDER BY DAY DESC")
+        rows = cur.fetchall()
+        self.assertEqual(rows, [(72,), (24,)])
+
     def test_select_chdb_version(self):
         ver = dbapi.get_client_info()  # chDB version liek '0.12.0'
         ver_tuple = dbapi.chdb_version  # chDB version tuple like ('0', '12', '0')

--- a/tests/test_dbapi.py
+++ b/tests/test_dbapi.py
@@ -31,7 +31,7 @@ class TestDBAPI(unittest.TestCase):
         CREATE TABLE rate (
             day Date,
             value Int32
-        )""")
+        ) ENGINE = Memory""")
 
         # Insert values
         cur.execute("INSERT INTO rate VALUES ('2024-01-01', 24)")


### PR DESCRIPTION
Fixes #163 #162 

### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)

### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Make dbapi implementation use session, which is stateful (most consumers of dbapi likely want statefulness). Also fix `execute` to not throw an exception for None-returning queries like `CREATE TABLE`.

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)