### PR TITLE
Fix executemany in dbapi cursor implementation, make tests more comprehensive

### DIFF
--- a/chdb/dbapi/cursors.py
+++ b/chdb/dbapi/cursors.py
@@ -206,7 +206,7 @@ class Cursor(object):
             prefix = prefix.encode(encoding)
         if isinstance(postfix, str):
             postfix = postfix.encode(encoding)
-        sql = str(prefix)
+        sql = prefix
         args = iter(args)
         v = values % escape(next(args), conn)
         if isinstance(v, str):
@@ -219,9 +219,9 @@ class Cursor(object):
                 v = v.encode(encoding, 'surrogateescape')
             if len(sql) + len(v) + len(postfix) + 1 > max_stmt_length:
                 rows += self.execute(sql + postfix)
-                sql = str(prefix)
+                sql = prefix
             else:
-                sql += ','
+                sql += ','.encode(encoding)
             sql += v
         rows += self.execute(sql + postfix)
         self.rowcount = rows

--- a/tests/test_dbapi.py
+++ b/tests/test_dbapi.py
@@ -63,6 +63,10 @@ class TestDBAPI(unittest.TestCase):
         rows = cur.fetchall()
         self.assertEqual(rows, ((96,), (72,), (24,)))
 
+        # Clean up
+        cur.close()
+        conn.close()
+
     def test_select_chdb_version(self):
         ver = dbapi.get_client_info()  # chDB version liek '0.12.0'
         ver_tuple = dbapi.chdb_version  # chDB version tuple like ('0', '12', '0')

--- a/tests/test_dbapi.py
+++ b/tests/test_dbapi.py
@@ -33,12 +33,14 @@ class TestDBAPI(unittest.TestCase):
         CREATE TABLE rate (
             day Date,
             value Int32
-        ) ENGINE = Log""")
+        ) ENGINE = ReplacingMergeTree ORDER BY day""")
 
         # Insert single value
         cur.execute("INSERT INTO rate VALUES (%s, %s)", ("2021-01-01", 24))
         # Insert multiple values
-        cur.executemany("INSERT INTO rate VALUES (%s, %s)", [("2021-01-02", 72), ("2021-01-03", 96)])
+        cur.executemany("INSERT INTO rate VALUES (%s, %s)", [("2021-01-02", 128), ("2021-01-03", 256)])
+        # Test executemany outside optimized INSERT/REPLACE path
+        cur.executemany("ALTER TABLE rate UPDATE value = %s WHERE day = %s", [(72, "2021-01-02"), (96, "2021-01-03")])
 
         # Test fetchone
         cur.execute("SELECT value FROM rate ORDER BY day DESC LIMIT 2")

--- a/tests/test_dbapi.py
+++ b/tests/test_dbapi.py
@@ -35,14 +35,15 @@ class TestDBAPI(unittest.TestCase):
             value Int32
         ) ENGINE = Log""")
 
-        # Insert values
-        cur.execute("INSERT INTO rate VALUES ('2024-01-01', 24)")
-        cur.execute("INSERT INTO rate VALUES ('2024-01-02', 72)")
+        # Insert single value
+        cur.execute("INSERT INTO rate VALUES (%s, %s)", ("2021-01-01", 24))
+        # Insert multiple values
+        cur.executemany("INSERT INTO rate VALUES (%s, %s)", [("2021-01-02", 72), ("2021-01-03", 96)])
 
         # Read values
         cur.execute("SELECT value FROM rate ORDER BY day DESC")
         rows = cur.fetchall()
-        self.assertEqual(rows, ((72,), (24,)))
+        assert rows==((96,), (72,), (24,))
 
     def test_select_chdb_version(self):
         ver = dbapi.get_client_info()  # chDB version liek '0.12.0'

--- a/tests/test_dbapi.py
+++ b/tests/test_dbapi.py
@@ -40,10 +40,24 @@ class TestDBAPI(unittest.TestCase):
         # Insert multiple values
         cur.executemany("INSERT INTO rate VALUES (%s, %s)", [("2021-01-02", 72), ("2021-01-03", 96)])
 
-        # Read values
+        # Test fetchone
+        cur.execute("SELECT value FROM rate ORDER BY day DESC LIMIT 2")
+        row1 = cur.fetchone()
+        self.assertEqual(row1, (96,))
+        row2 = cur.fetchone()
+        self.assertEqual(row2, (72,))
+
+        # Test fetchmany
+        cur.execute("SELECT value FROM rate ORDER BY day DESC")
+        result_set1 = cur.fetchmany(2)
+        self.assertEqual(result_set1, ((96,), (72,)))
+        result_set2 = cur.fetchmany(1)
+        self.assertEqual(result_set2, ((24,),))
+
+        # Test fetchall
         cur.execute("SELECT value FROM rate ORDER BY day DESC")
         rows = cur.fetchall()
-        assert rows==((96,), (72,), (24,))
+        self.assertEqual(rows, ((96,), (72,), (24,)))
 
     def test_select_chdb_version(self):
         ver = dbapi.get_client_info()  # chDB version liek '0.12.0'

--- a/tests/test_dbapi.py
+++ b/tests/test_dbapi.py
@@ -48,6 +48,8 @@ class TestDBAPI(unittest.TestCase):
         self.assertEqual(row1, (96,))
         row2 = cur.fetchone()
         self.assertEqual(row2, (72,))
+        row3 = cur.fetchone()
+        self.assertIsNone(row3)
 
         # Test fetchmany
         cur.execute("SELECT value FROM rate ORDER BY day DESC")


### PR DESCRIPTION
### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)

### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
`executemany` in the DBAPI cursor implementation would previously not work due to `TypeError: can only concatenate str (not "bytes") to str` in `_do_execute_many`. This PR correctly interprets everything as encoded bytes, and adds a test for executemany and parameterized queries.

(This unblocks something I ran into while getting chdb to work with [clickhouse-sqlalchemy](https://github.com/xzkostyan/clickhouse-sqlalchemy))

### Documentation entry for user-facing changes

- [x] Documentation is written (mandatory for new features)