### PR TITLE
Use macOS 13 build

### DIFF
--- a/.github/workflows/build_macos_x86_wheels.yml
+++ b/.github/workflows/build_macos_x86_wheels.yml
@@ -15,13 +15,13 @@ on:
       - '**/*.md'
 
 jobs:
-  build_wheels_macos_12:
+  build_wheels_macos_13:
     name: ${{ matrix.os }} py${{ matrix.python-version }}
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
       matrix:
-        os: [ macos-12 ]
+        os: [ macos-13 ]
         python-version: ["3.8", "3.9", "3.10", "3.11", "3.12" ]
     env:
       RUNNER_OS: ${{ matrix.os }}


### PR DESCRIPTION
Fix warning from homebrew
```
Warning: You are using macOS 12.
We (and Apple) do not provide support for this old version.
It is expected behaviour that some formulae will fail to build in this old version.
It is expected behaviour that Homebrew will be buggy and slow.
Do not create any issues about this on Homebrew's GitHub repositories.
Do not create any issues even if you think this message is unrelated.
Any opened issues will be immediately closed without response.
Do not ask for help from Homebrew or its maintainers on social media.
You may ask for help in Homebrew's discussions but are unlikely to receive a response.
Try to figure out the problem yourself and submit a fix as a pull request.
We will review it but may or may not accept it.
```