### PR TITLE
Patchset for 3.0.1

### DIFF
--- a/chdb/session/state.py
+++ b/chdb/session/state.py
@@ -51,7 +51,7 @@ class Session:
             )
             g_session.close()
             g_session_path = None
-        if path is None:
+        if path is None or ":memory:" in path:
             self._cleanup = True
             self._path = tempfile.mkdtemp()
         else:
@@ -89,6 +89,9 @@ class Session:
         if self._conn is not None:
             self._conn.close()
             self._conn = None
+        global g_session, g_session_path
+        g_session = None
+        g_session_path = None
 
     def cleanup(self):
         try:
@@ -96,6 +99,9 @@ class Session:
                 self._conn.close()
                 self._conn = None
             shutil.rmtree(self._path)
+            global g_session, g_session_path
+            g_session = None
+            g_session_path = None
         except:  # noqa
             pass
 

--- a/programs/local/LocalServer.cpp
+++ b/programs/local/LocalServer.cpp
@@ -785,17 +785,8 @@ void LocalServer::processConfig()
     /// Command-line parameters can override settings from the default profile.
     applyCmdSettings(global_context);
 
-    // global once flag
     /// We load temporary database first, because projections need it.
-    static std::once_flag db_catalog_once;
-    if (config().has("path"))
-    {
-        DatabaseCatalog::instance().initializeAndLoadTemporaryDatabase();
-    }
-    else
-    {
-        std::call_once(db_catalog_once, [&] { DatabaseCatalog::instance().initializeAndLoadTemporaryDatabase(); });
-    }
+    DatabaseCatalog::instance().initializeAndLoadTemporaryDatabase();
 
     std::string default_database = server_settings.default_database;
     DatabaseCatalog::instance().attachDatabase(default_database, createClickHouseLocalDatabaseOverlay(default_database, global_context));


### PR DESCRIPTION
- Fix initializeAndLoadTemporaryDatabase
- Reset g_session and g_session_path, cleanup on closing :memory: