### PR TITLE
Auto-detect ClickHouse Cloud secure connections

### DIFF
--- a/datastore/adapters.py
+++ b/datastore/adapters.py
@@ -8,8 +8,46 @@ Each adapter provides database-specific SQL generation for:
 - Building table function SQL
 """
 
+import logging
 from abc import ABC, abstractmethod
-from typing import List, Optional
+from typing import List, Optional, Tuple
+
+logger = logging.getLogger(__name__)
+
+CLICKHOUSE_CLOUD_SUFFIX = '.clickhouse.cloud'
+CLICKHOUSE_NATIVE_PORT = 9000
+CLICKHOUSE_NATIVE_SECURE_PORT = 9440
+
+
+def normalize_clickhouse_connection(host: str, secure: bool) -> Tuple[str, bool]:
+    """
+    Apply smart defaults for ClickHouse Cloud and secure connections.
+
+    Mirrors the auto-detection logic from clickhouse-client:
+    - PR #56638/#56649: .clickhouse.cloud host -> secure + port 9440
+    - PR #74212: port 9440 -> secure
+
+    Returns:
+        (normalized_host, secure) tuple
+    """
+    hostname, _, port_str = host.partition(':')
+    port = int(port_str) if port_str else None
+
+    if hostname.endswith(CLICKHOUSE_CLOUD_SUFFIX):
+        secure = True
+        if port == CLICKHOUSE_NATIVE_PORT:
+            logger.warning(
+                "ClickHouse Cloud does not support plaintext native protocol on port %d. "
+                "Switching to port %d (native + TLS).",
+                CLICKHOUSE_NATIVE_PORT, CLICKHOUSE_NATIVE_SECURE_PORT,
+            )
+            host = f"{hostname}:{CLICKHOUSE_NATIVE_SECURE_PORT}"
+        elif port is None:
+            host = f"{hostname}:{CLICKHOUSE_NATIVE_SECURE_PORT}"
+    elif port == CLICKHOUSE_NATIVE_SECURE_PORT:
+        secure = True
+
+    return host, secure
 
 
 class SourceAdapter(ABC):
@@ -83,6 +121,7 @@ class ClickHouseAdapter(SourceAdapter):
     
     def __init__(self, host: str, user: str = 'default', password: str = '', 
                  secure: bool = False, **kwargs):
+        host, secure = normalize_clickhouse_connection(host, secure)
         super().__init__(host, user, password, **kwargs)
         self.secure = secure
     

--- a/datastore/core.py
+++ b/datastore/core.py
@@ -443,6 +443,7 @@ class DataStore(PandasCompatMixin):
             "postgresql",
             "postgres",
         ]
+        clickhouse_sources = {"clickhouse", "remote", "remotesecure"}
         if source and source.lower() in remote_db_sources:
             # Merge port into host if provided separately
             host_val = kwargs.get("host", "")
@@ -451,12 +452,20 @@ class DataStore(PandasCompatMixin):
                 host_val = f"{host_val}:{port_val}"
                 kwargs["host"] = host_val  # update kwargs so table function also gets it
 
+            # Auto-detect ClickHouse Cloud / secure connections
+            secure_val = kwargs.get("secure", False)
+            if source.lower() in clickhouse_sources and host_val:
+                from .adapters import normalize_clickhouse_connection
+                host_val, secure_val = normalize_clickhouse_connection(host_val, secure_val)
+                kwargs["host"] = host_val
+                kwargs["secure"] = secure_val
+
             # Store remote params for metadata operations
             self._remote_params = {
                 "host": host_val,
                 "user": kwargs.get("user"),
                 "password": kwargs.get("password", ""),
-                "secure": kwargs.get("secure", False),
+                "secure": secure_val,
             }
 
             # Determine connection mode
@@ -2180,6 +2189,10 @@ class DataStore(PandasCompatMixin):
         """
         Create DataStore from remote ClickHouse server.
 
+        Auto-detects ClickHouse Cloud connections: hosts ending with
+        ``.clickhouse.cloud`` automatically use ``remoteSecure()`` on port 9440.
+        Port 9440 also auto-enables secure mode.
+
         Args:
             host: ClickHouse server address (host or host:port)
             database: Database name (optional - can be set later with use())
@@ -2201,9 +2214,9 @@ class DataStore(PandasCompatMixin):
             >>> ds_secure = DataStore.from_clickhouse("server:9440", "default", "events",
             ...                                       secure=True)
 
-            >>> # Port as separate parameter (e.g. ClickHouse Cloud)
-            >>> ds = DataStore.from_clickhouse("xxx.clickhouse.cloud", port=9440,
-            ...                                user="default", password="pass", secure=True)
+            >>> # ClickHouse Cloud - auto-detected, no need for secure=True or port
+            >>> ds = DataStore.from_clickhouse("xxx.clickhouse.cloud",
+            ...     user="default", password="pass", database="default", table="events")
         """
         if port is not None and ":" not in str(host):
             host = f"{host}:{port}"

--- a/datastore/table_functions.py
+++ b/datastore/table_functions.py
@@ -748,6 +748,8 @@ class RemoteTableFunction(TableFunction):
         return True
 
     def to_sql(self, quote_char: str = '"') -> str:
+        from .adapters import normalize_clickhouse_connection
+
         host = self.params.get("host")
         database = self.params.get("database", "default")
         table = self.params.get("table")
@@ -757,6 +759,8 @@ class RemoteTableFunction(TableFunction):
 
         if not all([host, table]):
             raise DataStoreError("'host' and 'table' are required for remote()")
+
+        host, secure = normalize_clickhouse_connection(host, secure)
 
         func_name = "remoteSecure" if secure else "remote"
 

--- a/datastore/tests/test_remote_connection.py
+++ b/datastore/tests/test_remote_connection.py
@@ -1330,5 +1330,123 @@ class TestEmptyPassword(unittest.TestCase):
         self.assertIn("''", func)  # Empty string in SQL
 
 
+class TestClickHouseCloudAutoDetect(unittest.TestCase):
+    """Test auto-detection of ClickHouse Cloud connections.
+
+    Mirrors clickhouse-client behavior:
+    - PR #56638/#56649: .clickhouse.cloud -> secure + port 9440
+    - PR #74212: port 9440 -> secure
+    """
+
+    def test_cloud_host_no_port_auto_secure_and_port(self):
+        """.clickhouse.cloud host without port -> secure=True, port 9440."""
+        ds = DataStore.from_clickhouse(
+            host="abc123.us-east-1.aws.clickhouse.cloud",
+            user="default", password="pass"
+        )
+        self.assertEqual(
+            ds._remote_params["host"],
+            "abc123.us-east-1.aws.clickhouse.cloud:9440",
+        )
+        self.assertTrue(ds._remote_params.get("secure"))
+
+    def test_cloud_host_port_9000_rewritten_to_9440(self):
+        """.clickhouse.cloud:9000 -> port rewritten to 9440."""
+        ds = DataStore.from_clickhouse(
+            host="abc123.clickhouse.cloud:9000",
+            user="default", password="pass"
+        )
+        self.assertEqual(
+            ds._remote_params["host"],
+            "abc123.clickhouse.cloud:9440",
+        )
+        self.assertTrue(ds._remote_params.get("secure"))
+
+    def test_cloud_host_port_9000_logs_warning(self):
+        """.clickhouse.cloud:9000 logs a warning about port switch."""
+        import logging
+        with self.assertLogs("datastore.adapters", level=logging.WARNING) as cm:
+            ClickHouseAdapter(
+                host="abc123.clickhouse.cloud:9000",
+                user="default", password="pass"
+            )
+        self.assertTrue(
+            any("port 9000" in msg and "9440" in msg for msg in cm.output),
+            f"Expected warning about port switch, got: {cm.output}",
+        )
+
+    def test_cloud_host_with_explicit_9440_kept(self):
+        """.clickhouse.cloud:9440 kept as-is, secure=True."""
+        ds = DataStore.from_clickhouse(
+            host="abc123.clickhouse.cloud:9440",
+            user="default", password="pass"
+        )
+        self.assertEqual(
+            ds._remote_params["host"],
+            "abc123.clickhouse.cloud:9440",
+        )
+        self.assertTrue(ds._remote_params.get("secure"))
+
+    def test_port_9440_auto_secure_non_cloud_host(self):
+        """Any host with port 9440 -> auto secure=True."""
+        ds = DataStore.from_clickhouse(
+            host="my-server.internal:9440",
+            user="default", password=""
+        )
+        self.assertTrue(ds._remote_params.get("secure"))
+
+    def test_non_cloud_host_port_9000_unchanged(self):
+        """Non-cloud host with port 9000 -> no changes."""
+        ds = DataStore.from_clickhouse(
+            host="localhost:9000", user="default", password=""
+        )
+        self.assertEqual(ds._remote_params["host"], "localhost:9000")
+        self.assertFalse(ds._remote_params.get("secure", False))
+
+    def test_cloud_host_with_port_param(self):
+        """ClickHouse Cloud with port as separate parameter."""
+        ds = DataStore.from_clickhouse(
+            host="abc123.clickhouse.cloud",
+            port=9000,
+            user="default", password="pass"
+        )
+        self.assertEqual(
+            ds._remote_params["host"],
+            "abc123.clickhouse.cloud:9440",
+        )
+        self.assertTrue(ds._remote_params.get("secure"))
+
+    def test_adapter_cloud_uses_remote_secure(self):
+        """ClickHouseAdapter with cloud host generates remoteSecure() SQL."""
+        adapter = ClickHouseAdapter(
+            host="abc123.clickhouse.cloud",
+            user="default", password="pass"
+        )
+        sql = adapter.list_databases_sql()
+        self.assertIn("remoteSecure(", sql)
+        self.assertIn("abc123.clickhouse.cloud:9440", sql)
+
+    def test_adapter_port_9440_uses_remote_secure(self):
+        """ClickHouseAdapter with port 9440 generates remoteSecure() SQL."""
+        adapter = ClickHouseAdapter(
+            host="my-server:9440",
+            user="default", password=""
+        )
+        sql = adapter.build_table_function("mydb", "users")
+        self.assertIn("remoteSecure(", sql)
+
+    def test_cloud_host_custom_port_preserved(self):
+        """.clickhouse.cloud with non-9000 custom port is preserved."""
+        ds = DataStore.from_clickhouse(
+            host="abc123.clickhouse.cloud:19440",
+            user="default", password="pass"
+        )
+        self.assertEqual(
+            ds._remote_params["host"],
+            "abc123.clickhouse.cloud:19440",
+        )
+        self.assertTrue(ds._remote_params.get("secure"))
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/datastore/tests/test_table_functions.py
+++ b/datastore/tests/test_table_functions.py
@@ -705,6 +705,33 @@ class TestRemoteTableFunction:
         sql = tf.to_sql()
         assert sql.startswith("remoteSecure(")
 
+    def test_remote_cloud_host_auto_secure(self):
+        """ClickHouse Cloud host auto-detects secure + port 9440."""
+        tf = RemoteTableFunction(
+            host="abc123.clickhouse.cloud", database="mydb", table="users"
+        )
+        sql = tf.to_sql()
+        assert sql.startswith("remoteSecure(")
+        assert "abc123.clickhouse.cloud:9440" in sql
+
+    def test_remote_cloud_host_port_9000_rewritten(self):
+        """ClickHouse Cloud host:9000 -> rewritten to 9440 + remoteSecure."""
+        tf = RemoteTableFunction(
+            host="abc123.clickhouse.cloud:9000", database="mydb", table="users"
+        )
+        sql = tf.to_sql()
+        assert sql.startswith("remoteSecure(")
+        assert "abc123.clickhouse.cloud:9440" in sql
+        assert ":9000" not in sql
+
+    def test_remote_port_9440_auto_secure(self):
+        """Port 9440 on any host -> remoteSecure."""
+        tf = RemoteTableFunction(
+            host="my-server:9440", database="mydb", table="users"
+        )
+        sql = tf.to_sql()
+        assert sql.startswith("remoteSecure(")
+
     def test_remote_missing_params(self):
         """Test error when required params are missing."""
         tf = RemoteTableFunction(host="localhost:9000")

--- a/datastore/tests/test_uri_parser.py
+++ b/datastore/tests/test_uri_parser.py
@@ -213,6 +213,31 @@ class TestDatabaseURIParsing:
         assert kwargs["user"] == "default"
         assert kwargs["password"] == "pass"
 
+    def test_clickhouse_uri_with_secure_true(self):
+        """Test ClickHouse URI with ?secure=true."""
+        uri = "clickhouse://myhost:9440/default/events?user=default&secure=true"
+        source_type, kwargs = parse_uri(uri)
+        assert source_type == "clickhouse"
+        assert kwargs["secure"] is True
+
+    def test_clickhouse_uri_with_secure_1(self):
+        """Test ClickHouse URI with ?secure=1."""
+        uri = "clickhouse://myhost:9440/default/events?secure=1"
+        source_type, kwargs = parse_uri(uri)
+        assert kwargs["secure"] is True
+
+    def test_clickhouse_uri_with_secure_false(self):
+        """Test ClickHouse URI with ?secure=false."""
+        uri = "clickhouse://myhost:9000/default/events?secure=false"
+        source_type, kwargs = parse_uri(uri)
+        assert kwargs["secure"] is False
+
+    def test_clickhouse_uri_without_secure(self):
+        """Test ClickHouse URI without secure param -> no secure key."""
+        uri = "clickhouse://myhost:9000/default/events"
+        source_type, kwargs = parse_uri(uri)
+        assert "secure" not in kwargs
+
 
 class TestHTTPURIParsing:
     """Test parsing of HTTP/HTTPS URIs."""

--- a/datastore/uri_parser.py
+++ b/datastore/uri_parser.py
@@ -480,7 +480,7 @@ def _parse_clickhouse_uri(parsed) -> Tuple[str, Dict[str, Any]]:
     """
     Parse clickhouse:// URI.
 
-    Format: clickhouse://host:port/database/table
+    Format: clickhouse://host:port/database/table?user=...&password=...&secure=true
     """
     kwargs = {}
 
@@ -504,6 +504,8 @@ def _parse_clickhouse_uri(parsed) -> Tuple[str, Dict[str, Any]]:
         kwargs["user"] = query_params["user"][0]
     if "password" in query_params:
         kwargs["password"] = query_params["password"][0]
+    if "secure" in query_params:
+        kwargs["secure"] = query_params["secure"][0].lower() in ("true", "1", "yes")
 
     return "clickhouse", kwargs
 


### PR DESCRIPTION
## Summary

- Auto-detect `.clickhouse.cloud` hosts and default to `remoteSecure()` on port 9440, mirroring [clickhouse-client behavior](https://github.com/ClickHouse/ClickHouse/pull/56649)
- Auto-enable `secure=True` when port 9440 is specified (mirrors [PR #74212](https://github.com/ClickHouse/ClickHouse/pull/74212))
- Add `?secure=true` support in `clickhouse://` URIs
- Log a warning when rewriting `.clickhouse.cloud:9000` → `:9440`

Fixes the `NO_REMOTE_SHARD_AVAILABLE` error users hit when connecting to ClickHouse Cloud without explicitly setting `secure=True` + port 9440.

## Changes

| File | Change |
|------|--------|
| `datastore/adapters.py` | Add `normalize_clickhouse_connection()` helper, call it in `ClickHouseAdapter.__init__` |
| `datastore/core.py` | Apply normalization when storing `_remote_params` for ClickHouse sources |
| `datastore/table_functions.py` | Apply normalization in `RemoteTableFunction.to_sql()` |
| `datastore/uri_parser.py` | Support `?secure=true` query parameter in `clickhouse://` URIs |

## Test plan

- [x] 10 new tests in `test_remote_connection.py` (cloud host, port rewrite, warning log, adapter SQL)
- [x] 3 new tests in `test_table_functions.py` (RemoteTableFunction auto-detection)
- [x] 4 new tests in `test_uri_parser.py` (`?secure=true/1/false`, absent)
- [x] All 300 tests in affected files pass
- [x] No linter errors