### PR TITLE
fix(sql): add support for query execution with explicit length for char safe handling

### DIFF
--- a/programs/local/FormatHelper.cpp
+++ b/programs/local/FormatHelper.cpp
@@ -2,20 +2,22 @@
 
 #include <algorithm>
 #include <cctype>
+#include <base/types.h>
 
 namespace CHDB {
 
 static bool is_json_supported = true;
 
-void SetCurrentFormat(const char * format)
+void SetCurrentFormat(const char * format, size_t format_len)
 {
     if (format)
     {
-        String lowerFormat = format;
-        std::transform(lowerFormat.begin(), lowerFormat.end(), lowerFormat.begin(), ::tolower);
+        String lower_format{format, format_len};
+        std::transform(lower_format.begin(), lower_format.end(), lower_format.begin(), ::tolower);
 
-        is_json_supported =  !(lowerFormat == "arrow" || lowerFormat == "parquet" || lowerFormat == "arrowstream"
-            || lowerFormat == "protobuf" || lowerFormat == "protobuflist" || lowerFormat == "protobufsingle");
+        is_json_supported
+            = !(lower_format == "arrow" || lower_format == "parquet" || lower_format == "arrowstream" || lower_format == "protobuf"
+                || lower_format == "protobuflist" || lower_format == "protobufsingle");
 
         return;
     }

--- a/programs/local/FormatHelper.h
+++ b/programs/local/FormatHelper.h
@@ -4,7 +4,7 @@
 
 namespace CHDB {
 
-void SetCurrentFormat(const char * format);
+void SetCurrentFormat(const char * format, size_t format_len);
 
 bool isJSONSupported();
 

--- a/programs/local/chdb-internal.h
+++ b/programs/local/chdb-internal.h
@@ -29,6 +29,13 @@ struct MaterializedQueryRequest : QueryRequestBase
     std::string query;
     std::string format;
 
+    MaterializedQueryRequest() = default;
+    MaterializedQueryRequest(const char * q, size_t q_len, const char * f, size_t f_len)
+        : query(q, q_len)
+        , format(f, f_len)
+    {
+    }
+
     bool isStreaming() const override { return false; }
 };
 
@@ -36,6 +43,13 @@ struct StreamingInitRequest : QueryRequestBase
 {
     std::string query;
     std::string format;
+
+    StreamingInitRequest() = default;
+    StreamingInitRequest(const char * q, size_t q_len, const char * f, size_t f_len)
+        : query(q, q_len)
+        , format(f, f_len)
+    {
+    }
 
     bool isStreaming() const override { return true; }
 };
@@ -76,4 +90,7 @@ void chdbCleanupConnection();
 
 void cancelStreamQuery(DB::LocalServer * server, void * stream_result);
 
+const std::string & chdb_result_error_string(chdb_result * result);
+
+const std::string & chdb_streaming_result_error_string(chdb_streaming_result * result);
 }

--- a/programs/local/chdb.cpp
+++ b/programs/local/chdb.cpp
@@ -1,13 +1,14 @@
 #include "chdb.h"
 #include <cstddef>
+#include <cstring>
 #include "Common/MemoryTracker.h"
-#include "chdb-internal.h"
 #include "LocalServer.h"
 #include "QueryResult.h"
+#include "chdb-internal.h"
 
 #if USE_PYTHON
-#include "FormatHelper.h"
-#include "PythonTableCache.h"
+#    include "FormatHelper.h"
+#    include "PythonTableCache.h"
 #endif
 
 extern thread_local bool chdb_destructor_cleanup_in_progress;
@@ -29,15 +30,9 @@ namespace CHDB
 class ChdbDestructorGuard
 {
 public:
-    ChdbDestructorGuard()
-    {
-        chdb_destructor_cleanup_in_progress = true;
-    }
+    ChdbDestructorGuard() { chdb_destructor_cleanup_in_progress = true; }
 
-    ~ChdbDestructorGuard()
-    {
-        chdb_destructor_cleanup_in_progress = false;
-    }
+    ~ChdbDestructorGuard() { chdb_destructor_cleanup_in_progress = false; }
 
     ChdbDestructorGuard(const ChdbDestructorGuard &) = delete;
     ChdbDestructorGuard & operator=(const ChdbDestructorGuard &) = delete;
@@ -215,9 +210,9 @@ static QueryResultPtr createStreamingIterateQueryResult(DB::LocalServer * server
             const auto storage_bytes_read = server->getStorageBytesRead();
             const auto elapsed_time = server->getElapsedTime();
             if (processed_rows <= old_processed_rows)
-                query_result =  std::make_unique<MaterializedQueryResult>(nullptr, 0.0, 0, 0, 0, 0);
+                query_result = std::make_unique<MaterializedQueryResult>(nullptr, 0.0, 0, 0, 0, 0);
             else
-                query_result =  std::make_unique<MaterializedQueryResult>(
+                query_result = std::make_unique<MaterializedQueryResult>(
                     ResultBuffer(server->stealQueryOutputVector()),
                     elapsed_time - old_elapsed_time,
                     processed_rows - old_processed_rows,
@@ -226,7 +221,7 @@ static QueryResultPtr createStreamingIterateQueryResult(DB::LocalServer * server
                     storage_bytes_read - old_storage_bytes_read);
         }
     }
-    catch (const DB::Exception& e)
+    catch (const DB::Exception & e)
     {
         query_result = std::make_unique<MaterializedQueryResult>(DB::getExceptionMessage(e, false));
     }
@@ -266,9 +261,8 @@ static std::pair<QueryResultPtr, bool> createQueryResult(DB::LocalServer * serve
         const auto & streaming_iter_request = static_cast<const CHDB::StreamingIterateRequest &>(req);
         auto materialized_query_result_ptr = static_cast<CHDB::MaterializedQueryResult *>(query_result.get());
 
-        is_end = !materialized_query_result_ptr->getError().empty()
-                    || materialized_query_result_ptr->rows_read == 0
-                    || streaming_iter_request.is_canceled;
+        is_end = !materialized_query_result_ptr->getError().empty() || materialized_query_result_ptr->rows_read == 0
+            || streaming_iter_request.is_canceled;
     }
 
     if (is_end)
@@ -278,7 +272,7 @@ static std::pair<QueryResultPtr, bool> createQueryResult(DB::LocalServer * serve
             server->streaming_query_context.reset();
         }
 #if USE_PYTHON
-        if (auto * local_connection = static_cast<DB::LocalConnection*>(server->connection.get()))
+        if (auto * local_connection = static_cast<DB::LocalConnection *>(server->connection.get()))
         {
             /// Must clean up Context objects whether the query succeeds or fails.
             /// During process exit, if LocalServer destructor triggers while cached PythonStorage
@@ -302,7 +296,9 @@ static bool checkConnectionValidity(chdb_conn * conn)
 static QueryResultPtr executeQueryRequest(
     CHDB::QueryQueue * queue,
     const char * query,
+    size_t query_len,
     const char * format,
+    size_t format_len,
     CHDB::QueryType query_type,
     void * streaming_result_ = nullptr,
     bool is_canceled = false)
@@ -317,7 +313,9 @@ static QueryResultPtr executeQueryRequest(
             if (query_type == CHDB::QueryType::TYPE_STREAMING_ITER)
                 queue->result_cv.wait(lock, [queue]() { return (!queue->has_query && !queue->has_result) || queue->shutdown; });
             else
-                queue->result_cv.wait(lock, [queue]() { return (!queue->has_query && !queue->has_result && !queue->has_streaming_query) || queue->shutdown; });
+                queue->result_cv.wait(
+                    lock,
+                    [queue]() { return (!queue->has_query && !queue->has_result && !queue->has_streaming_query) || queue->shutdown; });
 
             if (queue->shutdown)
             {
@@ -335,22 +333,16 @@ static QueryResultPtr executeQueryRequest(
 
             if (query_type == CHDB::QueryType::TYPE_STREAMING_INIT)
             {
-                auto streaming_req = std::make_unique<CHDB::StreamingInitRequest>();
-                streaming_req->query = query;
-                streaming_req->format = format;
-                queue->current_query = std::move(streaming_req);
+                queue->current_query = std::make_unique<CHDB::StreamingInitRequest>(query, query_len, format, format_len);
 #if USE_PYTHON
-                CHDB::SetCurrentFormat(format);
+                CHDB::SetCurrentFormat(format, format_len);
 #endif
             }
             else if (query_type == CHDB::QueryType::TYPE_MATERIALIZED)
             {
-                auto materialized_req = std::make_unique<CHDB::MaterializedQueryRequest>();
-                materialized_req->query = query;
-                materialized_req->format = format;
-                queue->current_query = std::move(materialized_req);
+                queue->current_query = std::make_unique<CHDB::MaterializedQueryRequest>(query, query_len, format, format_len);
 #if USE_PYTHON
-                CHDB::SetCurrentFormat(format);
+                CHDB::SetCurrentFormat(format, format_len);
 #endif
             }
             else
@@ -396,12 +388,12 @@ static QueryResultPtr executeQueryRequest(
 void chdbCleanupConnection()
 {
     try
-	{
+    {
         close_conn(&global_conn_ptr);
-	}
-	catch (...)
-	{
-	}
+    }
+    catch (...)
+    {
+    }
 }
 
 void cancelStreamQuery(DB::LocalServer * server, void * stream_result)
@@ -424,13 +416,10 @@ std::unique_ptr<MaterializedQueryResult> pyEntryClickHouseLocal(int argc, char *
         if (ret == 0)
         {
             return std::make_unique<MaterializedQueryResult>(
-                ResultBuffer(app.stealQueryOutputVector()),
-                app.getElapsedTime(),
-                app.getProcessedRows(),
-                app.getProcessedBytes(),
-                0,
-                0);
-        } else {
+                ResultBuffer(app.stealQueryOutputVector()), app.getElapsedTime(), app.getProcessedRows(), app.getProcessedBytes(), 0, 0);
+        }
+        else
+        {
             return std::make_unique<MaterializedQueryResult>(app.getErrorMsg());
         }
     }
@@ -447,6 +436,25 @@ std::unique_ptr<MaterializedQueryResult> pyEntryClickHouseLocal(int argc, char *
     {
         throw std::domain_error(DB::getCurrentExceptionMessage(true));
     }
+}
+
+const static std::string empty_string;
+const std::string & chdb_result_error_string(chdb_result * result)
+{
+    if (!result)
+        return empty_string;
+
+    auto * query_result = reinterpret_cast<QueryResult *>(result);
+    return query_result->getError();
+}
+
+const std::string & chdb_streaming_result_error_string(chdb_streaming_result * result)
+{
+    if (!result)
+        return empty_string;
+
+    auto * stream_query_result = reinterpret_cast<StreamQueryResult *>(result);
+    return stream_query_result->getError();
 }
 
 } // namespace CHDB
@@ -604,7 +612,6 @@ chdb_conn ** connect_chdb(int argc, char ** argv)
                             queue->query_cv.notify_all();
                             break;
                         }
-
                     }
 
                     CHDB::QueryRequestBase & req = *(queue->current_query);
@@ -727,6 +734,11 @@ void close_conn(chdb_conn ** conn)
 
 struct local_result_v2 * query_conn(chdb_conn * conn, const char * query, const char * format)
 {
+    return query_conn_n(conn, query, query ? std::strlen(query) : 0, format, format ? std::strlen(format) : 0);
+}
+
+struct local_result_v2 * query_conn_n(struct chdb_conn * conn, const char * query, size_t query_len, const char * format, size_t format_len)
+{
     ChdbDestructorGuard guard;
 
     // Add connection validity check under global lock
@@ -734,14 +746,19 @@ struct local_result_v2 * query_conn(chdb_conn * conn, const char * query, const 
 
     if (!checkConnectionValidity(conn))
         return createErrorLocalResultV2("Invalid or closed connection");
-
     auto * queue = static_cast<CHDB::QueryQueue *>(conn->queue);
-    auto query_result = executeQueryRequest(queue, query, format, CHDB::QueryType::TYPE_MATERIALIZED);
+    auto query_result = executeQueryRequest(queue, query, query_len, format, format_len, CHDB::QueryType::TYPE_MATERIALIZED);
 
     return convert2LocalResultV2(query_result.get());
 }
 
 chdb_streaming_result * query_conn_streaming(chdb_conn * conn, const char * query, const char * format)
+{
+    return query_conn_streaming_n(conn, query, query ? std::strlen(query) : 0, format, format ? std::strlen(format) : 0);
+}
+
+chdb_streaming_result *
+query_conn_streaming_n(struct chdb_conn * conn, const char * query, size_t query_len, const char * format, size_t format_len)
 {
     ChdbDestructorGuard guard;
 
@@ -755,7 +772,7 @@ chdb_streaming_result * query_conn_streaming(chdb_conn * conn, const char * quer
     }
 
     auto * queue = static_cast<CHDB::QueryQueue *>(conn->queue);
-    auto query_result = executeQueryRequest(queue, query, format, CHDB::QueryType::TYPE_STREAMING_INIT);
+    auto query_result = executeQueryRequest(queue, query, query_len, format, format_len, CHDB::QueryType::TYPE_STREAMING_INIT);
 
     if (!query_result)
     {
@@ -769,7 +786,7 @@ chdb_streaming_result * query_conn_streaming(chdb_conn * conn, const char * quer
 const char * chdb_streaming_result_error(chdb_streaming_result * result)
 {
     if (!result)
-	    return nullptr;
+        return nullptr;
 
     auto stream_query_result = reinterpret_cast<StreamQueryResult *>(result);
 
@@ -791,7 +808,7 @@ local_result_v2 * chdb_streaming_fetch_result(chdb_conn * conn, chdb_streaming_r
         return createErrorLocalResultV2("Invalid or closed connection");
 
     auto * queue = static_cast<CHDB::QueryQueue *>(conn->queue);
-    auto query_result = executeQueryRequest(queue, nullptr, nullptr, CHDB::QueryType::TYPE_STREAMING_ITER, result);
+    auto query_result = executeQueryRequest(queue, nullptr, 0, nullptr, 0, CHDB::QueryType::TYPE_STREAMING_ITER, result);
 
     return convert2LocalResultV2(query_result.get());
 }
@@ -807,7 +824,7 @@ void chdb_streaming_cancel_query(chdb_conn * conn, chdb_streaming_result * resul
         return;
 
     auto * queue = static_cast<CHDB::QueryQueue *>(conn->queue);
-    auto query_result = executeQueryRequest(queue, nullptr, nullptr, CHDB::QueryType::TYPE_STREAMING_ITER, result, true);
+    auto query_result = executeQueryRequest(queue, nullptr, 0, nullptr, 0, CHDB::QueryType::TYPE_STREAMING_ITER, result, true);
 
     query_result.reset();
 }
@@ -817,7 +834,7 @@ void chdb_destroy_result(chdb_streaming_result * result)
     ChdbDestructorGuard guard;
 
     if (!result)
-	    return;
+        return;
 
     auto stream_query_result = reinterpret_cast<StreamQueryResult *>(result);
 
@@ -845,6 +862,11 @@ void chdb_close_conn(chdb_connection * conn)
 
 chdb_result * chdb_query(chdb_connection conn, const char * query, const char * format)
 {
+    return chdb_query_n(conn, query, query ? std::strlen(query) : 0, format, format ? std::strlen(format) : 0);
+}
+
+chdb_result * chdb_query_n(chdb_connection conn, const char * query, size_t query_len, const char * format, size_t format_len)
+{
     ChdbDestructorGuard guard;
 
     std::shared_lock<std::shared_mutex> global_lock(global_connection_mutex);
@@ -855,7 +877,7 @@ chdb_result * chdb_query(chdb_connection conn, const char * query, const char * 
         return reinterpret_cast<chdb_result *>(result);
     }
 
-    auto connection = reinterpret_cast<chdb_conn *>(conn);
+    auto * connection = reinterpret_cast<chdb_conn *>(conn);
     if (!checkConnectionValidity(connection))
     {
         auto * result = new MaterializedQueryResult("Invalid or closed connection");
@@ -863,10 +885,9 @@ chdb_result * chdb_query(chdb_connection conn, const char * query, const char * 
     }
 
     auto * queue = static_cast<CHDB::QueryQueue *>(connection->queue);
-    auto query_result = executeQueryRequest(queue, query, format, CHDB::QueryType::TYPE_MATERIALIZED);
+    auto query_result = executeQueryRequest(queue, query, query_len, format, format_len, CHDB::QueryType::TYPE_MATERIALIZED);
 
     return reinterpret_cast<chdb_result *>(query_result.release());
-
 }
 
 chdb_result * chdb_query_cmdline(int argc, char ** argv)
@@ -894,6 +915,11 @@ chdb_result * chdb_query_cmdline(int argc, char ** argv)
 
 chdb_result * chdb_stream_query(chdb_connection conn, const char * query, const char * format)
 {
+    return chdb_stream_query_n(conn, query, query ? std::strlen(query) : 0, format, format ? std::strlen(format) : 0);
+}
+
+chdb_result * chdb_stream_query_n(chdb_connection conn, const char * query, size_t query_len, const char * format, size_t format_len)
+{
     ChdbDestructorGuard guard;
 
     std::shared_lock<std::shared_mutex> global_lock(global_connection_mutex);
@@ -904,7 +930,7 @@ chdb_result * chdb_stream_query(chdb_connection conn, const char * query, const 
         return reinterpret_cast<chdb_result *>(result);
     }
 
-    auto connection = reinterpret_cast<chdb_conn *>(conn);
+    auto * connection = reinterpret_cast<chdb_conn *>(conn);
     if (!checkConnectionValidity(connection))
     {
         auto * result = new StreamQueryResult("Invalid or closed connection");
@@ -912,7 +938,7 @@ chdb_result * chdb_stream_query(chdb_connection conn, const char * query, const 
     }
 
     auto * queue = static_cast<CHDB::QueryQueue *>(connection->queue);
-    auto query_result = executeQueryRequest(queue, query, format, CHDB::QueryType::TYPE_STREAMING_INIT);
+    auto query_result = executeQueryRequest(queue, query, query_len, format, format_len, CHDB::QueryType::TYPE_STREAMING_INIT);
 
     if (!query_result)
     {
@@ -942,7 +968,7 @@ chdb_result * chdb_stream_fetch_result(chdb_connection conn, chdb_result * resul
     }
 
 
-    auto connection = reinterpret_cast<chdb_conn *>(conn);
+    auto * connection = reinterpret_cast<chdb_conn *>(conn);
     if (!checkConnectionValidity(connection))
     {
         auto * query_result = new MaterializedQueryResult("Invalid or closed connection");
@@ -950,7 +976,7 @@ chdb_result * chdb_stream_fetch_result(chdb_connection conn, chdb_result * resul
     }
 
     auto * queue = static_cast<CHDB::QueryQueue *>(connection->queue);
-    auto query_result = executeQueryRequest(queue, nullptr, nullptr, CHDB::QueryType::TYPE_STREAMING_ITER, result);
+    auto query_result = executeQueryRequest(queue, nullptr, 0, nullptr, 0, CHDB::QueryType::TYPE_STREAMING_ITER, result);
 
     return reinterpret_cast<chdb_result *>(query_result.release());
 }
@@ -964,12 +990,12 @@ void chdb_stream_cancel_query(chdb_connection conn, chdb_result * result)
     if (!result || !conn)
         return;
 
-    auto connection = reinterpret_cast<chdb_conn *>(conn);
+    auto * connection = reinterpret_cast<chdb_conn *>(conn);
     if (!checkConnectionValidity(connection))
         return;
 
     auto * queue = static_cast<CHDB::QueryQueue *>(connection->queue);
-    auto query_result = executeQueryRequest(queue, nullptr, nullptr, CHDB::QueryType::TYPE_STREAMING_ITER, result, true);
+    auto query_result = executeQueryRequest(queue, nullptr, 0, nullptr, 0, CHDB::QueryType::TYPE_STREAMING_ITER, result, true);
     query_result.reset();
 }
 

--- a/programs/local/chdb.h
+++ b/programs/local/chdb.h
@@ -123,6 +123,21 @@ CHDB_EXPORT void close_conn(struct chdb_conn ** conn);
 CHDB_EXPORT struct local_result_v2 * query_conn(struct chdb_conn * conn, const char * query, const char * format);
 
 /**
+ * Executes a query on the given connection with explicit length parameters.
+ * @brief Thread-safe query execution with binary-safe string handling
+ * @param conn Connection to execute query on
+ * @param query SQL query string to execute (may contain null bytes)
+ * @param query_len Length of query string in bytes
+ * @param format Output format string (e.g., "CSV", default format)
+ * @param format_len Length of format string in bytes
+ * @return Query result structure containing output or error message
+ * @note Returns error result if connection is invalid or closed
+ * @note This function is binary-safe and can handle queries containing null bytes
+ */
+CHDB_EXPORT struct local_result_v2 *
+query_conn_n(struct chdb_conn * conn, const char * query, size_t query_len, const char * format, size_t format_len);
+
+/**
  * Executes a streaming query on the given connection.
  * @brief Initializes streaming query execution and returns result handle
  * @param conn Connection to execute query on
@@ -134,12 +149,28 @@ CHDB_EXPORT struct local_result_v2 * query_conn(struct chdb_conn * conn, const c
 CHDB_EXPORT chdb_streaming_result * query_conn_streaming(struct chdb_conn * conn, const char * query, const char * format);
 
 /**
+ * Executes a streaming query on the given connection with explicit length parameters.
+ * @brief Initializes streaming query execution with binary-safe string handling
+ * @param conn Connection to execute query on
+ * @param query SQL query string to execute (may contain null bytes)
+ * @param query_len Length of query string in bytes
+ * @param format Output format string (e.g., "CSV", default format)
+ * @param format_len Length of format string in bytes
+ * @return Streaming result handle containing query state or error message
+ * @note Returns error result if connection is invalid or closed
+ * @note This function is binary-safe and can handle queries containing null bytes
+ * @note Use chdb_streaming_fetch_result() to retrieve data chunks from the streaming query
+ */
+CHDB_EXPORT chdb_streaming_result *
+query_conn_streaming_n(struct chdb_conn * conn, const char * query, size_t query_len, const char * format, size_t format_len);
+
+/**
  * Retrieves error message from streaming result.
  * @brief Gets error message associated with streaming query execution
  * @param result Streaming result handle from query_conn_streaming()
  * @return Null-terminated error message string, or NULL if no error occurred
  */
- CHDB_EXPORT const char * chdb_streaming_result_error(chdb_streaming_result * result);
+CHDB_EXPORT const char * chdb_streaming_result_error(chdb_streaming_result * result);
 
 /**
  * Fetches next chunk of streaming results.
@@ -202,6 +233,21 @@ CHDB_EXPORT chdb_connection * chdb_connect(int argc, char ** argv);
 CHDB_EXPORT chdb_result * chdb_query(chdb_connection conn, const char * query, const char * format);
 
 /**
+ * Executes a query on the given connection with explicit length parameters.
+ * @brief Thread-safe query execution with binary-safe string handling
+ * @param conn Connection to execute query on
+ * @param query SQL query string to execute (may contain null bytes)
+ * @param query_len Length of query string in bytes
+ * @param format Output format string (e.g., "CSV", default format)
+ * @param format_len Length of format string in bytes
+ * @return Query result structure containing output or error message
+ * @note Returns error result if connection is invalid or closed
+ * @note This function is binary-safe and can handle queries containing null bytes
+ * @note Use chdb_result_* functions to access result data and metadata
+ */
+CHDB_EXPORT chdb_result * chdb_query_n(chdb_connection conn, const char * query, size_t query_len, const char * format, size_t format_len);
+
+/**
  * @brief Execute a query with command-line interface
  * @param argc Argument count (same as main()'s argc)
  * @param argv Argument vector (same as main()'s argv)
@@ -219,6 +265,35 @@ CHDB_EXPORT chdb_result * chdb_query_cmdline(int argc, char ** argv);
  * @note Returns error result if connection is invalid or closed
  */
 CHDB_EXPORT chdb_result * chdb_stream_query(chdb_connection conn, const char * query, const char * format);
+
+/**
+ * Executes a query with explicit string lengths (binary-safe).
+ * @brief Thread-safe function that handles query execution with specified buffer lengths
+ * @param conn Connection to execute query on
+ * @param query SQL query buffer (may contain null bytes)
+ * @param query_len Length of query buffer in bytes
+ * @param format Output format buffer (may contain null bytes)
+ * @param format_len Length of format buffer in bytes
+ * @return Query result structure containing output or error message
+ * @note Strings do not need to be null-terminated
+ * @note Use this function when dealing with queries/formats containing null bytes
+ */
+CHDB_EXPORT chdb_result * chdb_query_n(chdb_connection conn, const char * query, size_t query_len, const char * format, size_t format_len);
+
+/**
+ * Executes a streaming query with explicit string lengths (binary-safe).
+ * @brief Initializes streaming query execution with specified buffer lengths
+ * @param conn Connection to execute query on
+ * @param query SQL query buffer (may contain null bytes)
+ * @param query_len Length of query buffer in bytes
+ * @param format Output format buffer (may contain null bytes)
+ * @param format_len Length of format buffer in bytes
+ * @return Streaming result handle containing query state or error message
+ * @note Strings do not need to be null-terminated
+ * @note Use this function when dealing with queries/formats containing null bytes
+ */
+CHDB_EXPORT chdb_result *
+chdb_stream_query_n(chdb_connection conn, const char * query, size_t query_len, const char * format, size_t format_len);
 
 /**
  * Fetches next chunk of streaming results.

--- a/tests/test_query_py.py
+++ b/tests/test_query_py.py
@@ -92,6 +92,13 @@ class TestQueryPy(unittest.TestCase):
         ret = chdb.query("SELECT b, sum(a) FROM Python(reader) GROUP BY b ORDER BY b")
         self.assertEqual(str(ret), EXPECTED)
 
+    def test_string_with_null_character(self):
+        """Test basic string with null character in the middle"""
+        res = chdb.query("SELECT 'hello\0world' as test_string", "CSV")
+        self.assertFalse(res.has_error())
+        result_data = res.bytes().decode('utf-8')
+        self.assertIn('hello\0world', result_data)
+
     def test_query_df(self):
         df = pd.DataFrame(
             {


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/cancel_and_rerun_workflow_lambda/app.py
-->
### Changelog category (leave one):
Fix ChDB's SQL query execution by introducing binary-safe string handling.

The new APIs can handle SQL queries and format strings containing null bytes (\0).

<details>
    <summary>CI Settings</summary>

**NOTE:** If your merge the PR with modified CI you **MUST KNOW** what you are doing
**NOTE:** Checked options will be applied if set before CI RunConfig/PrepareRunConfig step

#### Run these jobs only (required builds will be added automatically):
- [ ] <!---ci_include_integration--> Integration Tests
- [ ] <!---ci_include_stateless--> Stateless tests
- [ ] <!---ci_include_stateful--> Stateful tests
- [ ] <!---ci_include_unit--> Unit tests
- [ ] <!---ci_include_performance--> Performance tests
- [ ] <!---ci_include_aarch64--> All with aarch64
- [ ] <!---ci_include_asan--> All with ASAN
- [ ] <!---ci_include_tsan--> All with TSAN
- [ ] <!---ci_include_analyzer--> All with Analyzer
- [ ] <!---ci_include_azure --> All with Azure
- [ ] <!---ci_include_KEYWORD--> Add your option here

#### Deny these jobs:
- [ ] <!---ci_exclude_fast--> Fast test
- [ ] <!---ci_exclude_integration--> Integration Tests
- [ ] <!---ci_exclude_stateless--> Stateless tests
- [ ] <!---ci_exclude_stateful--> Stateful tests
- [ ] <!---ci_exclude_performance--> Performance tests
- [ ] <!---ci_exclude_asan--> All with ASAN
- [ ] <!---ci_exclude_tsan--> All with TSAN
- [ ] <!---ci_exclude_msan--> All with MSAN
- [ ] <!---ci_exclude_ubsan--> All with UBSAN
- [ ] <!---ci_exclude_coverage--> All with Coverage
- [ ] <!---ci_exclude_aarch64--> All with Aarch64

#### Extra options:
- [ ] <!---do_not_test--> do not test (only style check)
- [ ] <!---no_merge_commit--> disable merge-commit (no merge from master before tests)
- [ ] <!---no_ci_cache--> disable CI cache (job reuse)

#### Only specified batches in multi-batch jobs:
- [ ] <!---batch_0--> 1
- [ ] <!---batch_1--> 2
- [ ] <!---batch_2--> 3
- [ ] <!---batch_3--> 4

</details>
