### PR TITLE
Fix update datastore/__init__.py version to match bumpversion config

### DIFF
--- a/datastore/__init__.py
+++ b/datastore/__init__.py
@@ -290,7 +290,7 @@ from .pandas_api import (  # noqa: E402
     array,
 )
 
-__version__ = "0.1.0"
+__version__ = "3.7.0"
 __author__ = "DataStore Contributors"
 
 __all__ = [


### PR DESCRIPTION
## Summary
- Fix v4.1.0 release CI failure (`bump-my-version replace` exit code 2)
- The refactor in 4c4e175 changed `.bumpversion.toml` to track `datastore/__init__.py` instead of `chdb/__init__.py`, but didn't update the version string from `"0.1.0"` to `"3.7.0"`
- This caused `bump-my-version` to fail with: `Did not find '3.7.0' in file: 'datastore/__init__.py'`

## Test plan
- After merge, delete and re-create the `v4.1.0` tag on the new HEAD, then re-push to trigger CI