### PR TITLE
Fix crash on multi refer Python(df)

### DIFF
--- a/programs/local/StoragePython.cpp
+++ b/programs/local/StoragePython.cpp
@@ -156,7 +156,21 @@ void StoragePython::prepareColumnCache(
 #endif
 
     auto & data_source = data_source_wrapper->getDataSource();
-    if (column_cache == nullptr)
+
+    bool need_rebuild = (column_cache == nullptr) || (column_cache->size() != names.size());
+    if (!need_rebuild)
+    {
+        for (size_t i = 0; i < names.size(); ++i)
+        {
+            if ((*column_cache)[i].name != names[i])
+            {
+                need_rebuild = true;
+                break;
+            }
+        }
+    }
+
+    if (need_rebuild)
     {
         column_cache = std::make_shared<PyColumnVec>(names.size());
         for (size_t i = 0; i < names.size(); ++i)

--- a/tests/test_query_py.py
+++ b/tests/test_query_py.py
@@ -400,6 +400,19 @@ class TestQueryPy(unittest.TestCase):
         finally:
             os.unlink(path)
 
+    def test_multiple_python_references_in_subquery(self):
+        df = pd.DataFrame({'id': [1, 2, 3], 'value': [10, 20, 30]})
+
+        result = chdb.query('''
+            SELECT id, value + (SELECT SUM(value) FROM Python(df)) AS total
+            FROM Python(df)
+            ORDER BY id
+        ''', "DataFrame")
+
+        self.assertEqual(len(result), 3)
+        self.assertEqual(result['id'].tolist(), [1, 2, 3])
+        self.assertEqual(result['total'].tolist(), [70, 80, 90])
+
 
 if __name__ == "__main__":
     unittest.main(verbosity=3)


### PR DESCRIPTION
Fixed https://github.com/chdb-io/chdb/issues/503

<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/cancel_and_rerun_workflow_lambda/app.py
-->
### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->


> Information about CI checks: https://clickhouse.com/docs/en/development/continuous-integration/

<details>
    <summary>CI Settings</summary>

**NOTE:** If your merge the PR with modified CI you **MUST KNOW** what you are doing
**NOTE:** Checked options will be applied if set before CI RunConfig/PrepareRunConfig step

#### Run these jobs only (required builds will be added automatically):
- [ ] <!---ci_include_integration--> Integration Tests
- [ ] <!---ci_include_stateless--> Stateless tests
- [ ] <!---ci_include_stateful--> Stateful tests
- [ ] <!---ci_include_unit--> Unit tests
- [ ] <!---ci_include_performance--> Performance tests
- [ ] <!---ci_include_aarch64--> All with aarch64
- [ ] <!---ci_include_asan--> All with ASAN
- [ ] <!---ci_include_tsan--> All with TSAN
- [ ] <!---ci_include_analyzer--> All with Analyzer
- [ ] <!---ci_include_azure --> All with Azure
- [ ] <!---ci_include_KEYWORD--> Add your option here

#### Deny these jobs:
- [ ] <!---ci_exclude_fast--> Fast test
- [ ] <!---ci_exclude_integration--> Integration Tests
- [ ] <!---ci_exclude_stateless--> Stateless tests
- [ ] <!---ci_exclude_stateful--> Stateful tests
- [ ] <!---ci_exclude_performance--> Performance tests
- [ ] <!---ci_exclude_asan--> All with ASAN
- [ ] <!---ci_exclude_tsan--> All with TSAN
- [ ] <!---ci_exclude_msan--> All with MSAN
- [ ] <!---ci_exclude_ubsan--> All with UBSAN
- [ ] <!---ci_exclude_coverage--> All with Coverage
- [ ] <!---ci_exclude_aarch64--> All with Aarch64

#### Extra options:
- [ ] <!---do_not_test--> do not test (only style check)
- [ ] <!---no_merge_commit--> disable merge-commit (no merge from master before tests)
- [ ] <!---no_ci_cache--> disable CI cache (job reuse)

#### Only specified batches in multi-batch jobs:
- [ ] <!---batch_0--> 1
- [ ] <!---batch_1--> 2
- [ ] <!---batch_2--> 3
- [ ] <!---batch_3--> 4

</details>
