### PR TITLE
Add AI Agent Skill for chdb multi-source data analytics

### DIFF
--- a/README.md
+++ b/README.md
@@ -543,6 +543,15 @@ For more examples, see [examples](examples) and [tests](tests).
 - For DataStore API, see [Pandas Compatibility Guide](docs/PANDAS_COMPATIBILITY.md)
 
 
+## AI Coding Agent Skill
+
+chdb provides an [AI Skill](agent/skills/using-chdb/) that teaches AI coding agents (Cursor, Claude Code, etc.) chdb's multi-source data analytics API. Install it so your AI assistant can write correct chdb code out of the box:
+
+```bash
+curl -sL https://raw.githubusercontent.com/chdb-io/chdb/main/install_skill.sh | bash
+```
+
+
 ## Events
 
 - Demo chDB at [ClickHouse v23.7 livehouse!](https://t.co/todc13Kn19) and [Slides](https://docs.google.com/presentation/d/1ikqjOlimRa7QAg588TAB_Fna-Tad2WMg7_4AgnbQbFA/edit?usp=sharing)

--- a/agent/skills/using-chdb/SKILL.md
+++ b/agent/skills/using-chdb/SKILL.md
@@ -1,0 +1,210 @@
+---
+name: using-chdb
+description: Guide for using chdb, an in-process SQL OLAP engine powered by ClickHouse. Covers pandas-compatible DataStore API, 16+ data sources (MySQL, PostgreSQL, S3, ClickHouse, MongoDB, Iceberg, Delta Lake, etc.), 10+ file formats, and cross-source joins. Use when the user wants to analyze data, query files, join multiple data sources, or build data integration pipelines.
+---
+
+# chdb — Pandas-Compatible Multi-Source Data Analytics
+
+chdb is an in-process ClickHouse engine for Python. Write familiar pandas code, query 16+ data sources and 10+ file formats, join them freely — no server, no ETL, no data movement.
+
+```bash
+pip install chdb
+```
+
+## Why chdb
+
+- **Drop-in pandas replacement**: `import datastore as pd` — same API, ClickHouse performance
+- **16+ data sources as first-class citizens**: local files, S3, GCS, Azure, HDFS, MySQL, PostgreSQL, ClickHouse, MongoDB, SQLite, Redis, Iceberg, Delta Lake, Hudi, HTTP URLs
+- **10+ file formats**: Parquet, CSV, TSV, JSON, JSONLines, Arrow, ORC, Avro, XML — auto-detected by extension
+- **Cross-source joins**: join a MySQL table with an S3 Parquet file and a local CSV in one expression
+- **Lazy evaluation**: operations compile to optimized SQL, execute only when results are needed
+
+## DataStore: Pandas API on Any Data Source
+
+### Connecting to data — always the same pattern
+
+```python
+from datastore import DataStore
+
+# Local files (format auto-detected: .parquet, .csv, .json, .arrow, .orc, .avro, .tsv, .xml)
+ds = DataStore.from_file("sales.parquet")
+ds = DataStore.from_file("logs/*.csv")          # glob patterns
+
+# Cloud storage
+ds = DataStore.from_s3("s3://bucket/data.parquet", nosign=True)
+ds = DataStore.from_s3("s3://private/data.parquet", access_key_id="KEY", secret_access_key="SECRET")
+ds = DataStore.from_gcs("gs://bucket/data.parquet", nosign=True)
+ds = DataStore.from_azure(connection_string="...", container="data", path="events.parquet")
+ds = DataStore.from_hdfs("hdfs://namenode:9000/warehouse/*.parquet")
+ds = DataStore.from_url("https://example.com/data.csv")
+
+# Databases
+ds = DataStore.from_mysql(host="db:3306", database="shop", table="orders", user="root", password="pass")
+ds = DataStore.from_postgresql(host="pg:5432", database="analytics", table="events", user="user", password="pass")
+ds = DataStore.from_clickhouse(host="ch:9000", database="logs", table="access_log")
+ds = DataStore.from_mongodb(host="mongo:27017", database="app", collection="users", user="user", password="pass")
+ds = DataStore.from_sqlite("/data/local.db", "users")
+
+# Data lake formats
+ds = DataStore.from_iceberg("s3://warehouse/iceberg/events", access_key_id="KEY", secret_access_key="SECRET")
+ds = DataStore.from_delta("s3://warehouse/delta/transactions", access_key_id="KEY", secret_access_key="SECRET")
+ds = DataStore.from_hudi("s3://warehouse/hudi/logs", access_key_id="KEY", secret_access_key="SECRET")
+
+# URI shorthand — auto-detect source and format
+ds = DataStore.uri("s3://bucket/data.parquet?nosign=true")
+ds = DataStore.uri("mysql://root:pass@db:3306/shop/orders")
+ds = DataStore.uri("postgresql://user:pass@pg:5432/analytics/events")
+ds = DataStore.uri("clickhouse://ch:9440/logs/access_log?user=default")
+ds = DataStore.uri("mongodb://user:pass@mongo:27017/app.users")
+ds = DataStore.uri("deltalake:///data/delta/events")
+
+# In-memory from dict or DataFrame
+ds = DataStore({"name": ["Alice", "Bob"], "age": [25, 30]})
+```
+
+### Once connected, always the same pandas API
+
+No matter where the data lives, the operations are identical:
+
+```python
+# Filter
+result = ds[ds["age"] > 25]
+result = ds[(ds["status"] == "active") & (ds["revenue"] > 1000)]
+
+# Select columns
+result = ds[["name", "city", "revenue"]]
+
+# Sort
+result = ds.sort_values("revenue", ascending=False)
+
+# GroupBy + aggregation
+result = ds.groupby("department")["salary"].mean()
+result = ds.groupby(["region", "product"]).agg({"revenue": "sum", "quantity": "mean"})
+
+# Add computed columns
+result = ds.assign(profit=ds["revenue"] - ds["cost"], margin=lambda x: x["profit"] / x["revenue"])
+
+# String and datetime accessors
+ds["name"].str.upper()
+ds["email"].str.contains("@gmail")
+ds["order_date"].dt.year
+ds["order_date"].dt.month
+
+# Inspection
+ds.columns        # column names
+ds.shape           # (rows, cols)
+ds.head(10)        # first 10 rows
+ds.describe()      # statistics
+ds.to_sql()        # view the generated SQL behind the scenes
+```
+
+### Cross-source joins — the killer feature
+
+Join data across completely different sources with one expression:
+
+```python
+from datastore import DataStore
+
+# Three different sources
+customers = DataStore.from_mysql(host="db:3306", database="crm", table="customers", user="root", password="pass")
+orders = DataStore.from_file("orders.parquet")
+reviews = DataStore.from_s3("s3://feedback/reviews.parquet", nosign=True)
+
+# Join them all with pandas syntax
+result = (orders
+    .join(customers, left_on="customer_id", right_on="id")
+    .join(reviews, on="product_id")
+    .groupby("country")
+    .agg({"amount": "sum", "rating": "mean", "review_id": "count"})
+    .sort_values("amount", ascending=False)
+)
+print(result)
+```
+
+### Writing data across sources
+
+```python
+source = DataStore.from_mysql(host="db:3306", database="shop", table="orders", user="root", password="pass")
+target = DataStore("file", path="output/summary.parquet", format="Parquet")
+
+target.insert_into("category", "total", "count").select_from(
+    source.groupby("category").select("category", "sum(amount) AS total", "count() AS count")
+).execute()
+```
+
+## Raw SQL: Direct ClickHouse Power
+
+For complex analytics or when you prefer SQL:
+
+```python
+import chdb
+
+# Query any file
+chdb.query("SELECT * FROM file('data.parquet', Parquet) WHERE price > 100 LIMIT 10")
+
+# Query databases directly
+chdb.query("SELECT * FROM mysql('db:3306', 'shop', 'orders', 'root', 'pass') WHERE status = 'shipped'")
+chdb.query("SELECT * FROM postgresql('pg:5432', 'analytics', 'events', 'user', 'pass') ORDER BY ts DESC LIMIT 100")
+
+# Cross-source SQL join
+chdb.query("""
+    SELECT u.name, o.product, o.amount
+    FROM mysql('db:3306', 'crm', 'users', 'root', 'pass') AS u
+    JOIN file('orders.parquet', Parquet) AS o ON u.id = o.user_id
+    WHERE o.amount > 100
+    ORDER BY o.amount DESC
+""")
+
+# Data lake formats
+chdb.query("SELECT * FROM deltaLake('s3://bucket/delta/table', NOSIGN) LIMIT 10")
+chdb.query("SELECT * FROM iceberg('s3://bucket/iceberg/table', 'KEY', 'SECRET') LIMIT 10")
+
+# Python dict/DataFrame as SQL table
+data = {"name": ["Alice", "Bob"], "score": [95, 87]}
+chdb.query("SELECT * FROM Python(data) ORDER BY score DESC")
+
+# Output formats: CSV (default), JSON, DataFrame, Arrow, ArrowTable, Parquet, Pretty
+df = chdb.query("SELECT * FROM numbers(10)", "DataFrame")
+
+# Parametrized queries
+chdb.query(
+    "SELECT toDate({d:String}) + number AS date FROM numbers({n:UInt64})",
+    "DataFrame",
+    params={"d": "2025-01-01", "n": 30}
+)
+```
+
+## Session: Stateful Pipelines
+
+```python
+from chdb import session as chs
+
+sess = chs.Session("./analytics_db")   # persistent; use Session() for in-memory
+
+# Ingest from external sources into local tables
+sess.query("""
+    CREATE TABLE users ENGINE = MergeTree() ORDER BY id AS
+    SELECT * FROM mysql('db:3306', 'crm', 'users', 'root', 'pass')
+""")
+sess.query("""
+    CREATE TABLE events ENGINE = MergeTree() ORDER BY (ts, user_id) AS
+    SELECT * FROM s3('s3://logs/events/*.parquet', NOSIGN)
+""")
+
+# Analyze locally — fast iterative queries
+sess.query("""
+    SELECT u.country, e.event_type, count() AS cnt, uniqExact(e.user_id) AS users
+    FROM events e JOIN users u ON e.user_id = u.id
+    WHERE e.ts >= today() - 7
+    GROUP BY u.country, e.event_type
+    ORDER BY cnt DESC
+""", "Pretty").show()
+
+sess.close()
+```
+
+## Quick Reference
+
+- Official docs: https://clickhouse.com/docs/chdb
+- API signatures and ClickHouse SQL functions: [reference.md](reference.md)
+- 15 runnable examples (cross-source joins, data lakes, cloud storage, ETL pipelines): [examples.md](examples.md)

--- a/agent/skills/using-chdb/examples.md
+++ b/agent/skills/using-chdb/examples.md
@@ -1,0 +1,407 @@
+# chdb Multi-Source Data Analysis Examples
+
+## 1. Query Any File with One Line
+
+```python
+import chdb
+
+# Parquet
+chdb.query("SELECT country, count() AS cnt FROM file('users.parquet', Parquet) GROUP BY country ORDER BY cnt DESC LIMIT 10", "Pretty").show()
+
+# CSV
+chdb.query("SELECT * FROM file('sales.csv', CSVWithNames) WHERE revenue > 10000 ORDER BY revenue DESC", "DataFrame")
+
+# JSON
+chdb.query("SELECT * FROM file('events.jsonl', JSONEachRow) WHERE event_type = 'purchase'")
+
+# Glob patterns — query all files at once
+chdb.query("SELECT * FROM file('logs/2024-*.parquet', Parquet) WHERE level = 'ERROR'")
+```
+
+## 2. DataStore: Pandas Workflow on Any Source
+
+```python
+from datastore import DataStore
+
+# Local Parquet — feels like pandas
+ds = DataStore.from_file("sales.parquet")
+top_products = (ds[ds['revenue'] > 0]
+    .groupby('product')
+    .agg({'revenue': 'sum', 'quantity': 'sum'})
+    .sort_values('revenue', ascending=False)
+    .head(10))
+print(top_products)
+
+# MySQL — same pandas syntax, backed by SQL
+ds = DataStore.from_mysql(
+    host="db.example.com:3306", database="ecommerce",
+    table="orders", user="analyst", password="pass"
+)
+monthly = ds.groupby(ds['order_date'].dt.month)['amount'].sum()
+print(monthly)
+
+# S3 Parquet — same API, cloud data
+ds = DataStore.from_s3("s3://data-lake/clickstream/*.parquet", nosign=True)
+active_users = ds[ds['event'] == 'login'].groupby('user_id')['ts'].count()
+print(active_users.sort_values(ascending=False).head(20))
+```
+
+## 3. Cross-Source Join: MySQL + Local Parquet
+
+```python
+from datastore import DataStore
+
+# Customer data in MySQL
+customers = DataStore.from_mysql(
+    host="db:3306", database="crm", table="customers",
+    user="reader", password="pass"
+)
+
+# Order data in local Parquet
+orders = DataStore.from_file("orders.parquet")
+
+# Join and analyze — chdb handles the cross-source query
+result = (customers
+    .join(orders, left_on="id", right_on="customer_id", how="inner")
+    .groupby("country")
+    .agg({"amount": ["sum", "mean"], "order_id": "count"})
+    .sort_values("sum", ascending=False)
+)
+print(result)
+
+# View the generated SQL
+print(result.to_sql())
+```
+
+## 4. Cross-Source Join: S3 + PostgreSQL
+
+```python
+from datastore import DataStore
+
+# Event logs on S3
+events = DataStore.from_s3(
+    "s3://analytics/events/2024-*.parquet",
+    access_key_id="AKIA...", secret_access_key="secret..."
+)
+
+# User profiles in PostgreSQL
+profiles = DataStore.from_postgresql(
+    host="pg.example.com:5432", database="users",
+    table="profiles", user="analyst", password="pass"
+)
+
+# Combine cloud events with DB profiles
+result = (events
+    .join(profiles, left_on="user_id", right_on="id")
+    .filter(events['event_type'] == 'purchase')
+    .groupby(["country", "age_group"])
+    .agg({"amount": "sum", "event_id": "count"})
+    .sort_values("sum", ascending=False)
+)
+print(result)
+```
+
+## 5. Three-Way Join: File + Database + Cloud
+
+```python
+from datastore import DataStore
+
+products = DataStore.from_file("products.csv")
+orders = DataStore.from_mysql(
+    host="db:3306", database="shop", table="orders",
+    user="root", password="pass"
+)
+reviews = DataStore.from_s3("s3://feedback/reviews.parquet", nosign=True)
+
+# Join all three sources
+result = (orders
+    .join(products, left_on="product_id", right_on="id")
+    .join(reviews, left_on="product_id", right_on="product_id")
+    .groupby("category")
+    .agg({
+        "amount": "sum",
+        "rating": "mean",
+        "review_id": "count"
+    })
+    .sort_values("sum", ascending=False)
+)
+print(result)
+```
+
+## 6. Data Lake Formats: Iceberg, Delta Lake, Hudi
+
+```python
+from datastore import DataStore
+
+# Apache Iceberg on S3
+ds = DataStore.from_iceberg(
+    "s3://warehouse/iceberg/events",
+    access_key_id="KEY", secret_access_key="SECRET"
+)
+print(ds.head(10))
+
+# Delta Lake
+ds = DataStore.from_delta(
+    "s3://warehouse/delta/transactions",
+    access_key_id="KEY", secret_access_key="SECRET"
+)
+summary = ds.groupby("category").agg({"amount": "sum"}).sort_values("sum", ascending=False)
+print(summary)
+
+# Hudi
+ds = DataStore.from_hudi("s3://warehouse/hudi/logs", access_key_id="KEY", secret_access_key="SECRET")
+errors = ds[ds['level'] == 'ERROR']
+print(errors.head(20))
+
+# Raw SQL also works
+import chdb
+chdb.query("SELECT * FROM deltaLake('s3://public-datasets/delta/hits/', NOSIGN) LIMIT 5", "Pretty").show()
+```
+
+## 7. URI-Based Access: One-Liner for Any Source
+
+```python
+from datastore import DataStore
+
+# Local file
+ds = DataStore.uri("sales.parquet")
+
+# S3 (public)
+ds = DataStore.uri("s3://public-data/dataset.parquet?nosign=true")
+
+# MySQL
+ds = DataStore.uri("mysql://root:pass@localhost:3306/shop/orders")
+
+# PostgreSQL
+ds = DataStore.uri("postgresql://analyst:pass@pg:5432/analytics/events")
+
+# Remote ClickHouse
+ds = DataStore.uri("clickhouse://ch.example.com:9440/analytics/hits?user=reader&password=pass")
+
+# MongoDB
+ds = DataStore.uri("mongodb://user:pass@mongo:27017/logs.app_events")
+
+# SQLite
+ds = DataStore.uri("sqlite:///data/local.db?table=users")
+
+# Data lakes
+ds = DataStore.uri("iceberg://my_catalog/my_namespace/my_table")
+ds = DataStore.uri("deltalake:///data/delta/events")
+ds = DataStore.uri("hudi:///data/hudi/events")
+
+# After creating from any source, same pandas API
+result = ds[ds['value'] > 100].groupby('category').sum().sort_values('value', ascending=False)
+print(result)
+```
+
+## 8. Raw SQL Cross-Source Joins
+
+```python
+import chdb
+
+# MySQL + Parquet join
+chdb.query("""
+    SELECT u.name, u.email, o.product, o.amount
+    FROM mysql('db:3306', 'crm', 'users', 'root', 'pass') AS u
+    JOIN file('orders.parquet', Parquet) AS o ON u.id = o.user_id
+    WHERE o.amount > 100
+    ORDER BY o.amount DESC
+    LIMIT 20
+""", "Pretty").show()
+
+# S3 + PostgreSQL join
+chdb.query("""
+    SELECT e.event_type, p.country, count() AS cnt
+    FROM s3('s3://bucket/events.parquet', 'KEY', 'SECRET', 'Parquet') AS e
+    JOIN postgresql('pg:5432', 'users', 'profiles', 'user', 'pass') AS p ON e.user_id = p.id
+    GROUP BY e.event_type, p.country
+    ORDER BY cnt DESC
+""", "DataFrame")
+
+# ClickHouse + local CSV
+chdb.query("""
+    SELECT r.host, l.status_code, count() AS requests
+    FROM remote('ch:9000', 'logs', 'access_log', 'default', '') AS r
+    JOIN file('server_config.csv', CSVWithNames) AS l ON r.host = l.hostname
+    GROUP BY r.host, l.status_code
+    ORDER BY requests DESC
+""")
+```
+
+## 9. Cloud Storage Variants
+
+```python
+from datastore import DataStore
+
+# AWS S3 (private)
+ds = DataStore.from_s3("s3://my-bucket/data.parquet", access_key_id="AKIA...", secret_access_key="secret...")
+
+# AWS S3 (public, no signing)
+ds = DataStore.from_s3("s3://public-data/dataset.parquet", nosign=True)
+
+# Google Cloud Storage
+ds = DataStore.from_gcs("gs://my-bucket/data.parquet", hmac_key="KEY", hmac_secret="SECRET")
+ds = DataStore.from_gcs("gs://public-bucket/data.parquet", nosign=True)
+
+# Azure Blob Storage
+ds = DataStore.from_azure(
+    connection_string="DefaultEndpointsProtocol=https;AccountName=...;AccountKey=...",
+    container="data", path="analytics/events.parquet"
+)
+
+# HDFS
+ds = DataStore.from_hdfs("hdfs://namenode:9000/warehouse/events/*.parquet")
+```
+
+## 10. Session: Build Analytical Tables from Multiple Sources
+
+```python
+from chdb import session as chs
+
+sess = chs.Session("./analytics_db")
+
+# Ingest from multiple sources into local tables
+sess.query("""
+    CREATE TABLE users ENGINE = MergeTree() ORDER BY id AS
+    SELECT * FROM mysql('db:3306', 'crm', 'users', 'root', 'pass')
+""")
+
+sess.query("""
+    CREATE TABLE events ENGINE = MergeTree() ORDER BY (ts, user_id) AS
+    SELECT * FROM s3('s3://logs/events/*.parquet', NOSIGN)
+""")
+
+# Now analyze locally — super fast
+sess.query("""
+    SELECT
+        u.country,
+        e.event_type,
+        count() AS cnt,
+        uniqExact(e.user_id) AS unique_users
+    FROM events e
+    JOIN users u ON e.user_id = u.id
+    WHERE e.ts >= today() - 7
+    GROUP BY u.country, e.event_type
+    ORDER BY cnt DESC
+    LIMIT 20
+""", "Pretty").show()
+
+sess.close()
+```
+
+## 11. Python DataFrame as SQL Table
+
+```python
+import chdb
+import pandas as pd
+
+# Query any Python dict/DataFrame directly in SQL
+scores = {"student": ["Alice", "Bob", "Carol"], "math": [95, 87, 92], "science": [88, 91, 85]}
+chdb.query("SELECT student, math + science AS total FROM Python(scores) ORDER BY total DESC").show()
+
+# Join Python data with external source
+users_df = pd.DataFrame({"id": [1, 2, 3], "name": ["Alice", "Bob", "Carol"]})
+chdb.query("""
+    SELECT p.name, o.product, o.amount
+    FROM Python(users_df) AS p
+    JOIN file('orders.parquet', Parquet) AS o ON p.id = o.user_id
+    ORDER BY o.amount DESC
+""").show()
+```
+
+## 12. Parametrized Queries
+
+```python
+import chdb
+
+result = chdb.query(
+    """
+    SELECT
+        toDate({start:String}) + number AS date,
+        rand() % 1000 AS value
+    FROM numbers({days:UInt64})
+    """,
+    "DataFrame",
+    params={"start": "2025-01-01", "days": 30}
+)
+print(result)
+```
+
+## 13. Writing Data Across Sources
+
+```python
+from datastore import DataStore
+
+# Read from MySQL, transform, write to Parquet
+source = DataStore.from_mysql(
+    host="db:3306", database="shop", table="orders",
+    user="root", password="pass"
+)
+target = DataStore("file", path="output/orders_summary.parquet", format="Parquet")
+
+target.insert_into("category", "total_revenue", "order_count").select_from(
+    source
+        .groupby("category")
+        .select("category", "sum(amount) AS total_revenue", "count() AS order_count")
+        .filter(source['amount'] > 0)
+).execute()
+
+# Read from S3, filter, write to local file
+source = DataStore.from_s3("s3://logs/events.parquet", nosign=True)
+target = DataStore("file", path="filtered_events.parquet", format="Parquet")
+
+target.insert_into("user_id", "event_type", "ts").select_from(
+    source.select("user_id", "event_type", "ts").filter(source['event_type'] == 'error')
+).execute()
+```
+
+## 14. Window Functions & Advanced Analytics
+
+```python
+import chdb
+
+# Ranking within groups
+chdb.query("""
+    SELECT
+        department,
+        name,
+        salary,
+        rank() OVER (PARTITION BY department ORDER BY salary DESC) AS dept_rank,
+        salary - avg(salary) OVER (PARTITION BY department) AS diff_from_avg
+    FROM file('employees.parquet', Parquet)
+    ORDER BY department, dept_rank
+""", "Pretty").show()
+
+# Running totals
+chdb.query("""
+    SELECT
+        date,
+        revenue,
+        sum(revenue) OVER (ORDER BY date) AS cumulative_revenue,
+        avg(revenue) OVER (ORDER BY date ROWS BETWEEN 6 PRECEDING AND CURRENT ROW) AS rolling_7d_avg
+    FROM file('daily_sales.csv', CSVWithNames)
+    ORDER BY date
+""", "DataFrame")
+```
+
+## 15. Exploring Remote Database Schema
+
+```python
+from datastore import DataStore
+
+# Connect and browse MySQL schema
+mysql_ds = DataStore.from_mysql(
+    host="db:3306", database="ecommerce",
+    user="analyst", password="pass"
+)
+
+# Discover available tables and columns
+print(mysql_ds.databases())
+print(mysql_ds.tables("ecommerce"))
+
+# Quick preview of a table
+orders = DataStore.from_mysql(host="db:3306", database="ecommerce", table="orders", user="analyst", password="pass")
+print(orders.columns)
+print(orders.describe())
+print(orders.head(5))
+```

--- a/agent/skills/using-chdb/reference.md
+++ b/agent/skills/using-chdb/reference.md
@@ -1,0 +1,246 @@
+# chdb API Reference
+
+## chdb.query()
+
+```python
+chdb.query(sql, output_format="CSV", path="", udf_path="", params=None)
+```
+
+| Param | Type | Description |
+|-------|------|-------------|
+| `sql` | str | ClickHouse SQL query |
+| `output_format` | str | CSV, JSON, JSONEachRow, Arrow, Parquet, DataFrame, ArrowTable, Pretty, Debug |
+| `path` | str | Database path (empty = in-memory) |
+| `params` | dict | Named parameters `{name: value}`, referenced in SQL as `{name:Type}` |
+
+Returns result with `.show()`, `.bytes()`, `.data()`, `.rows_read`, `.elapsed`, `.bytes_read`.
+
+---
+
+## DataStore
+
+```python
+from datastore import DataStore
+# or: from chdb.datastore import DataStore
+```
+
+### Constructors
+
+```python
+DataStore(source=None, table=None, database=":memory:", connection=None, **kwargs)
+```
+
+| Source type | Usage |
+|-------------|-------|
+| dict | `DataStore({'col1': [1,2], 'col2': ['a','b']})` |
+| pd.DataFrame | `DataStore(df)` |
+| str (source type) | `DataStore("file", path="data.parquet")` |
+| str (source type) | `DataStore("mysql", host="host:3306", database="db", table="t", user="u", password="p")` |
+
+### Factory Methods — Files & Cloud Storage
+
+| Method | Signature |
+|--------|-----------|
+| `from_file` | `(path, format=None, structure=None, compression=None, **kwargs)` |
+| `from_s3` | `(url, access_key_id=None, secret_access_key=None, format=None, nosign=False, **kwargs)` |
+| `from_gcs` | `(url, hmac_key=None, hmac_secret=None, format=None, nosign=False, **kwargs)` |
+| `from_azure` | `(connection_string, container, path="", format=None, **kwargs)` |
+| `from_hdfs` | `(uri, format=None, structure=None, **kwargs)` |
+| `from_url` | `(url, format=None, structure=None, headers=None, **kwargs)` |
+
+### Factory Methods — Databases
+
+| Method | Signature |
+|--------|-----------|
+| `from_mysql` | `(host, database=None, table=None, user=None, password="", port=None, **kwargs)` |
+| `from_postgresql` | `(host, database=None, table=None, user=None, password="", port=None, **kwargs)` |
+| `from_clickhouse` | `(host, database=None, table=None, user="default", password="", secure=False, port=None, **kwargs)` |
+| `from_mongodb` | `(host, database, collection, user, password="", **kwargs)` |
+| `from_sqlite` | `(database_path, table, **kwargs)` |
+| `from_redis` | `(host, key, structure, password=None, db_index=0, **kwargs)` |
+
+### Factory Methods — Data Lakes
+
+| Method | Signature |
+|--------|-----------|
+| `from_iceberg` | `(url, access_key_id=None, secret_access_key=None, **kwargs)` |
+| `from_delta` | `(url, access_key_id=None, secret_access_key=None, **kwargs)` |
+| `from_hudi` | `(url, access_key_id=None, secret_access_key=None, **kwargs)` |
+
+### Factory Methods — Other
+
+| Method | Signature |
+|--------|-----------|
+| `from_df` / `from_dataframe` | `(df, name=None)` |
+| `from_numbers` | `(count, start=None, step=None, **kwargs)` |
+| `from_random` | `(structure, random_seed=None, max_string_length=None, max_array_length=None, **kwargs)` |
+| `run_sql` | `(query)` — run SQL and return DataStore |
+| `uri` | `(uri_string, **kwargs)` — universal URI-based factory |
+
+### URI Schemes
+
+| Scheme | Example |
+|--------|---------|
+| (path) | `/data/file.csv`, `data.parquet` |
+| `file` | `file:///data/file.csv` |
+| `s3`, `s3a`, `s3n` | `s3://bucket/key?nosign=true` |
+| `gs`, `gcs` | `gs://bucket/path` |
+| `az`, `azure`, `wasb` | `az://container/blob?account_name=X&account_key=Y` |
+| `hdfs` | `hdfs://namenode:9000/path` |
+| `http`, `https` | `https://example.com/data.json` |
+| `mysql` | `mysql://user:pass@host:port/db/table` |
+| `postgresql`, `postgres` | `postgresql://user:pass@host:port/db/table` |
+| `clickhouse` | `clickhouse://host:port/db/table?user=X&password=Y` |
+| `mongodb`, `mongo` | `mongodb://user:pass@host:port/db.collection` |
+| `sqlite` | `sqlite:///path/to/db.db?table=name` |
+| `redis` | `redis://host:port/db?key=mykey&password=pass` |
+| `iceberg` | `iceberg://catalog/namespace/table` |
+| `deltalake`, `delta` | `deltalake:///path/to/table` |
+| `hudi` | `hudi:///path/to/table` |
+
+### Selection & Filtering
+
+| Method | Description |
+|--------|-------------|
+| `ds['col']` | Single column → LazySeries |
+| `ds[['c1', 'c2']]` | Multiple columns → DataStore |
+| `ds[condition]` | Boolean filter → DataStore |
+| `.select(*fields)` | SQL-style SELECT |
+| `.filter(condition)` / `.where(condition)` | SQL-style WHERE |
+
+### Sorting & Limiting
+
+| Method | Description |
+|--------|-------------|
+| `.sort_values(by, ascending=True)` | Pandas-style sort |
+| `.sort(*columns, ascending=True)` / `.orderby(...)` | SQL-style ORDER BY |
+| `.limit(n)` | LIMIT |
+| `.offset(n)` | OFFSET |
+| `.head(n=5)` / `.tail(n=5)` | First/last N rows |
+
+### GroupBy & Aggregation
+
+| Method | Description |
+|--------|-------------|
+| `.groupby(*columns)` | → LazyGroupBy |
+| `.agg(func=None, **kwargs)` | `'sum'`, `'mean'`, `'count'`, `'min'`, `'max'`, `'std'`, `'var'` |
+| `.having(condition)` | HAVING clause |
+
+### Joins
+
+| Method | Description |
+|--------|-------------|
+| `.join(other, on=, how='inner', left_on=, right_on=, suffixes=)` | SQL JOIN (cross-source supported) |
+| `.merge(other, on=, how='inner')` | Pandas-style merge |
+
+`how` options: `'inner'`, `'left'`, `'right'`, `'outer'`, `'cross'`
+
+### Mutation
+
+| Method | Description |
+|--------|-------------|
+| `.assign(**kwargs)` | Add computed columns |
+| `.with_column(name, expr)` | Add single column |
+| `.drop(columns)` | Remove columns |
+| `.rename(columns={})` | Rename columns |
+| `.fillna(value)` | Fill NaN |
+| `.dropna(subset=)` | Drop rows with NaN |
+| `.distinct(subset=, keep='first')` | Deduplicate |
+
+### String & DateTime Accessors
+
+```python
+ds['name'].str.upper()
+ds['name'].str.contains('pattern')
+ds['date'].dt.year
+ds['date'].dt.month
+```
+
+### Inspection & Execution
+
+| Property/Method | Description |
+|----------------|-------------|
+| `.columns` | Column names (triggers execution) |
+| `.shape` | (rows, cols) tuple |
+| `.dtypes` | Column types |
+| `.head()` / `.tail()` | Preview rows |
+| `.describe()` | Statistics |
+| `.info()` | DataFrame info |
+| `.to_sql()` | View generated SQL |
+| `.explain()` | Execution plan |
+
+Execution triggers naturally: `print()`, `len()`, `.columns`, `for row in ds`, `.equals()`.
+
+### Writing Data
+
+```python
+target = DataStore("file", path="output.parquet", format="Parquet")
+target.insert_into("col1", "col2").select_from(
+    source.select("col1", "col2").filter(source['value'] > 100)
+).execute()
+```
+
+---
+
+## Session
+
+```python
+from chdb import session as chs
+sess = chs.Session(path=":memory:")     # in-memory
+sess = chs.Session(path="./mydb")       # persistent
+```
+
+| Method | Description |
+|--------|-------------|
+| `query(sql, fmt="CSV", params=None)` | Execute with state |
+| `send_query(sql, format="CSV")` | Streaming (returns iterator) |
+| `close()` | Close session |
+
+---
+
+## ClickHouse Table Functions (for raw SQL)
+
+| Function | SQL Example |
+|----------|-------------|
+| `file()` | `SELECT * FROM file('data.csv', CSVWithNames)` |
+| `s3()` | `SELECT * FROM s3('s3://bucket/key', 'KEY', 'SECRET', 'Parquet')` |
+| `url()` | `SELECT * FROM url('https://example.com/data.json', JSONEachRow)` |
+| `gcs()` | `SELECT * FROM gcs('gs://bucket/path', NOSIGN)` |
+| `azureBlobStorage()` | `SELECT * FROM azureBlobStorage('conn_str', 'container', 'path', 'Format')` |
+| `hdfs()` | `SELECT * FROM hdfs('hdfs://node:9000/path', 'Parquet')` |
+| `mysql()` | `SELECT * FROM mysql('host:3306', 'db', 'table', 'user', 'pass')` |
+| `postgresql()` | `SELECT * FROM postgresql('host:5432', 'db', 'table', 'user', 'pass')` |
+| `remote()` / `remoteSecure()` | `SELECT * FROM remote('host:9000', 'db', 'table', 'user', 'pass')` |
+| `mongodb()` | `SELECT * FROM mongodb('host:27017', 'db', 'collection', 'user', 'pass')` |
+| `sqlite()` | `SELECT * FROM sqlite('/path/to/db.db', 'table')` |
+| `iceberg()` | `SELECT * FROM iceberg('s3://bucket/iceberg/table', 'KEY', 'SECRET')` |
+| `deltaLake()` | `SELECT * FROM deltaLake('s3://bucket/delta/table', 'KEY', 'SECRET')` |
+| `hudi()` | `SELECT * FROM hudi('s3://bucket/hudi/table', 'KEY', 'SECRET')` |
+| `numbers()` | `SELECT * FROM numbers(100)` |
+| `Python()` | `SELECT * FROM Python(df)` |
+
+## ClickHouse SQL Functions (commonly used)
+
+| Category | Functions |
+|----------|-----------|
+| **Aggregate** | `count()`, `sum()`, `avg()`, `min()`, `max()`, `groupArray()`, `quantile(0.95)(col)`, `uniqExact()` |
+| **String** | `lower()`, `upper()`, `trim()`, `splitByChar()`, `replaceAll()`, `like()`, `match()` (regex) |
+| **Date** | `toDate()`, `toDateTime()`, `now()`, `today()`, `dateDiff()`, `formatDateTime()` |
+| **Type** | `toInt32()`, `toFloat64()`, `toString()`, `CAST(x AS Type)` |
+| **Conditional** | `if(cond, then, else)`, `multiIf()`, `CASE WHEN` |
+| **Array** | `arrayJoin()`, `arrayMap()`, `arrayFilter()`, `length()` |
+| **JSON** | `JSONExtract()`, `JSONExtractString()`, `simpleJSONExtractString()` |
+| **Window** | `row_number()`, `rank()`, `lag()`, `lead()` over `OVER (PARTITION BY ... ORDER BY ...)` |
+
+## DataStore Configuration
+
+```python
+from datastore import config
+
+config.use_chdb()         # prefer chDB/SQL backend
+config.use_pandas()       # prefer pandas backend
+config.prefer_chdb()      # prefer chDB when possible
+config.prefer_pandas()    # prefer pandas when possible
+config.enable_debug()     # verbose logging
+config.enable_profiling() # performance profiling
+```

--- a/install_skill.sh
+++ b/install_skill.sh
@@ -1,0 +1,39 @@
+#!/usr/bin/env bash
+# Install chdb AI Skill for coding agents (Cursor, Claude Code, Codex, etc.)
+set -e
+
+BASE_URL="https://raw.githubusercontent.com/chdb-io/chdb/main/agent/skills/using-chdb"
+FILES="SKILL.md reference.md examples.md"
+
+install_to() {
+  mkdir -p "$1"
+  for f in $FILES; do curl -sL "$BASE_URL/$f" -o "$1/$f"; done
+  echo "✓ Installed → $1"
+}
+
+installed=0
+
+# Cursor
+if [ -d "$HOME/.cursor" ]; then
+  install_to "$HOME/.cursor/skills/using-chdb"
+  installed=1
+fi
+
+# Claude Code
+if [ -d "$HOME/.claude" ]; then
+  install_to "$HOME/.claude/skills/using-chdb"
+  installed=1
+fi
+
+# Codex (OpenAI)
+codex_home="${CODEX_HOME:-$HOME/.codex}"
+if [ -d "$codex_home" ]; then
+  install_to "$codex_home/skills/using-chdb"
+  installed=1
+fi
+
+# None detected — install to all default locations
+if [ "$installed" -eq 0 ]; then
+  install_to "$HOME/.cursor/skills/using-chdb"
+  install_to "$HOME/.claude/skills/using-chdb"
+fi


### PR DESCRIPTION
## Summary

- Add an **AI Agent Skill** (`agent/skills/using-chdb/`) that teaches coding agents (Cursor, Claude Code, Codex, etc.) chdb's multi-data-source analytics API
- Add one-line `install_skill.sh` that auto-detects and installs to Cursor, Claude Code, and Codex
- Add brief section in README with install command

## Skill Contents

```
agent/skills/using-chdb/
├── SKILL.md       — Main guide: pandas-compatible API, 16+ data sources, cross-source joins, raw SQL
├── reference.md   — API reference: factory methods, URI schemes, ClickHouse table functions
└── examples.md    — 15 examples: cross-source joins, data lakes, cloud storage, pipelines
```

## Install

```bash
curl -sL https://raw.githubusercontent.com/chdb-io/chdb/main/install_skill.sh | bash
```