### PR TITLE
Support pandas StringDtype columns in DataFrame query

### DIFF
--- a/programs/local/PandasDataFrame.cpp
+++ b/programs/local/PandasDataFrame.cpp
@@ -129,7 +129,7 @@ void PandasDataFrame::fillColumn(const py::handle & data_source, const std::stri
     py::object dtype = data_source.attr("dtypes")[py::str(col_name)];
 
     auto numpy_type = ConvertNumpyType(dtype);
-    column.is_object_type = (numpy_type.type == NumpyNullableType::OBJECT);
+    column.is_object_type = (numpy_type.type == NumpyNullableType::OBJECT || numpy_type.type == NumpyNullableType::STRING);
 
     py::array array = series.attr("values");
     column.row_count = py::len(series);

--- a/tests/test_dataframe_null_handling.py
+++ b/tests/test_dataframe_null_handling.py
@@ -268,6 +268,17 @@ class TestDataFrameNullHandling(unittest.TestCase):
         self.assertEqual(result['is_null1'].iloc[4], 1)
         self.assertEqual(result['is_null1'].iloc[5], 0)
 
+    def test_pandas_string_dtype(self):
+        df = pd.DataFrame({
+            'id': [1, 2, 3, 4],
+            'name': pd.array(['a', None, 'c', None], dtype='string')
+        })
+        result = self.conn.query('SELECT * FROM Python(df) ORDER BY id', 'DataFrame')
+        self.assertEqual(result['name'].iloc[0], 'a')
+        self.assertTrue(pd.isna(result['name'].iloc[1]))
+        self.assertEqual(result['name'].iloc[2], 'c')
+        self.assertTrue(pd.isna(result['name'].iloc[3]))
+
 
 if __name__ == '__main__':
     unittest.main(verbosity=2)


### PR DESCRIPTION
Fixed https://github.com/chdb-io/chdb/issues/483
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/cancel_and_rerun_workflow_lambda/app.py
-->
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->


> Information about CI checks: https://clickhouse.com/docs/en/development/continuous-integration/

<details>
    <summary>CI Settings</summary>

**NOTE:** If your merge the PR with modified CI you **MUST KNOW** what you are doing
**NOTE:** Checked options will be applied if set before CI RunConfig/PrepareRunConfig step

#### Run these jobs only (required builds will be added automatically):
- [ ] <!---ci_include_integration--> Integration Tests
- [ ] <!---ci_include_stateless--> Stateless tests
- [ ] <!---ci_include_stateful--> Stateful tests
- [ ] <!---ci_include_unit--> Unit tests
- [ ] <!---ci_include_performance--> Performance tests
- [ ] <!---ci_include_aarch64--> All with aarch64
- [ ] <!---ci_include_asan--> All with ASAN
- [ ] <!---ci_include_tsan--> All with TSAN
- [ ] <!---ci_include_analyzer--> All with Analyzer
- [ ] <!---ci_include_azure --> All with Azure
- [ ] <!---ci_include_KEYWORD--> Add your option here

#### Deny these jobs:
- [ ] <!---ci_exclude_fast--> Fast test
- [ ] <!---ci_exclude_integration--> Integration Tests
- [ ] <!---ci_exclude_stateless--> Stateless tests
- [ ] <!---ci_exclude_stateful--> Stateful tests
- [ ] <!---ci_exclude_performance--> Performance tests
- [ ] <!---ci_exclude_asan--> All with ASAN
- [ ] <!---ci_exclude_tsan--> All with TSAN
- [ ] <!---ci_exclude_msan--> All with MSAN
- [ ] <!---ci_exclude_ubsan--> All with UBSAN
- [ ] <!---ci_exclude_coverage--> All with Coverage
- [ ] <!---ci_exclude_aarch64--> All with Aarch64

#### Extra options:
- [ ] <!---do_not_test--> do not test (only style check)
- [ ] <!---no_merge_commit--> disable merge-commit (no merge from master before tests)
- [ ] <!---no_ci_cache--> disable CI cache (job reuse)

#### Only specified batches in multi-batch jobs:
- [ ] <!---batch_0--> 1
- [ ] <!---batch_1--> 2
- [ ] <!---batch_2--> 3
- [ ] <!---batch_3--> 4

</details>
