### PR TITLE
Try to fix gpt example

### DIFF
--- a/examples/chDB_GPT.ipynb
+++ b/examples/chDB_GPT.ipynb
@@ -1,42 +1,28 @@
 {
-  "nbformat": 4,
-  "nbformat_minor": 0,
-  "metadata": {
-    "colab": {
-      "provenance": []
-    },
-    "kernelspec": {
-      "name": "python3",
-      "display_name": "Python 3"
-    },
-    "language_info": {
-      "name": "python"
-    }
-  },
   "cells": [
     {
       "cell_type": "markdown",
+      "metadata": {
+        "id": "qx9ZBUUkQwvG"
+      },
       "source": [
         "<img src=\"https://github.com/chdb-io/chdb/raw/pybind/docs/_static/snake-chdb.png\" width=320 >\n",
         "\n",
         "# chdb-GPT\n",
         "Generate **chDB** and **ClickHouse** queries using natural language and  **OpenAI APIs**"
-      ],
-      "metadata": {
-        "id": "qx9ZBUUkQwvG"
-      }
+      ]
     },
     {
       "cell_type": "code",
-      "source": [
-        "#@title Install Requirements { display-mode: \"form\" }\n",
-        "!pip install openai chdb --quiet"
-      ],
+      "execution_count": null,
       "metadata": {
         "id": "Gyo2KvBkMUHI"
       },
-      "execution_count": null,
-      "outputs": []
+      "outputs": [],
+      "source": [
+        "#@title Install Requirements { display-mode: \"form\" }\n",
+        "!pip install openai chdb --quiet"
+      ]
     },
     {
       "cell_type": "code",
@@ -58,6 +44,11 @@
     },
     {
       "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "id": "-GYCp4HzQ9_X"
+      },
+      "outputs": [],
       "source": [
         "#@title Prepare ClickHouse GTP Agent { display-mode: \"form\" }\n",
         "class Conversation:\n",
@@ -136,24 +127,24 @@
         "        \"\"\"\n",
         "\n",
         "        return input_str\n"
-      ],
-      "metadata": {
-        "id": "-GYCp4HzQ9_X"
-      },
-      "execution_count": null,
-      "outputs": []
+      ]
     },
     {
       "cell_type": "markdown",
-      "source": [
-        "Let's input our query and form a prompt:\n"
-      ],
       "metadata": {
         "id": "SkSjhVDvUZHa"
-      }
+      },
+      "source": [
+        "Let's input our query and form a prompt:\n"
+      ]
     },
     {
       "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "id": "wDXDTbooM8mE"
+      },
+      "outputs": [],
       "source": [
         "#@title Prompt using Natural Language { display-mode: \"form\" }\n",
         "query = \"show the top 10 towns from url https://datasets-documentation.s3.eu-west-3.amazonaws.com/house_parquet/house_0.parquet\"  #@param {type:\"string\"}\n",
@@ -164,58 +155,68 @@
         "\n",
         "answer = conversation.answer(prompt)\n",
         "print(answer)"
-      ],
-      "metadata": {
-        "id": "wDXDTbooM8mE"
-      },
-      "execution_count": null,
-      "outputs": []
+      ]
     },
     {
       "cell_type": "markdown",
-      "source": [
-        "Create a new instance of `Conversation` whenever you want to clear the context."
-      ],
       "metadata": {
         "id": "aM1NvWGOUfOa"
-      }
+      },
+      "source": [
+        "Create a new instance of `Conversation` whenever you want to clear the context."
+      ]
     },
     {
       "cell_type": "markdown",
-      "source": [
-        "We can now extend our query and the API will remember what we did before."
-      ],
       "metadata": {
         "id": "9k5x7gvUUn5z"
-      }
+      },
+      "source": [
+        "We can now extend our query and the API will remember what we did before."
+      ]
     },
     {
       "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "cellView": "form",
+        "id": "MY06L5jvNMNQ"
+      },
+      "outputs": [],
       "source": [
         "#@title Refine SQL using Natural Language\n",
         "refine_query = \"add round(avg(price)) AS price to the query\" #@param {type:\"string\"}\n",
-        "query = conversation.answer(refine_query)\n",
-        "print(answer)"
-      ],
-      "metadata": {
-        "id": "MY06L5jvNMNQ",
-        "cellView": "form"
-      },
-      "execution_count": null,
-      "outputs": []
+        "answer = conversation.answer(refine_query)\n",
+        "query = answer.replace(\"```sql\",\"\").replace(\"```\",\"\")\n",
+        "print(query)"
+      ]
     },
     {
       "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "id": "BKeDfL1fQ4XB"
+      },
+      "outputs": [],
       "source": [
         "#@title Execute Query using chDB { display-mode: \"form\" }\n",
         "import chdb\n",
         "res = chdb.query(query, 'Pretty'); print(res.data())"
-      ],
-      "metadata": {
-        "id": "BKeDfL1fQ4XB"
-      },
-      "execution_count": null,
-      "outputs": []
+      ]
     }
-  ]
+  ],
+  "metadata": {
+    "colab": {
+      "provenance": []
+    },
+    "kernelspec": {
+      "display_name": "Python 3",
+      "name": "python3"
+    },
+    "language_info": {
+      "name": "python"
+    }
+  },
+  "nbformat": 4,
+  "nbformat_minor": 0
 }


### PR DESCRIPTION
In examples/chDB_GPT.ipynb, the refine_query part should print the _query_ str instead of _answer_ I think? 

Meanwhile, for many LLMs (I used Zhipu for test in this case), the generated result always contains a markdown code block syntax around the real sql, so maybe we can add two replace operations to remove this? The test result is shown as below:
<img width="833" alt="image" src="https://github.com/user-attachments/assets/8611f5a4-e083-40e2-aea3-6f502dd03ea7">

