### PR TITLE
Fix DataFrame output with binary type

### DIFF
--- a/programs/local/NumpyArray.cpp
+++ b/programs/local/NumpyArray.cpp
@@ -593,7 +593,13 @@ static bool CHColumnStringToNumpyArray(NumpyAppendData & append_data)
 			StringRef str_ref = string_column->getDataAt(src_index);
 			auto * str_ptr = const_cast<char *>(str_ref.data);
 			auto str_size = str_ref.size;
-			dest_ptr[dest_index] = PyUnicode_FromStringAndSize(str_ptr, str_size);
+			PyObject * py_str = PyUnicode_DecodeUTF8(str_ptr, str_size, nullptr);
+			if (!py_str)
+			{
+				PyErr_Clear();
+				py_str = PyByteArray_FromStringAndSize(str_ptr, str_size);
+			}
+			dest_ptr[dest_index] = py_str;
 		}
 	}
 

--- a/tests/test_dataframe_column_types_2.py
+++ b/tests/test_dataframe_column_types_2.py
@@ -1380,6 +1380,22 @@ class TestDataFrameColumnTypesTwo(unittest.TestCase):
         self.assertEqual(df['a'].dtype, result['a'].dtype)
         self.assertEqual(df['a'].isna().tolist(), result['a'].isna().tolist())
 
+    def test_binary_blob_and_string(self):
+        result = self.session.query("SELECT 'hello' AS str_col, toFixedString('world', 5) AS fixed_str", 'DataFrame')
+        self.assertIsInstance(result['str_col'].iloc[0], str)
+        self.assertEqual(result['str_col'].iloc[0], 'hello')
+        self.assertIsInstance(result['fixed_str'].iloc[0], str)
+        self.assertEqual(result['fixed_str'].iloc[0], 'world')
+
+        result = self.session.query(
+            "SELECT unhex('0186000000') AS blob_col, toFixedString(unhex('ff00fe01'), 4) AS fixed_blob",
+            'DataFrame'
+        )
+        self.assertIsInstance(result['blob_col'].iloc[0], bytearray)
+        self.assertEqual(bytes(result['blob_col'].iloc[0]), b'\x01\x86\x00\x00\x00')
+        self.assertIsInstance(result['fixed_blob'].iloc[0], bytearray)
+        self.assertEqual(bytes(result['fixed_blob'].iloc[0]), b'\xff\x00\xfe\x01')
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
Resolved https://github.com/chdb-io/chdb/issues/482, scenarios where the output type is DataFrame.

<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/cancel_and_rerun_workflow_lambda/app.py
-->
### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->


> Information about CI checks: https://clickhouse.com/docs/en/development/continuous-integration/

<details>
    <summary>CI Settings</summary>

**NOTE:** If your merge the PR with modified CI you **MUST KNOW** what you are doing
**NOTE:** Checked options will be applied if set before CI RunConfig/PrepareRunConfig step

#### Run these jobs only (required builds will be added automatically):
- [ ] <!---ci_include_integration--> Integration Tests
- [ ] <!---ci_include_stateless--> Stateless tests
- [ ] <!---ci_include_stateful--> Stateful tests
- [ ] <!---ci_include_unit--> Unit tests
- [ ] <!---ci_include_performance--> Performance tests
- [ ] <!---ci_include_aarch64--> All with aarch64
- [ ] <!---ci_include_asan--> All with ASAN
- [ ] <!---ci_include_tsan--> All with TSAN
- [ ] <!---ci_include_analyzer--> All with Analyzer
- [ ] <!---ci_include_azure --> All with Azure
- [ ] <!---ci_include_KEYWORD--> Add your option here

#### Deny these jobs:
- [ ] <!---ci_exclude_fast--> Fast test
- [ ] <!---ci_exclude_integration--> Integration Tests
- [ ] <!---ci_exclude_stateless--> Stateless tests
- [ ] <!---ci_exclude_stateful--> Stateful tests
- [ ] <!---ci_exclude_performance--> Performance tests
- [ ] <!---ci_exclude_asan--> All with ASAN
- [ ] <!---ci_exclude_tsan--> All with TSAN
- [ ] <!---ci_exclude_msan--> All with MSAN
- [ ] <!---ci_exclude_ubsan--> All with UBSAN
- [ ] <!---ci_exclude_coverage--> All with Coverage
- [ ] <!---ci_exclude_aarch64--> All with Aarch64

#### Extra options:
- [ ] <!---do_not_test--> do not test (only style check)
- [ ] <!---no_merge_commit--> disable merge-commit (no merge from master before tests)
- [ ] <!---no_ci_cache--> disable CI cache (job reuse)

#### Only specified batches in multi-batch jobs:
- [ ] <!---batch_0--> 1
- [ ] <!---batch_1--> 2
- [ ] <!---batch_2--> 3
- [ ] <!---batch_3--> 4

</details>
