### PR TITLE
Fix connection_wrapper destructor sometimes closing other connections

### DIFF
--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -1,6 +1,6 @@
 # Contributors
 
-* auxten  [auxtenwpc@gmail.com](mailto:auxtenwpc@gmail.com)
+* auxten [auxten@clickhouse.com](mailto:auxten@clickhouse.com)
 * Daniel Robbins  [elongaos@gmail.com](mailto:elongaos@gmail.com)
 * Lorenzo Mangani  [lorenzo.mangani@gmail.com](mailto:lorenzo.mangani@gmail.com)
 * nmreadelf  [frank.q.kong@hotmail.com](mailto:frank.q.kong@hotmail.com)
@@ -13,7 +13,6 @@
 * xinhuitian  [xinhui_tian@126.com](mailto:xinhui_tian@126.com)
 * Alex Bocharov  [alex@x.ai](mailto:alex@x.ai)
 * meastham [meastham@ramp.com](mailto:meastham@ramp.com)
-
 
 To see the list of authors who created the source code of ClickHouse, published and distributed by ClickHouse, Inc. as the owner,
 run "SELECT * FROM system.contributors;" query on any ClickHouse server.

--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -1,7 +1,19 @@
 # Contributors
 
-* auxten [auxten@clickhouse.com](mailto:auxten@clickhouse.com)
+* auxten  [auxtenwpc@gmail.com](mailto:auxtenwpc@gmail.com)
+* Daniel Robbins  [elongaos@gmail.com](mailto:elongaos@gmail.com)
+* Lorenzo Mangani  [lorenzo.mangani@gmail.com](mailto:lorenzo.mangani@gmail.com)
+* nmreadelf  [frank.q.kong@hotmail.com](mailto:frank.q.kong@hotmail.com)
+* laodouya  [laodouya@yeah.net](mailto:laodouya@yeah.net)
+* DemoYeti  [164791169+DemoYeti@users.noreply.github.com](mailto:164791169+DemoYeti@users.noreply.github.com)
+* Michael Razuvaev  [razuvaev@yandex-team.ru](mailto:razuvaev@yandex-team.ru)
+* Nevin  [nevinpuri1901@gmail.com](mailto:nevinpuri1901@gmail.com)
+* Yunyu Lin  [mail@yunyul.in](mailto:mail@yunyul.in)
+* reema93jain  [113460610+reema93jain@users.noreply.github.com](mailto:113460610+reema93jain@users.noreply.github.com)
+* xinhuitian  [xinhui_tian@126.com](mailto:xinhui_tian@126.com)
+* Alex Bocharov  [alex@x.ai](mailto:alex@x.ai)
 * meastham [meastham@ramp.com](mailto:meastham@ramp.com)
+
 
 To see the list of authors who created the source code of ClickHouse, published and distributed by ClickHouse, Inc. as the owner,
 run "SELECT * FROM system.contributors;" query on any ClickHouse server.

--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -1,6 +1,7 @@
 # Contributors
 
 * auxten [auxten@clickhouse.com](mailto:auxten@clickhouse.com)
+* meastham [meastham@ramp.com](mailto:meastham@ramp.com)
 
 To see the list of authors who created the source code of ClickHouse, published and distributed by ClickHouse, Inc. as the owner,
 run "SELECT * FROM system.contributors;" query on any ClickHouse server.

--- a/programs/local/LocalChdb.cpp
+++ b/programs/local/LocalChdb.cpp
@@ -285,8 +285,12 @@ connection_wrapper::~connection_wrapper()
 
 void connection_wrapper::close()
 {
-    py::gil_scoped_release release;
-    close_conn(conn);
+    {
+        py::gil_scoped_release release;
+        close_conn(conn);
+    }
+    // Ensure that if a new connection is created before this object is destroyed that we don't try to close it.
+    conn = nullptr;
 }
 
 cursor_wrapper * connection_wrapper::cursor()


### PR DESCRIPTION
Currently, if a dbapi connection is closed using `connection.close()`, and then another dbapi connection is opened before the first connection is destroyed, the destruction of the first connection's python object will cause the second connection to be closed.

This happens because `connection_wrapper.conn` continues to point at the global `chdb_conn*` after `close()` runs, so it's possible for the `connection_wrapper` destructor to close a connection it didn't create.

I used this short script to test this:

```
conn1 = dbapi.connect("/tmp/chdb1")
cur1 = conn1.cursor()
cur1.execute('select version()')
cur1.close()
conn1.close()

conn2 = dbapi.connect("/tmp/chdb2")
cur2 = conn2.cursor()

# Works
cur2.execute('select version()')
print(cur2.fetchone())

# Cause the closed connection to be destroyed
del cur1
del conn1

# Exception: Invalid or closed connection
cur2.execute('select version()')
print(cur2.fetchone())
```

the second to last line throws `# Exception: Invalid or closed connection` with chdb 3.1.1, but not with a wheel built from this commit.

### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Fix connection_wrapper destructor sometimes closing other connections

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

> Information about CI checks: https://clickhouse.com/docs/en/development/continuous-integration/

<details>
    <summary>CI Settings</summary>

**NOTE:** If your merge the PR with modified CI you **MUST KNOW** what you are doing
**NOTE:** Checked options will be applied if set before CI RunConfig/PrepareRunConfig step

#### Run these jobs only (required builds will be added automatically):
- [ ] <!---ci_include_integration--> Integration Tests
- [ ] <!---ci_include_stateless--> Stateless tests
- [ ] <!---ci_include_stateful--> Stateful tests
- [ ] <!---ci_include_unit--> Unit tests
- [ ] <!---ci_include_performance--> Performance tests
- [ ] <!---ci_include_aarch64--> All with aarch64
- [ ] <!---ci_include_asan--> All with ASAN
- [ ] <!---ci_include_tsan--> All with TSAN
- [ ] <!---ci_include_analyzer--> All with Analyzer
- [ ] <!---ci_include_azure --> All with Azure
- [ ] <!---ci_include_KEYWORD--> Add your option here

#### Deny these jobs:
- [ ] <!---ci_exclude_fast--> Fast test
- [ ] <!---ci_exclude_integration--> Integration Tests
- [ ] <!---ci_exclude_stateless--> Stateless tests
- [ ] <!---ci_exclude_stateful--> Stateful tests
- [ ] <!---ci_exclude_performance--> Performance tests
- [ ] <!---ci_exclude_asan--> All with ASAN
- [ ] <!---ci_exclude_tsan--> All with TSAN
- [ ] <!---ci_exclude_msan--> All with MSAN
- [ ] <!---ci_exclude_ubsan--> All with UBSAN
- [ ] <!---ci_exclude_coverage--> All with Coverage
- [ ] <!---ci_exclude_aarch64--> All with Aarch64

#### Extra options:
- [ ] <!---do_not_test--> do not test (only style check)
- [ ] <!---no_merge_commit--> disable merge-commit (no merge from master before tests)
- [ ] <!---no_ci_cache--> disable CI cache (job reuse)

#### Only specified batches in multi-batch jobs:
- [ ] <!---batch_0--> 1
- [ ] <!---batch_1--> 2
- [ ] <!---batch_2--> 3
- [ ] <!---batch_3--> 4

</details>
