### PR TITLE
Disable output_format_json_quote_64bit_integers

### DIFF
--- a/src/Core/Settings.h
+++ b/src/Core/Settings.h
@@ -979,7 +979,7 @@ class IColumn;
     M(UInt64, format_binary_max_array_size, 1_GiB, "The maximum allowed size for Array in RowBinary format. It prevents allocating large amount of memory in case of corrupted data. 0 means there is no limit", 0) \
     M(URI, format_avro_schema_registry_url, "", "For AvroConfluent format: Confluent Schema Registry URL.", 0) \
     \
-    M(Bool, output_format_json_quote_64bit_integers, true, "Controls quoting of 64-bit integers in JSON output format.", 0) \
+    M(Bool, output_format_json_quote_64bit_integers, false, "Controls quoting of 64-bit integers in JSON output format.", 0) \
     M(Bool, output_format_json_quote_denormals, false, "Enables '+nan', '-nan', '+inf', '-inf' outputs in JSON output format.", 0) \
     M(Bool, output_format_json_quote_decimals, false, "Controls quoting of decimals in JSON output format.", 0) \
     M(Bool, output_format_json_quote_64bit_floats, false, "Controls quoting of 64-bit float numbers in JSON output format.", 0) \

--- a/tests/test_dbapi.py
+++ b/tests/test_dbapi.py
@@ -32,7 +32,7 @@ class TestDBAPI(unittest.TestCase):
         cur.execute("""
         CREATE TABLE rate (
             day Date,
-            value Int32
+            value Int64
         ) ENGINE = ReplacingMergeTree ORDER BY day""")
 
         # Insert single value


### PR DESCRIPTION
Fixes #117

### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)

### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):

Makes dbapi (main JSON output format consumer in chdb) return int objects instead of str for int64 columns, since python supports int64 parsing (vs JS for which the default was set)