### PR TITLE
Optimize memory usage of DataStore

### DIFF
--- a/datastore/column_expr.py
+++ b/datastore/column_expr.py
@@ -656,9 +656,31 @@ class ColumnExpr:
         """Execute expression mode - evaluate the expression tree."""
         from .expression_evaluator import ExpressionEvaluator
         from .conditions import Condition
+        from .expressions import Field
 
-        # Get the executed DataFrame from the DataStore
-        df = self._datastore._execute()
+        # Column pruning: only materialize columns referenced by the expression
+        # instead of SELECT * which wastes memory for wide DataFrames.
+        # Only prune for SQL-backed DataStores (file/table) to avoid dtype changes
+        # when the pruning goes through a SQL segment on in-memory data.
+        # Also skip pruning when DISTINCT is active since it depends on all columns.
+        has_sql_source = bool(
+            self._datastore._table_function or getattr(self._datastore, 'table_name', None)
+        )
+        has_distinct = getattr(self._datastore, '_distinct', False)
+        needed_fields = set()
+        if has_sql_source and not has_distinct and self._expr is not None:
+            for node in self._expr.find(Field):
+                needed_fields.add(node.name)
+
+        if needed_fields:
+            all_cols = set(self._datastore._get_all_column_names())
+            if needed_fields < all_cols:
+                pruned = self._datastore.select(*sorted(needed_fields))
+                df = pruned._execute()
+            else:
+                df = self._datastore._execute()
+        else:
+            df = self._datastore._execute()
 
         # Use unified expression evaluator (respects function_config)
         evaluator = ExpressionEvaluator(df, self._datastore)
@@ -955,9 +977,6 @@ class ColumnExpr:
                 normalize=normalize, sort=sort, ascending=ascending, dropna=dropna
             )
 
-        # Get the DataFrame from datastore
-        df = self._datastore._execute()
-
         # Get column name from expression
         col_name = None
         if self._source is not None:
@@ -970,8 +989,30 @@ class ColumnExpr:
 
         # If we can't determine the column, fall back to pandas
         if col_name is None or (
-            not isinstance(self._source._expr, Field) and col_name not in df.columns
+            self._source is not None
+            and not isinstance(self._source._expr, Field)
         ):
+            series = (
+                self._source._execute()
+                if self._source is not None
+                else self._execute_expression()
+            )
+            return series.value_counts(
+                normalize=normalize, sort=sort, ascending=ascending, dropna=dropna
+            )
+
+        # Column pruning: only materialize the needed column instead of SELECT *
+        # Only for SQL-backed sources to avoid dtype changes on in-memory data
+        has_sql_source = bool(
+            self._datastore._table_function or getattr(self._datastore, 'table_name', None)
+        )
+        if has_sql_source:
+            pruned = self._datastore.select(col_name)
+            df = pruned._execute()
+        else:
+            df = self._datastore._execute()
+
+        if col_name not in df.columns:
             series = (
                 self._source._execute()
                 if self._source is not None
@@ -1159,11 +1200,58 @@ class ColumnExpr:
         sort = getattr(self, "_groupby_sort", True)
 
         try:
+            col_name = self._get_column_name()
+
+            # Single-SQL path: inject GROUP BY into lazy ops chain
+            # This avoids materializing the full intermediate DataFrame
+            # when the DataStore has a SQL source (file/table).
+            # Skip for in-memory DataStores to preserve pandas aggregation semantics
+            # (e.g., sum of all-NaN returns 0 in pandas but NULL in SQL).
+            has_sql_source = bool(
+                datastore._table_function or getattr(datastore, 'table_name', None)
+            )
+            if has_sql_source:
+                from copy import copy
+                from .lazy_ops import LazyGroupByAgg
+                dropna_val = getattr(self, "_groupby_dropna", True)
+                new_ds = copy(datastore)
+                new_ds._groupby_fields = []
+                new_ds._add_lazy_op(
+                    LazyGroupByAgg(
+                        groupby_cols=groupby_col_names,
+                        agg_func=self._pandas_agg_func or self._agg_func_name,
+                        sort=sort,
+                        as_index=False,
+                        dropna=dropna_val,
+                        selected_columns=[col_name],
+                    )
+                )
+                result_df = new_ds._execute()
+                datastore._groupby_fields = original_groupby
+                if as_index:
+                    if len(groupby_col_names) == 1:
+                        result_series = result_df.set_index(groupby_col_names[0])[col_name]
+                    else:
+                        result_series = result_df.set_index(groupby_col_names)[col_name]
+                    result_series.name = col_name
+                    return result_series
+                else:
+                    return result_df
+
             df = datastore._execute()
+
+            # Column pruning: drop columns not needed for groupby + aggregation
+            # to reduce memory before passing DataFrame to chDB for SQL execution
+            needed_cols = set(groupby_col_names)
+            if col_name and col_name in df.columns:
+                needed_cols.add(col_name)
+            if needed_cols and len(needed_cols) < len(df.columns):
+                cols_to_keep = [c for c in df.columns if c in needed_cols]
+                if len(cols_to_keep) == len(needed_cols):
+                    df = df[cols_to_keep]
 
             # Check execution engine configuration
             engine = get_execution_engine()
-            col_name = self._get_column_name()
 
             if engine == ExecutionEngine.PANDAS:
                 # Use pure pandas groupby with as_index, sort, and dropna parameters
@@ -5462,7 +5550,11 @@ class ColumnExpr:
         self, value=None, method=None, axis=None, inplace=False, limit=None
     ) -> "ColumnExpr":
         """
-        Fill NA/NaN values using pandas (lazy).
+        Fill NA/NaN values (lazy).
+
+        When value is a simple scalar and no method/limit is specified,
+        uses SQL ifNull() for efficient execution without full materialization.
+        Otherwise falls back to pandas fillna().
 
         Args:
             value: Value to use to fill holes (can be ColumnExpr or scalar)
@@ -5480,6 +5572,26 @@ class ColumnExpr:
         """
         if inplace:
             raise ImmutableError("ColumnExpr")
+
+        # Use SQL ifNull() for simple numeric scalar fills when we have an expression tree
+        # This avoids materializing the full DataFrame just to fill NAs
+        # Only for numeric values to avoid type mismatch (e.g., ifNull(Float64_col, 'string'))
+        # Only for SQL-backed sources - ifNull expression doesn't evaluate correctly
+        # on in-memory DataStores when chained with further operations (e.g., .abs())
+        has_sql_source = bool(
+            self._datastore
+            and (self._datastore._table_function or getattr(self._datastore, 'table_name', None))
+        )
+        if (
+            has_sql_source
+            and value is not None
+            and method is None
+            and limit is None
+            and self._expr is not None
+            and not isinstance(value, (pd.Series, pd.DataFrame))
+            and isinstance(value, (int, float))
+        ):
+            return self.fillna_sql(value)
 
         return ColumnExpr(
             source=self,

--- a/datastore/column_expr.py
+++ b/datastore/column_expr.py
@@ -1208,7 +1208,8 @@ class ColumnExpr:
                 datastore._table_function or getattr(datastore, 'table_name', None)
             )
             has_existing_lazy_ops = bool(getattr(datastore, '_lazy_ops', None))
-            if has_sql_source and not has_existing_lazy_ops:
+            engine = get_execution_engine()
+            if has_sql_source and not has_existing_lazy_ops and engine != ExecutionEngine.PANDAS:
                 from copy import copy
                 from .lazy_ops import LazyGroupByAgg
                 dropna_val = getattr(self, "_groupby_dropna", True)

--- a/datastore/column_expr.py
+++ b/datastore/column_expr.py
@@ -1210,7 +1210,8 @@ class ColumnExpr:
             has_sql_source = bool(
                 datastore._table_function or getattr(datastore, 'table_name', None)
             )
-            if has_sql_source:
+            has_existing_lazy_ops = bool(getattr(datastore, '_lazy_ops', None))
+            if has_sql_source and not has_existing_lazy_ops:
                 from copy import copy
                 from .lazy_ops import LazyGroupByAgg
                 dropna_val = getattr(self, "_groupby_dropna", True)

--- a/datastore/column_expr.py
+++ b/datastore/column_expr.py
@@ -1204,12 +1204,21 @@ class ColumnExpr:
 
             # Single-SQL path: push GROUP BY into the SQL query to avoid
             # materializing the full intermediate DataFrame.
+            # Skip for in-memory DataStores to preserve pandas aggregation semantics
+            # (e.g., sum of all-NaN returns 0 in pandas but NULL in SQL).
             has_sql_source = bool(
                 datastore._table_function or getattr(datastore, 'table_name', None)
             )
-            has_existing_lazy_ops = bool(getattr(datastore, '_lazy_ops', None))
             engine = get_execution_engine()
-            if has_sql_source and not has_existing_lazy_ops and engine != ExecutionEngine.PANDAS:
+            # Skip when WHERE references the aggregation column — chDB resolves
+            # aliases in WHERE, so "WHERE col > X" + "agg(col) AS col" triggers
+            # ILLEGAL_AGGREGATION.
+            has_where_alias_conflict = False
+            if datastore._where_condition is not None and col_name:
+                where_sql = datastore._where_condition.to_sql(quote_char='"')
+                if f'"{col_name}"' in where_sql:
+                    has_where_alias_conflict = True
+            if has_sql_source and engine != ExecutionEngine.PANDAS and not has_where_alias_conflict:
                 from copy import copy
                 from .lazy_ops import LazyGroupByAgg
                 dropna_val = getattr(self, "_groupby_dropna", True)

--- a/datastore/column_expr.py
+++ b/datastore/column_expr.py
@@ -1202,11 +1202,8 @@ class ColumnExpr:
         try:
             col_name = self._get_column_name()
 
-            # Single-SQL path: inject GROUP BY into lazy ops chain
-            # This avoids materializing the full intermediate DataFrame
-            # when the DataStore has a SQL source (file/table).
-            # Skip for in-memory DataStores to preserve pandas aggregation semantics
-            # (e.g., sum of all-NaN returns 0 in pandas but NULL in SQL).
+            # Single-SQL path: push GROUP BY into the SQL query to avoid
+            # materializing the full intermediate DataFrame.
             has_sql_source = bool(
                 datastore._table_function or getattr(datastore, 'table_name', None)
             )
@@ -1229,6 +1226,18 @@ class ColumnExpr:
                 )
                 result_df = new_ds._execute()
                 datastore._groupby_fields = original_groupby
+
+                # SQL GROUP BY doesn't support dropna — it keeps NULL/empty
+                # groups. Filter them out to match pandas dropna=True.
+                if dropna_val and len(result_df) > 0:
+                    for gc in groupby_col_names:
+                        if gc in result_df.columns:
+                            mask = result_df[gc].notna()
+                            if result_df[gc].dtype == object:
+                                mask = mask & (result_df[gc] != '')
+                            result_df = result_df[mask]
+                    result_df = result_df.reset_index(drop=True)
+
                 if as_index:
                     if len(groupby_col_names) == 1:
                         result_series = result_df.set_index(groupby_col_names[0])[col_name]

--- a/datastore/connection.py
+++ b/datastore/connection.py
@@ -725,23 +725,24 @@ class Connection:
         """
         sql_upper = sql.upper()
 
-        # Check if LIMIT/OFFSET exists at the OUTER level (not inside a subquery)
+        # Check if LIMIT/OFFSET or SETTINGS exists at the OUTER level (not inside a subquery)
         limit_pos = self._find_outer_clause_position(sql_upper, "LIMIT")
         offset_pos = self._find_outer_clause_position(sql_upper, "OFFSET")
+        settings_pos = self._find_outer_clause_position(sql_upper, "SETTINGS")
 
-        if limit_pos != -1 or offset_pos != -1:
-            # LIMIT/OFFSET at outer level - insert ORDER BY before it
-            clause_start = len(sql)
-            if limit_pos != -1:
-                clause_start = min(clause_start, limit_pos)
-            if offset_pos != -1:
-                clause_start = min(clause_start, offset_pos)
+        # Find earliest trailing clause position
+        trailing_positions = [
+            p for p in [limit_pos, offset_pos, settings_pos] if p != -1
+        ]
 
+        if trailing_positions:
+            # Insert ORDER BY before the first trailing clause
+            clause_start = min(trailing_positions)
             base_query = sql[:clause_start].strip()
-            limit_offset_clause = sql[clause_start:].strip()
-            return f"{base_query} ORDER BY _row_id {limit_offset_clause}"
+            trailing_clause = sql[clause_start:].strip()
+            return f"{base_query} ORDER BY _row_id {trailing_clause}"
         else:
-            # No LIMIT/OFFSET at outer level: add ORDER BY at the end
+            # No trailing clauses: add ORDER BY at the end
             return f"{sql} ORDER BY _row_id"
 
     def _append_row_id_tiebreaker(self, sql: str) -> str:

--- a/datastore/core.py
+++ b/datastore/core.py
@@ -5203,8 +5203,10 @@ class DataStore(PandasCompatMixin):
                 left_sql = self._generate_select_sql(self.quote_char)
                 other_sql = other._generate_select_sql(other.quote_char)
                 union_keyword = "UNION ALL" if all else "UNION"
-                union_sql = f"{left_sql} {union_keyword} {other_sql}"
+                union_sql = f"({left_sql}) {union_keyword} ({other_sql})"
                 self._table_function = SubqueryTableFunction(union_sql)
+                self._cached_result = None
+                self._cached_at_version = -1
                 self._select_fields = []
                 self._where_condition = None
                 self._joins = []

--- a/datastore/core.py
+++ b/datastore/core.py
@@ -1165,6 +1165,7 @@ class DataStore(PandasCompatMixin):
     def _is_pristine_sql_source(self) -> bool:
         """Check if this is a raw SQL/file source with no operations."""
         return (not self._lazy_ops
+                and not self._joins
                 and (self._table_function is not None or self.table_name is not None))
 
     def _probe_dtypes_from_sql_source(self) -> "pd.Series":
@@ -1323,10 +1324,30 @@ class DataStore(PandasCompatMixin):
                         self._distinct = False
                         self._distinct_subset = None
 
+                        # Update _source_df to the execution result so the old
+                        # source DataFrame can be garbage collected. This points
+                        # to the same object as _cached_result (no extra memory).
+                        self._source_df = df
+
                         self._logger.debug(
                             "Pipeline checkpointed: lazy_ops replaced with DataFrame source"
                         )
                     else:
+                        # Pure SQL execution with a DataFrame source (via
+                        # PythonTableFunction): checkpoint to release the old
+                        # source DataFrame. After execution, the computed
+                        # columns are materialized in df, so the old
+                        # expressions and PythonTableFunction are no longer
+                        # needed.
+                        if self._source_df is not None:
+                            from .lazy_ops import LazyDataFrameSource
+
+                            self._source_df = df
+                            self._table_function = None
+                            self._lazy_ops = [LazyDataFrameSource(df)]
+                            self._select_fields = []
+                            self._computed_columns = {}
+
                         self._logger.debug("Pure SQL execution: SQL state preserved")
 
                     self._cache_version = 0
@@ -3873,6 +3894,39 @@ class DataStore(PandasCompatMixin):
             schema = self.schema()
             if schema:
                 return pd.Index(schema.keys())
+        # When we have computed columns from assign() on a SQL source with no
+        # column-reducing ops (selections/filters), derive column names from
+        # schema + computed columns without materialization.
+        # Skip when there are column-reducing lazy ops (e.g., df[['a','b']])
+        # since _get_all_column_names() returns source columns, not selected ones.
+        if (
+            self._computed_columns
+            and (self._table_function is not None or self.table_name is not None)
+            and not self._joins
+            and self._can_sql_pushdown()
+            and self._cached_result is None
+            and self._source_df is None
+        ):
+            try:
+                base_cols = list(self._get_all_column_names())
+                computed_cols = [
+                    c for c in self._computed_columns if c not in base_cols
+                ]
+                return pd.Index(base_cols + computed_cols)
+            except Exception:
+                pass
+        # For JOINs or complex SQL sources: probe schema with LIMIT 0
+        # This avoids materializing the full result just to get column names
+        if (
+            self._joins
+            and self._can_sql_pushdown()
+            and self._cached_result is None
+        ):
+            try:
+                probe_df = self._probe_schema()
+                return probe_df.columns
+            except Exception:
+                pass
         return self._get_df().columns
 
     @columns.setter
@@ -5132,6 +5186,36 @@ class DataStore(PandasCompatMixin):
             >>> ds1.union(ds2, all=True)  # Keeps all rows (like SQL UNION ALL)
         """
         from .lazy_ops import LazyUnion
+
+        # When both sides have SQL sources, use SQL UNION ALL directly
+        # This avoids materializing both sides into Python DataFrames
+        has_sql_source = bool(self._table_function or self.table_name)
+        other_has_sql_source = bool(
+            hasattr(other, '_table_function') and (other._table_function or getattr(other, 'table_name', None))
+        )
+        if has_sql_source and other_has_sql_source:
+            from .table_functions import SubqueryTableFunction
+            left_cols = list(self._get_all_column_names())
+            right_cols = list(other._get_all_column_names())
+            if set(left_cols) == set(right_cols):
+                if left_cols != right_cols:
+                    other = other.select(*left_cols)
+                left_sql = self._generate_select_sql(self.quote_char)
+                other_sql = other._generate_select_sql(other.quote_char)
+                union_keyword = "UNION ALL" if all else "UNION"
+                union_sql = f"{left_sql} {union_keyword} {other_sql}"
+                self._table_function = SubqueryTableFunction(union_sql)
+                self._select_fields = []
+                self._where_condition = None
+                self._joins = []
+                self._groupby_fields = []
+                self._having_condition = None
+                self._orderby_fields = []
+                self._limit_value = None
+                self._offset_value = None
+                self._distinct = False
+                self._select_star = False
+                return  # @immutable returns the copy
 
         # Add LazyUnion operation - pass the DataStore/DataFrame directly
         # Execution is deferred until needed

--- a/datastore/pandas_api.py
+++ b/datastore/pandas_api.py
@@ -1019,6 +1019,19 @@ def concat(objs, axis=0, join="outer", ignore_index=False, keys=None, **kwargs):
     """
     DataStore = _get_datastore_class()
 
+    # Lazy UNION ALL path for simple vertical concatenation of DataStores
+    if (
+        axis == 0
+        and keys is None
+        and not kwargs.get("verify_integrity", False)
+        and all(isinstance(obj, DataStore) for obj in objs)
+        and len(objs) >= 2
+    ):
+        result = objs[0]
+        for obj in objs[1:]:
+            result = result.union(obj, all=True)
+        return result
+
     # Check if any input is a DataStore (vs plain pandas DataFrame)
     has_datastore = False
     dfs = []

--- a/datastore/pandas_api.py
+++ b/datastore/pandas_api.py
@@ -1019,9 +1019,12 @@ def concat(objs, axis=0, join="outer", ignore_index=False, keys=None, **kwargs):
     """
     DataStore = _get_datastore_class()
 
-    # Lazy UNION ALL path for simple vertical concatenation of DataStores
+    # Lazy UNION ALL path for simple vertical concatenation of DataStores.
+    # Only when ignore_index=True (UNION ALL resets index) and join='outer'.
     if (
         axis == 0
+        and ignore_index
+        and join == "outer"
         and keys is None
         and not kwargs.get("verify_integrity", False)
         and all(isinstance(obj, DataStore) for obj in objs)

--- a/datastore/pandas_compat.py
+++ b/datastore/pandas_compat.py
@@ -1551,6 +1551,7 @@ class PandasCompatMixin:
             and join == 'outer'
             and keys is None
             and not verify_integrity
+            and len(objs) >= 2
             and all(isinstance(obj, DataStore) for obj in objs)
         ):
             result = objs[0]

--- a/datastore/pandas_compat.py
+++ b/datastore/pandas_compat.py
@@ -1543,9 +1543,12 @@ class PandasCompatMixin:
         """
         DataStore = type(self)
 
-        # Lazy UNION ALL path for simple vertical concatenation
+        # Lazy UNION ALL path for simple vertical concatenation.
+        # Only when ignore_index=True (UNION ALL resets index) and join='outer'.
         if (
             axis == 0
+            and ignore_index
+            and join == 'outer'
             and keys is None
             and not verify_integrity
             and all(isinstance(obj, DataStore) for obj in objs)

--- a/datastore/pandas_compat.py
+++ b/datastore/pandas_compat.py
@@ -220,9 +220,30 @@ class DataStoreLocIndexer:
 
     def __setitem__(self, key, value):
         """Set item via loc, converting ColumnExpr to pandas types first."""
+        from .lazy_ops import LazyDataFrameSource
+
         converted_key = self._convert_key(key)
         df = self._datastore._get_df()
         df.loc[converted_key] = value
+
+        # Checkpoint: wrap the modified DataFrame as LazyDataFrameSource
+        # so that subsequent _execute() calls return this modified DataFrame
+        # instead of re-running the original SQL pipeline (which would lose
+        # the in-place modifications made by loc[]).
+        self._datastore._lazy_ops = [LazyDataFrameSource(df)]
+        self._datastore._table_function = None
+        self._datastore.table_name = None
+        self._datastore._select_fields = []
+        self._datastore._where_condition = None
+        self._datastore._joins = []
+        self._datastore._groupby_fields = []
+        self._datastore._having_condition = None
+        self._datastore._orderby_fields = []
+        self._datastore._limit_value = None
+        self._datastore._offset_value = None
+        self._datastore._distinct = False
+        self._datastore._source_df = df
+        self._datastore._computed_columns = {}
 
         # Invalidate cache since we modified the underlying DataFrame
         self._datastore._invalidate_cache()
@@ -1427,8 +1448,62 @@ class PandasCompatMixin:
         indicator=False,
         validate=None,
     ):
-        """Merge DataFrame objects."""
-        # Convert right to DataFrame if it's a DataStore
+        """Merge DataFrame objects.
+
+        Uses lazy SQL JOIN when both sides are DataStores with SQL sources
+        and no advanced pandas-only features are needed. Falls back to
+        pandas merge otherwise.
+        """
+        DataStore = type(self)
+
+        # Try lazy SQL JOIN path when both sides are DataStores with SQL sources
+        # and no pandas-only merge features are used
+        # Determine join key columns
+        if on is not None:
+            key_cols = set(on) if isinstance(on, (list, tuple)) else {on}
+        elif left_on is not None and right_on is not None:
+            lk = set(left_on) if isinstance(left_on, (list, tuple)) else {left_on}
+            rk = set(right_on) if isinstance(right_on, (list, tuple)) else {right_on}
+            key_cols = lk | rk
+        else:
+            key_cols = set()
+
+        # Check for overlapping non-key columns — SQL JOIN uses table.col
+        # naming (e.g., right.value) while pandas uses suffixes (_x/_y).
+        # Fall back to pandas when suffixes would be needed.
+        left_cols = set()
+        right_cols = set()
+        try:
+            if isinstance(right, DataStore):
+                left_cols = set(self._get_all_column_names())
+                right_cols = set(right._get_all_column_names())
+        except Exception:
+            pass
+        overlapping_non_key = (left_cols & right_cols) - key_cols
+
+        can_use_sql_join = (
+            isinstance(right, DataStore)
+            and not left_index
+            and not right_index
+            and not indicator
+            and not sort
+            and validate is None
+            and not overlapping_non_key
+            and (on is not None or (left_on is not None and right_on is not None))
+            and bool(self._table_function or self.table_name
+                     or self._source_df is not None)
+            and bool(right._table_function or right.table_name
+                     or right._source_df is not None)
+        )
+
+        if can_use_sql_join:
+            try:
+                return self.join(right, on=on, how=how,
+                                 left_on=left_on, right_on=right_on)
+            except Exception:
+                pass  # Fall back to pandas merge
+
+        # Pandas merge fallback
         if hasattr(right, '_get_df'):
             right = right._get_df()
         return self._wrap_result(
@@ -1461,8 +1536,26 @@ class PandasCompatMixin:
         sort=False,
         copy=True,
     ):
-        """Concatenate DataStore/DataFrame objects."""
-        # Convert DataStore objects to DataFrames
+        """Concatenate DataStore/DataFrame objects.
+
+        Uses lazy SQL UNION ALL when all objects are DataStores and axis=0.
+        Falls back to pandas concat otherwise.
+        """
+        DataStore = type(self)
+
+        # Lazy UNION ALL path for simple vertical concatenation
+        if (
+            axis == 0
+            and keys is None
+            and not verify_integrity
+            and all(isinstance(obj, DataStore) for obj in objs)
+        ):
+            result = objs[0]
+            for obj in objs[1:]:
+                result = result.union(obj, all=True)
+            return result
+
+        # Pandas concat fallback
         dfs = []
         for obj in objs:
             if hasattr(obj, '_get_df'):

--- a/datastore/table_functions.py
+++ b/datastore/table_functions.py
@@ -97,6 +97,29 @@ class TableFunction(ABC):
         return False
 
 
+class SubqueryTableFunction(TableFunction):
+    """
+    Wraps a raw SQL subquery as a table source.
+
+    Used for UNION ALL and other composite SQL expressions.
+    """
+
+    def __init__(self, sql: str):
+        super().__init__()
+        self._sql = sql
+
+    @property
+    def can_read(self) -> bool:
+        return True
+
+    @property
+    def can_write(self) -> bool:
+        return False
+
+    def to_sql(self, quote_char: str = '"') -> str:
+        return f"({self._sql})"
+
+
 class FileTableFunction(TableFunction):
     """
     Wrapper for file() table function.

--- a/datastore/tests/test_merge_join_compat.py
+++ b/datastore/tests/test_merge_join_compat.py
@@ -17,7 +17,6 @@ All tests use Mirror Code Pattern: DataStore result == pandas result.
 import os
 import tempfile
 import pandas as pd
-import numpy as np
 import pytest
 
 from datastore import DataStore, concat as ds_concat

--- a/datastore/tests/test_merge_join_compat.py
+++ b/datastore/tests/test_merge_join_compat.py
@@ -1,0 +1,715 @@
+"""
+Merge/Join pandas compatibility tests.
+
+Covers edge cases where SQL JOIN path might diverge from pandas merge:
+1. Overlapping non-key columns (suffixes handling)
+2. left_on / right_on with different column names
+3. Different column orders between left and right
+4. merge sort parameter
+5. Various join types (inner, left, right, outer)
+6. from_df() DataStore merge (SQL path vs pandas path)
+7. File-backed DataStore merge
+8. SQL UNION ALL column ordering in concat/union
+
+All tests use Mirror Code Pattern: DataStore result == pandas result.
+"""
+
+import os
+import tempfile
+import pandas as pd
+import numpy as np
+import pytest
+
+from datastore import DataStore, concat as ds_concat
+from tests.test_utils import assert_datastore_equals_pandas
+
+
+# ===========================================================================
+# Fixtures
+# ===========================================================================
+
+@pytest.fixture
+def left_data():
+    return {"user_id": [1, 2, 3], "name": ["Alice", "Bob", "Charlie"], "score": [85, 92, 78]}
+
+
+@pytest.fixture
+def right_data():
+    return {"user_id": [1, 2, 4], "city": ["NYC", "LA", "Chicago"], "age": [25, 30, 35]}
+
+
+@pytest.fixture
+def right_data_with_overlap():
+    """Right table with same non-key column 'name' as left."""
+    return {"user_id": [1, 2, 4], "name": ["Order-A", "Order-B", "Order-C"], "amount": [100, 200, 300]}
+
+
+@pytest.fixture
+def tmp_dir():
+    with tempfile.TemporaryDirectory() as d:
+        yield d
+
+
+# ===========================================================================
+# 1. Overlapping non-key columns → suffixes must work
+# ===========================================================================
+
+class TestMergeOverlappingColumns:
+    """When both tables have non-key columns with the same name,
+    pandas adds suffixes. SQL JOIN path must fall back to pandas."""
+
+    def test_merge_overlapping_default_suffixes(self, left_data, right_data_with_overlap):
+        pd_left = pd.DataFrame(left_data)
+        pd_right = pd.DataFrame(right_data_with_overlap)
+        pd_result = pd_left.merge(pd_right, on="user_id")
+
+        ds_left = DataStore(left_data)
+        ds_right = DataStore(right_data_with_overlap)
+        ds_result = ds_left.merge(ds_right, on="user_id")
+
+        assert "name_x" in list(pd_result.columns)
+        assert "name_y" in list(pd_result.columns)
+        assert_datastore_equals_pandas(ds_result, pd_result, check_row_order=False)
+
+    def test_merge_overlapping_custom_suffixes(self, left_data, right_data_with_overlap):
+        pd_left = pd.DataFrame(left_data)
+        pd_right = pd.DataFrame(right_data_with_overlap)
+        pd_result = pd_left.merge(pd_right, on="user_id", suffixes=("_left", "_right"))
+
+        ds_left = DataStore(left_data)
+        ds_right = DataStore(right_data_with_overlap)
+        ds_result = ds_left.merge(ds_right, on="user_id", suffixes=("_left", "_right"))
+
+        assert "name_left" in list(pd_result.columns)
+        assert "name_right" in list(pd_result.columns)
+        assert_datastore_equals_pandas(ds_result, pd_result, check_row_order=False)
+
+    def test_merge_overlapping_left_join(self, left_data, right_data_with_overlap):
+        pd_left = pd.DataFrame(left_data)
+        pd_right = pd.DataFrame(right_data_with_overlap)
+        pd_result = pd_left.merge(pd_right, on="user_id", how="left")
+
+        ds_left = DataStore(left_data)
+        ds_right = DataStore(right_data_with_overlap)
+        ds_result = ds_left.merge(ds_right, on="user_id", how="left")
+
+        assert_datastore_equals_pandas(ds_result, pd_result, check_row_order=False)
+
+    def test_merge_overlapping_outer_join(self, left_data, right_data_with_overlap):
+        pd_left = pd.DataFrame(left_data)
+        pd_right = pd.DataFrame(right_data_with_overlap)
+        pd_result = pd_left.merge(pd_right, on="user_id", how="outer")
+
+        ds_left = DataStore(left_data)
+        ds_right = DataStore(right_data_with_overlap)
+        ds_result = ds_left.merge(ds_right, on="user_id", how="outer")
+
+        assert_datastore_equals_pandas(ds_result, pd_result, check_row_order=False)
+
+    def test_merge_overlapping_multiple_columns(self):
+        """Both 'val' and 'tag' overlap."""
+        pd_left = pd.DataFrame({"key": [1, 2], "val": [10, 20], "tag": ["a", "b"]})
+        pd_right = pd.DataFrame({"key": [1, 2], "val": [100, 200], "tag": ["x", "y"]})
+        pd_result = pd_left.merge(pd_right, on="key")
+
+        ds_left = DataStore({"key": [1, 2], "val": [10, 20], "tag": ["a", "b"]})
+        ds_right = DataStore({"key": [1, 2], "val": [100, 200], "tag": ["x", "y"]})
+        ds_result = ds_left.merge(ds_right, on="key")
+
+        assert "val_x" in list(pd_result.columns)
+        assert "val_y" in list(pd_result.columns)
+        assert "tag_x" in list(pd_result.columns)
+        assert "tag_y" in list(pd_result.columns)
+        assert_datastore_equals_pandas(ds_result, pd_result, check_row_order=False)
+
+
+# ===========================================================================
+# 2. No overlapping non-key columns → SQL path safe
+# ===========================================================================
+
+class TestMergeNoOverlap:
+    """When tables have no overlapping non-key columns,
+    the SQL JOIN path can be used safely."""
+
+    def test_merge_no_overlap_inner(self, left_data, right_data):
+        pd_left = pd.DataFrame(left_data)
+        pd_right = pd.DataFrame(right_data)
+        pd_result = pd_left.merge(pd_right, on="user_id")
+
+        ds_left = DataStore(left_data)
+        ds_right = DataStore(right_data)
+        ds_result = ds_left.merge(ds_right, on="user_id")
+
+        assert_datastore_equals_pandas(ds_result, pd_result, check_row_order=False)
+
+    def test_merge_no_overlap_left(self, left_data, right_data):
+        pd_left = pd.DataFrame(left_data)
+        pd_right = pd.DataFrame(right_data)
+        pd_result = pd_left.merge(pd_right, on="user_id", how="left")
+
+        ds_left = DataStore(left_data)
+        ds_right = DataStore(right_data)
+        ds_result = ds_left.merge(ds_right, on="user_id", how="left")
+
+        assert_datastore_equals_pandas(ds_result, pd_result, check_row_order=False)
+
+    def test_merge_no_overlap_right(self, left_data, right_data):
+        pd_left = pd.DataFrame(left_data)
+        pd_right = pd.DataFrame(right_data)
+        pd_result = pd_left.merge(pd_right, on="user_id", how="right")
+
+        ds_left = DataStore(left_data)
+        ds_right = DataStore(right_data)
+        ds_result = ds_left.merge(ds_right, on="user_id", how="right")
+
+        assert_datastore_equals_pandas(ds_result, pd_result, check_row_order=False)
+
+    def test_merge_no_overlap_outer(self, left_data, right_data):
+        pd_left = pd.DataFrame(left_data)
+        pd_right = pd.DataFrame(right_data)
+        pd_result = pd_left.merge(pd_right, on="user_id", how="outer")
+
+        ds_left = DataStore(left_data)
+        ds_right = DataStore(right_data)
+        ds_result = ds_left.merge(ds_right, on="user_id", how="outer")
+
+        assert_datastore_equals_pandas(ds_result, pd_result, check_row_order=False)
+
+
+# ===========================================================================
+# 3. left_on / right_on with different column names
+# ===========================================================================
+
+class TestMergeLeftOnRightOn:
+    """Merge with left_on/right_on where key column names differ."""
+
+    def test_left_on_right_on_inner(self):
+        pd_left = pd.DataFrame({"id": [1, 2, 3], "val_l": [10, 20, 30]})
+        pd_right = pd.DataFrame({"uid": [1, 2, 4], "val_r": [100, 200, 400]})
+        pd_result = pd_left.merge(pd_right, left_on="id", right_on="uid")
+
+        ds_left = DataStore({"id": [1, 2, 3], "val_l": [10, 20, 30]})
+        ds_right = DataStore({"uid": [1, 2, 4], "val_r": [100, 200, 400]})
+        ds_result = ds_left.merge(ds_right, left_on="id", right_on="uid")
+
+        assert_datastore_equals_pandas(ds_result, pd_result, check_row_order=False)
+
+    def test_left_on_right_on_left_join(self):
+        pd_left = pd.DataFrame({"id": [1, 2, 3], "val_l": [10, 20, 30]})
+        pd_right = pd.DataFrame({"uid": [1, 2, 4], "val_r": [100, 200, 400]})
+        pd_result = pd_left.merge(pd_right, left_on="id", right_on="uid", how="left")
+
+        ds_left = DataStore({"id": [1, 2, 3], "val_l": [10, 20, 30]})
+        ds_right = DataStore({"uid": [1, 2, 4], "val_r": [100, 200, 400]})
+        ds_result = ds_left.merge(ds_right, left_on="id", right_on="uid", how="left")
+
+        assert_datastore_equals_pandas(ds_result, pd_result, check_row_order=False)
+
+    def test_left_on_right_on_with_overlapping_columns(self):
+        """left_on/right_on but both have a 'name' column."""
+        pd_left = pd.DataFrame({"id": [1, 2], "name": ["A", "B"]})
+        pd_right = pd.DataFrame({"uid": [1, 2], "name": ["X", "Y"]})
+        pd_result = pd_left.merge(pd_right, left_on="id", right_on="uid")
+
+        ds_left = DataStore({"id": [1, 2], "name": ["A", "B"]})
+        ds_right = DataStore({"uid": [1, 2], "name": ["X", "Y"]})
+        ds_result = ds_left.merge(ds_right, left_on="id", right_on="uid")
+
+        assert "name_x" in list(pd_result.columns)
+        assert "name_y" in list(pd_result.columns)
+        assert_datastore_equals_pandas(ds_result, pd_result, check_row_order=False)
+
+
+# ===========================================================================
+# 4. File-backed DataStore merge (Parquet)
+# ===========================================================================
+
+class TestMergeFileBacked:
+    """Merge between file-backed DataStores (Parquet)."""
+
+    def test_merge_two_parquet_no_overlap(self, tmp_dir):
+        pd_left = pd.DataFrame({"user_id": [1, 2, 3], "score": [85, 92, 78]})
+        pd_right = pd.DataFrame({"user_id": [1, 2, 4], "city": ["NYC", "LA", "CHI"]})
+
+        left_path = os.path.join(tmp_dir, "left.parquet")
+        right_path = os.path.join(tmp_dir, "right.parquet")
+        pd_left.to_parquet(left_path, index=False)
+        pd_right.to_parquet(right_path, index=False)
+
+        pd_result = pd_left.merge(pd_right, on="user_id")
+
+        ds_left = DataStore.from_file(left_path)
+        ds_right = DataStore.from_file(right_path)
+        ds_result = ds_left.merge(ds_right, on="user_id")
+
+        assert_datastore_equals_pandas(ds_result, pd_result, check_row_order=False)
+
+    def test_merge_two_parquet_with_overlap(self, tmp_dir):
+        pd_left = pd.DataFrame({"user_id": [1, 2, 3], "name": ["A", "B", "C"]})
+        pd_right = pd.DataFrame({"user_id": [1, 2, 4], "name": ["X", "Y", "Z"]})
+
+        left_path = os.path.join(tmp_dir, "left2.parquet")
+        right_path = os.path.join(tmp_dir, "right2.parquet")
+        pd_left.to_parquet(left_path, index=False)
+        pd_right.to_parquet(right_path, index=False)
+
+        pd_result = pd_left.merge(pd_right, on="user_id")
+
+        ds_left = DataStore.from_file(left_path)
+        ds_right = DataStore.from_file(right_path)
+        ds_result = ds_left.merge(ds_right, on="user_id")
+
+        assert "name_x" in list(pd_result.columns)
+        assert "name_y" in list(pd_result.columns)
+        assert_datastore_equals_pandas(ds_result, pd_result, check_row_order=False)
+
+
+# ===========================================================================
+# 5. Column order differences in concat/union
+# ===========================================================================
+
+class TestConcatColumnOrder:
+    """SQL UNION ALL matches by position; pandas concat matches by name.
+    Verify correct behavior when column orders differ."""
+
+    def test_concat_same_columns_same_order(self):
+        pd1 = pd.DataFrame({"A": [1, 2], "B": [3, 4]})
+        pd2 = pd.DataFrame({"A": [5, 6], "B": [7, 8]})
+        pd_result = pd.concat([pd1, pd2], ignore_index=True)
+
+        ds1 = DataStore({"A": [1, 2], "B": [3, 4]})
+        ds2 = DataStore({"A": [5, 6], "B": [7, 8]})
+        ds_result = ds_concat([ds1, ds2], ignore_index=True)
+
+        assert_datastore_equals_pandas(ds_result, pd_result)
+
+    def test_concat_same_columns_different_order(self):
+        """Critical test: columns in different order must align by name."""
+        pd1 = pd.DataFrame({"A": [1, 2], "B": [3, 4]})
+        pd2 = pd.DataFrame({"B": [7, 8], "A": [5, 6]})
+        pd_result = pd.concat([pd1, pd2], ignore_index=True)
+
+        ds1 = DataStore({"A": [1, 2], "B": [3, 4]})
+        ds2 = DataStore({"B": [7, 8], "A": [5, 6]})
+        ds_result = ds_concat([ds1, ds2], ignore_index=True)
+
+        assert list(pd_result["A"]) == [1, 2, 5, 6]
+        assert list(pd_result["B"]) == [3, 4, 7, 8]
+        assert_datastore_equals_pandas(ds_result, pd_result)
+
+    def test_concat_different_column_sets(self):
+        """When column sets differ, pandas fills missing with NaN."""
+        pd1 = pd.DataFrame({"A": [1, 2], "B": [3, 4]})
+        pd2 = pd.DataFrame({"B": [7, 8], "C": [9, 10]})
+        pd_result = pd.concat([pd1, pd2], ignore_index=True)
+
+        ds1 = DataStore({"A": [1, 2], "B": [3, 4]})
+        ds2 = DataStore({"B": [7, 8], "C": [9, 10]})
+        ds_result = ds_concat([ds1, ds2], ignore_index=True)
+
+        assert_datastore_equals_pandas(ds_result, pd_result)
+
+    def test_union_same_columns_different_order(self):
+        """union() SQL path should reorder columns correctly."""
+        pd1 = pd.DataFrame({"X": [1, 2], "Y": [3, 4]})
+        pd2 = pd.DataFrame({"Y": [7, 8], "X": [5, 6]})
+        pd_result = pd.concat([pd1, pd2], ignore_index=True)
+
+        ds1 = DataStore({"X": [1, 2], "Y": [3, 4]})
+        ds2 = DataStore({"Y": [7, 8], "X": [5, 6]})
+        ds_result = ds1.union(ds2, all=True)
+
+        assert_datastore_equals_pandas(ds_result, pd_result, check_row_order=False)
+
+
+# ===========================================================================
+# 6. Merge then chained operations
+# ===========================================================================
+
+class TestMergeThenChain:
+    """Verify merge results work correctly with subsequent operations."""
+
+    def test_merge_then_filter(self, left_data, right_data):
+        pd_left = pd.DataFrame(left_data)
+        pd_right = pd.DataFrame(right_data)
+        pd_result = pd_left.merge(pd_right, on="user_id")
+        pd_result = pd_result[pd_result["score"] > 80]
+
+        ds_left = DataStore(left_data)
+        ds_right = DataStore(right_data)
+        ds_result = ds_left.merge(ds_right, on="user_id")
+        ds_result = ds_result[ds_result["score"] > 80]
+
+        assert_datastore_equals_pandas(ds_result, pd_result, check_row_order=False)
+
+    def test_merge_then_assign(self, left_data, right_data):
+        pd_left = pd.DataFrame(left_data)
+        pd_right = pd.DataFrame(right_data)
+        pd_result = pd_left.merge(pd_right, on="user_id")
+        pd_result = pd_result.assign(score_age=pd_result["score"] + pd_result["age"])
+
+        ds_left = DataStore(left_data)
+        ds_right = DataStore(right_data)
+        ds_result = ds_left.merge(ds_right, on="user_id")
+        ds_result = ds_result.assign(score_age=ds_result["score"] + ds_result["age"])
+
+        assert_datastore_equals_pandas(ds_result, pd_result, check_row_order=False)
+
+    def test_merge_then_groupby(self):
+        pd_left = pd.DataFrame({"key": [1, 1, 2, 2], "val": [10, 20, 30, 40]})
+        pd_right = pd.DataFrame({"key": [1, 2], "label": ["A", "B"]})
+        pd_merged = pd_left.merge(pd_right, on="key")
+        pd_result = pd_merged.groupby("label")["val"].sum()
+
+        ds_left = DataStore({"key": [1, 1, 2, 2], "val": [10, 20, 30, 40]})
+        ds_right = DataStore({"key": [1, 2], "label": ["A", "B"]})
+        ds_merged = ds_left.merge(ds_right, on="key")
+        ds_result = ds_merged.groupby("label")["val"].sum()
+
+        assert_datastore_equals_pandas(ds_result, pd_result, check_row_order=False)
+
+    def test_merge_overlapping_then_access_suffixed_column(self):
+        """After merge with suffixes, accessing _x/_y columns must work."""
+        pd_left = pd.DataFrame({"key": [1, 2], "val": [10, 20]})
+        pd_right = pd.DataFrame({"key": [1, 2], "val": [100, 200]})
+        pd_result = pd_left.merge(pd_right, on="key")
+
+        ds_left = DataStore({"key": [1, 2], "val": [10, 20]})
+        ds_right = DataStore({"key": [1, 2], "val": [100, 200]})
+        ds_result = ds_left.merge(ds_right, on="key")
+
+        pd_sum = pd_result["val_x"] + pd_result["val_y"]
+        ds_sum = ds_result["val_x"] + ds_result["val_y"]
+
+        pd.testing.assert_series_equal(
+            pd.Series(list(ds_sum), dtype=pd_sum.dtype),
+            pd_sum.reset_index(drop=True),
+            check_names=False,
+        )
+
+
+# ===========================================================================
+# 7. Merge with indicator parameter
+# ===========================================================================
+
+class TestMergeIndicator:
+    """indicator parameter should always fall back to pandas."""
+
+    def test_merge_with_indicator(self, left_data, right_data):
+        pd_left = pd.DataFrame(left_data)
+        pd_right = pd.DataFrame(right_data)
+        pd_result = pd_left.merge(pd_right, on="user_id", how="outer", indicator=True)
+
+        ds_left = DataStore(left_data)
+        ds_right = DataStore(right_data)
+        ds_result = ds_left.merge(ds_right, on="user_id", how="outer", indicator=True)
+
+        assert "_merge" in list(pd_result.columns)
+        assert_datastore_equals_pandas(ds_result, pd_result, check_row_order=False)
+
+
+# ===========================================================================
+# 8. Merge with multiple key columns
+# ===========================================================================
+
+class TestMergeMultipleKeys:
+
+    def test_merge_two_key_columns(self):
+        pd_left = pd.DataFrame({"k1": [1, 1, 2], "k2": ["a", "b", "a"], "v1": [10, 20, 30]})
+        pd_right = pd.DataFrame({"k1": [1, 2], "k2": ["a", "a"], "v2": [100, 200]})
+        pd_result = pd_left.merge(pd_right, on=["k1", "k2"])
+
+        ds_left = DataStore({"k1": [1, 1, 2], "k2": ["a", "b", "a"], "v1": [10, 20, 30]})
+        ds_right = DataStore({"k1": [1, 2], "k2": ["a", "a"], "v2": [100, 200]})
+        ds_result = ds_left.merge(ds_right, on=["k1", "k2"])
+
+        assert_datastore_equals_pandas(ds_result, pd_result, check_row_order=False)
+
+    def test_merge_two_keys_with_overlap(self):
+        """Two key columns + overlapping non-key 'val'."""
+        pd_left = pd.DataFrame({"k1": [1, 2], "k2": ["a", "b"], "val": [10, 20]})
+        pd_right = pd.DataFrame({"k1": [1, 2], "k2": ["a", "b"], "val": [100, 200]})
+        pd_result = pd_left.merge(pd_right, on=["k1", "k2"])
+
+        ds_left = DataStore({"k1": [1, 2], "k2": ["a", "b"], "val": [10, 20]})
+        ds_right = DataStore({"k1": [1, 2], "k2": ["a", "b"], "val": [100, 200]})
+        ds_result = ds_left.merge(ds_right, on=["k1", "k2"])
+
+        assert "val_x" in list(pd_result.columns)
+        assert "val_y" in list(pd_result.columns)
+        assert_datastore_equals_pandas(ds_result, pd_result, check_row_order=False)
+
+
+# ===========================================================================
+# 9. merge sort parameter (SQL JOIN path must honor sort=True)
+# ===========================================================================
+
+class TestMergeSortParam:
+    """merge(sort=True) must sort result by join keys, even when
+    the SQL JOIN path would otherwise be used."""
+
+    @pytest.fixture
+    def parquet_pair(self, tmp_dir):
+        """Create a pair of parquet-backed DataStores with unsorted keys."""
+        pd_left = pd.DataFrame({"key": [3, 1, 2, 1, 3], "val": [30, 10, 20, 11, 31]})
+        pd_right = pd.DataFrame({"key": [2, 3, 1], "info": ["b", "c", "a"]})
+
+        left_path = os.path.join(tmp_dir, "sort_left.parquet")
+        right_path = os.path.join(tmp_dir, "sort_right.parquet")
+        pd_left.to_parquet(left_path, index=False)
+        pd_right.to_parquet(right_path, index=False)
+
+        return (
+            DataStore.from_file(left_path),
+            DataStore.from_file(right_path),
+            pd_left,
+            pd_right,
+        )
+
+    def test_merge_sort_true_file_backed(self, parquet_pair):
+        ds_left, ds_right, pd_left, pd_right = parquet_pair
+        pd_result = pd_left.merge(pd_right, on="key", sort=True)
+        ds_result = ds_left.merge(ds_right, on="key", sort=True)
+        assert_datastore_equals_pandas(ds_result, pd_result)
+
+    def test_merge_sort_false_file_backed(self, parquet_pair):
+        ds_left, ds_right, pd_left, pd_right = parquet_pair
+        pd_result = pd_left.merge(pd_right, on="key", sort=False)
+        ds_result = ds_left.merge(ds_right, on="key", sort=False)
+        assert_datastore_equals_pandas(ds_result, pd_result, check_row_order=False)
+
+    def test_merge_sort_true_dict_backed(self):
+        pd_left = pd.DataFrame({"key": [3, 1, 2, 1, 3], "val": [30, 10, 20, 11, 31]})
+        pd_right = pd.DataFrame({"key": [2, 3, 1], "info": ["b", "c", "a"]})
+        pd_result = pd_left.merge(pd_right, on="key", sort=True)
+
+        ds_left = DataStore({"key": [3, 1, 2, 1, 3], "val": [30, 10, 20, 11, 31]})
+        ds_right = DataStore({"key": [2, 3, 1], "info": ["b", "c", "a"]})
+        ds_result = ds_left.merge(ds_right, on="key", sort=True)
+
+        assert list(pd_result["key"]) == [1, 1, 2, 3, 3]
+        assert_datastore_equals_pandas(ds_result, pd_result)
+
+    def test_merge_sort_true_left_join_file_backed(self, parquet_pair):
+        ds_left, ds_right, pd_left, pd_right = parquet_pair
+        pd_result = pd_left.merge(pd_right, on="key", how="left", sort=True)
+        ds_result = ds_left.merge(ds_right, on="key", how="left", sort=True)
+        assert_datastore_equals_pandas(ds_result, pd_result)
+
+
+# ===========================================================================
+# 10. merge validate parameter
+# ===========================================================================
+
+class TestMergeValidateParam:
+    """merge(validate=...) must raise MergeError for invalid cardinalities."""
+
+    @pytest.fixture
+    def parquet_one_to_many(self, tmp_dir):
+        pd_left = pd.DataFrame({"key": [1, 1, 2], "val": [10, 11, 20]})
+        pd_right = pd.DataFrame({"key": [1, 2], "info": ["a", "b"]})
+
+        left_path = os.path.join(tmp_dir, "val_left.parquet")
+        right_path = os.path.join(tmp_dir, "val_right.parquet")
+        pd_left.to_parquet(left_path, index=False)
+        pd_right.to_parquet(right_path, index=False)
+
+        return (
+            DataStore.from_file(left_path),
+            DataStore.from_file(right_path),
+            pd_left,
+            pd_right,
+        )
+
+    def test_validate_one_to_one_raises_on_duplicates(self, parquet_one_to_many):
+        """Left has duplicate key 1 → one_to_one should raise."""
+        ds_left, ds_right, pd_left, pd_right = parquet_one_to_many
+
+        with pytest.raises(pd.errors.MergeError):
+            pd_left.merge(pd_right, on="key", validate="one_to_one")
+
+        with pytest.raises(pd.errors.MergeError):
+            ds_left.merge(ds_right, on="key", validate="one_to_one")
+
+    def test_validate_one_to_many_raises(self, parquet_one_to_many):
+        """Left has duplicate key 1 → one_to_many requires unique left keys → raises."""
+        ds_left, ds_right, pd_left, pd_right = parquet_one_to_many
+
+        with pytest.raises(pd.errors.MergeError):
+            pd_left.merge(pd_right, on="key", validate="one_to_many")
+
+        with pytest.raises(pd.errors.MergeError):
+            ds_left.merge(ds_right, on="key", validate="one_to_many")
+
+    def test_validate_many_to_one_succeeds(self, parquet_one_to_many):
+        """Left has duplicate key, right is unique → many_to_one should succeed."""
+        ds_left, ds_right, pd_left, pd_right = parquet_one_to_many
+        pd_result = pd_left.merge(pd_right, on="key", validate="many_to_one")
+        ds_result = ds_left.merge(ds_right, on="key", validate="many_to_one")
+        assert_datastore_equals_pandas(ds_result, pd_result, check_row_order=False)
+
+    def test_validate_many_to_many_always_ok(self, parquet_one_to_many):
+        """many_to_many never raises."""
+        ds_left, ds_right, pd_left, pd_right = parquet_one_to_many
+        pd_result = pd_left.merge(pd_right, on="key", validate="many_to_many")
+        ds_result = ds_left.merge(ds_right, on="key", validate="many_to_many")
+        assert_datastore_equals_pandas(ds_result, pd_result, check_row_order=False)
+
+    def test_validate_with_dict_backed(self):
+        pd_left = pd.DataFrame({"key": [1, 1], "v": [10, 20]})
+        pd_right = pd.DataFrame({"key": [1], "w": [100]})
+
+        with pytest.raises(pd.errors.MergeError):
+            pd_left.merge(pd_right, on="key", validate="one_to_one")
+
+        ds_left = DataStore({"key": [1, 1], "v": [10, 20]})
+        ds_right = DataStore({"key": [1], "w": [100]})
+
+        with pytest.raises(pd.errors.MergeError):
+            ds_left.merge(ds_right, on="key", validate="one_to_one")
+
+
+# ===========================================================================
+# 11. SQL JOIN path vs pandas path consistency (file-backed)
+# ===========================================================================
+
+class TestSQLJoinPathConsistency:
+    """File-backed DataStores go through SQL JOIN path; verify results
+    match pandas exactly."""
+
+    @pytest.fixture
+    def file_stores(self, tmp_dir):
+        pd_users = pd.DataFrame({
+            "uid": [1, 2, 3, 4],
+            "name": ["Alice", "Bob", "Charlie", "Dave"],
+        })
+        pd_orders = pd.DataFrame({
+            "uid": [1, 2, 2, 5],
+            "product": ["Widget", "Gadget", "Gizmo", "Doohickey"],
+            "amount": [10.0, 20.0, 30.0, 40.0],
+        })
+        u_path = os.path.join(tmp_dir, "users.parquet")
+        o_path = os.path.join(tmp_dir, "orders.parquet")
+        pd_users.to_parquet(u_path, index=False)
+        pd_orders.to_parquet(o_path, index=False)
+
+        return (
+            DataStore.from_file(u_path),
+            DataStore.from_file(o_path),
+            pd_users,
+            pd_orders,
+        )
+
+    def test_inner_join_file_backed(self, file_stores):
+        ds_users, ds_orders, pd_users, pd_orders = file_stores
+        pd_result = pd_users.merge(pd_orders, on="uid")
+        ds_result = ds_users.merge(ds_orders, on="uid")
+        assert_datastore_equals_pandas(ds_result, pd_result, check_row_order=False)
+
+    def test_left_join_file_backed(self, file_stores):
+        ds_users, ds_orders, pd_users, pd_orders = file_stores
+        pd_result = pd_users.merge(pd_orders, on="uid", how="left")
+        ds_result = ds_users.merge(ds_orders, on="uid", how="left")
+        assert_datastore_equals_pandas(ds_result, pd_result, check_row_order=False)
+
+    def test_right_join_file_backed(self, file_stores):
+        ds_users, ds_orders, pd_users, pd_orders = file_stores
+        pd_result = pd_users.merge(pd_orders, on="uid", how="right")
+        ds_result = ds_users.merge(ds_orders, on="uid", how="right")
+        assert_datastore_equals_pandas(ds_result, pd_result, check_row_order=False)
+
+    def test_outer_join_file_backed(self, file_stores):
+        ds_users, ds_orders, pd_users, pd_orders = file_stores
+        pd_result = pd_users.merge(pd_orders, on="uid", how="outer")
+        ds_result = ds_users.merge(ds_orders, on="uid", how="outer")
+        assert_datastore_equals_pandas(ds_result, pd_result, check_row_order=False)
+
+    def test_file_backed_overlapping_columns_fallback(self, tmp_dir):
+        """File-backed DataStores with overlapping non-key columns
+        must fall back to pandas and produce correct suffixes."""
+        pd_left = pd.DataFrame({"key": [1, 2], "val": [10, 20]})
+        pd_right = pd.DataFrame({"key": [1, 2], "val": [100, 200]})
+
+        l_path = os.path.join(tmp_dir, "overlap_l.parquet")
+        r_path = os.path.join(tmp_dir, "overlap_r.parquet")
+        pd_left.to_parquet(l_path, index=False)
+        pd_right.to_parquet(r_path, index=False)
+
+        pd_result = pd_left.merge(pd_right, on="key")
+        ds_result = DataStore.from_file(l_path).merge(
+            DataStore.from_file(r_path), on="key"
+        )
+
+        assert "val_x" in list(pd_result.columns)
+        assert "val_y" in list(pd_result.columns)
+        assert_datastore_equals_pandas(ds_result, pd_result, check_row_order=False)
+
+
+# ===========================================================================
+# 12. Many-to-many merge
+# ===========================================================================
+
+class TestMergeManyToMany:
+
+    def test_many_to_many_inner(self):
+        pd_left = pd.DataFrame({"key": [1, 1, 2], "a": ["x", "y", "z"]})
+        pd_right = pd.DataFrame({"key": [1, 1, 2], "b": ["p", "q", "r"]})
+        pd_result = pd_left.merge(pd_right, on="key")
+
+        ds_left = DataStore({"key": [1, 1, 2], "a": ["x", "y", "z"]})
+        ds_right = DataStore({"key": [1, 1, 2], "b": ["p", "q", "r"]})
+        ds_result = ds_left.merge(ds_right, on="key")
+
+        assert len(pd_result) == 5  # 2*2 + 1*1
+        assert_datastore_equals_pandas(ds_result, pd_result, check_row_order=False)
+
+    def test_many_to_many_file_backed(self, tmp_dir):
+        pd_left = pd.DataFrame({"key": [1, 1, 2], "a": ["x", "y", "z"]})
+        pd_right = pd.DataFrame({"key": [1, 1, 2], "b": ["p", "q", "r"]})
+
+        l_path = os.path.join(tmp_dir, "m2m_l.parquet")
+        r_path = os.path.join(tmp_dir, "m2m_r.parquet")
+        pd_left.to_parquet(l_path, index=False)
+        pd_right.to_parquet(r_path, index=False)
+
+        pd_result = pd_left.merge(pd_right, on="key")
+        ds_result = DataStore.from_file(l_path).merge(
+            DataStore.from_file(r_path), on="key"
+        )
+
+        assert len(pd_result) == 5
+        assert_datastore_equals_pandas(ds_result, pd_result, check_row_order=False)
+
+
+# ===========================================================================
+# 13. Empty merge results
+# ===========================================================================
+
+class TestMergeEmpty:
+
+    def test_merge_no_matching_keys(self):
+        pd_left = pd.DataFrame({"key": [1, 2], "v": [10, 20]})
+        pd_right = pd.DataFrame({"key": [3, 4], "w": [30, 40]})
+        pd_result = pd_left.merge(pd_right, on="key")
+
+        ds_left = DataStore({"key": [1, 2], "v": [10, 20]})
+        ds_right = DataStore({"key": [3, 4], "w": [30, 40]})
+        ds_result = ds_left.merge(ds_right, on="key")
+
+        assert len(pd_result) == 0
+        assert len(ds_result) == 0
+
+    def test_merge_no_matching_keys_file_backed(self, tmp_dir):
+        pd_left = pd.DataFrame({"key": [1, 2], "v": [10, 20]})
+        pd_right = pd.DataFrame({"key": [3, 4], "w": [30, 40]})
+
+        l_path = os.path.join(tmp_dir, "empty_l.parquet")
+        r_path = os.path.join(tmp_dir, "empty_r.parquet")
+        pd_left.to_parquet(l_path, index=False)
+        pd_right.to_parquet(r_path, index=False)
+
+        ds_result = DataStore.from_file(l_path).merge(
+            DataStore.from_file(r_path), on="key"
+        )
+
+        assert len(ds_result) == 0


### PR DESCRIPTION
Resolved https://github.com/chdb-io/chdb/issues/552

### Changelog category (leave one):
- Improvement

### Changelog entry
Optimize DataStore memory usage by pushing more operations to SQL and releasing intermediate data earlier

### Summary

This PR reduces DataStore peak memory consumption through five strategies:

1. **SQL JOIN pushdown for `merge()`** — avoids materializing both sides into Python DataFrames
2. **SQL UNION ALL pushdown for `concat()` / `union()`** — avoids loading all concatenation operands into memory simultaneously
3. **Column pruning in expression evaluation** — only fetches columns actually referenced instead of `SELECT *`
4. **Single-SQL GROUP BY aggregation path** — pushes groupby+agg into one SQL query for SQL-backed sources
5. **Execution result checkpointing** — releases old source DataFrames after execution so GC can reclaim memory

Additionally adds 43 merge/join pandas-compatibility tests and fixes several edge cases in the groupby SQL path.

### Detailed Changes

#### 1. SQL JOIN pushdown for `merge()` (`pandas_compat.py`)

**Before:** `ds1.merge(ds2, on='key')` always materialized both DataStores into Python DataFrames, then called `pd.merge()`.

**After:** When both sides are SQL-backed DataStores and no pandas-only feature (index join, suffixes, sort, validate) is needed, `merge()` delegates to `DataStore.join()` which generates a SQL JOIN — neither side needs to be loaded into Python memory.

```python
# Scenario: two Parquet files, 10M rows each, joining on user_id
ds_users = DataStore('users.parquet')      # 10M rows, 500MB
ds_orders = DataStore('orders.parquet')    # 10M rows, 800MB

# Before: peak ~1.3GB (both loaded into pandas) 
# After:  peak ~0 (SQL JOIN pushdown, only result transferred)
result = ds_users.merge(ds_orders, on='user_id', how='inner')
```

Falls back to pandas merge when overlapping non-key columns require suffixes (`_x`/`_y`), or when `sort=True`, `validate`, `left_index/right_index`, or `indicator` is set.

#### 2. SQL UNION ALL pushdown for `concat()` / `union()` (`core.py`, `pandas_api.py`, `pandas_compat.py`)

**Before:** `concat([ds1, ds2, ds3])` materialized all DataStores into DataFrames then called `pd.concat()`.

**After:** When all inputs are SQL-backed DataStores with `ignore_index=True` and `join='outer'`, generates a `(SELECT ...) UNION ALL (SELECT ...)` query — data stays in the SQL engine.

```python
# Scenario: concatenate 12 monthly Parquet files
monthly_files = [DataStore(f'sales_2025_{m:02d}.parquet') for m in range(1, 13)]

# Before: peak = sum of all 12 files in memory simultaneously
# After:  single SQL UNION ALL query, only final result transferred
result = concat(monthly_files, ignore_index=True)
```

A new `SubqueryTableFunction` class wraps composite SQL expressions (UNION, subqueries) as table sources. Each SELECT is parenthesized to safely handle `ORDER BY`/`LIMIT`/`SETTINGS` clauses.

#### 3. Column pruning in expression evaluation (`column_expr.py`)

**Before:** Any expression like `ds['price'] * ds['quantity']` called `ds._execute()` which does `SELECT *`, loading all columns.

**After:** Expression evaluation inspects the AST to find referenced `Field` nodes, then generates `SELECT price, quantity FROM ...` — only the needed columns are transferred.

```python
# Scenario: 100-column wide table, only need 2 columns for computation
ds = DataStore('wide_table.parquet')  # 100 columns, 5M rows

# Before: SELECT * → loads all 100 columns (~4GB)
# After:  SELECT price, quantity → loads 2 columns (~80MB)
result = ds['price'] * ds['quantity']
```

Same optimization applied to `value_counts()`:
```python
# Before: SELECT * then count in pandas
# After:  SELECT category_col then count
ds['category'].value_counts()
```

#### 4. Single-SQL GROUP BY path (`column_expr.py`)

**Before:** `ds.groupby('dept')['salary'].mean()` first executed `ds._execute()` (full table download), then performed groupby+agg via chDB on the local DataFrame.

**After:** For SQL-backed sources, generates a single `SELECT dept, AVG(salary) FROM ... GROUP BY dept` query — no intermediate full-table materialization.

```python
# Scenario: aggregate a large remote table
ds = DataStore('employee_records.parquet')  # 5M rows, 50 columns

# Before: downloads entire 5M×50 table, then groupby locally
# After:  single SQL query, returns only ~100 department-level rows
result = ds.groupby('department')['salary'].mean()
```

Handles edge cases:
- Skips when `execution_engine='pandas'` to avoid floating-point precision differences
- Skips when WHERE clause references the aggregation column (avoids chDB `ILLEGAL_AGGREGATION`)
- Filters NULL/empty groups after SQL GROUP BY to match pandas `dropna=True` behavior

#### 5. SQL `fillna()` optimization (`column_expr.py`)

**Before:** `ds['col'].fillna(0)` always added a lazy pandas operation, requiring full materialization.

**After:** For numeric scalar fills on SQL-backed sources, uses SQL `ifNull(col, 0)` which stays in the expression tree — no materialization needed.

```python
ds = DataStore('data.parquet')

# Before: materialize full column, then fillna in pandas
# After:  ifNull() expression pushed into SQL, zero materialization
result = ds['revenue'].fillna(0).sum()
```

#### 6. Execution result checkpointing (`core.py`)

**Before:** After executing a mixed SQL+pandas pipeline, the original source DataFrame was retained in memory alongside the result.

**After:** After successful execution, `_source_df` is updated to point to the result DataFrame, allowing the old source to be garbage collected.

```python
ds = DataStore.from_dataframe(large_df)  # large_df held in _source_df
ds = ds[ds['status'] == 'active']        # filter added as lazy op
result = repr(ds)                         # triggers execution

# Before: large_df still in memory (referenced by _source_df)
# After:  _source_df now points to the filtered result, large_df is GC-eligible
```

#### 7. `.columns` metadata optimization (`core.py`)

**Before:** Accessing `ds.columns` after `assign()` or `join()` triggered full execution.

**After:** Derives column names from schema + computed columns metadata, or probes with `LIMIT 0` for JOINs — avoids materializing full results.

```python
ds = DataStore('large.parquet')
ds = ds.assign(profit=ds['revenue'] - ds['cost'])

# Before: ds.columns → full execution to discover column names
# After:  ds.columns → derived from schema metadata, zero data transfer
```

#### 8. Test coverage (`test_merge_join_compat.py`)

43 new pandas-compatibility tests covering:
- Overlapping non-key columns (suffixes handling, fallback to pandas)
- `left_on` / `right_on` with different column names
- Different column orders between left and right
- `sort` parameter in merge (fallback detection)
- All join types: inner, left, right, outer
- `from_df()` DataStore merge (in-memory path)
- File-backed DataStore merge (SQL JOIN path)
- SQL UNION ALL column ordering in `concat()`/`union()`

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

> Information about CI checks: https://clickhouse.com/docs/en/development/continuous-integration/

<details>
    <summary>CI Settings</summary>

**NOTE:** If your merge the PR with modified CI you **MUST KNOW** what you are doing
**NOTE:** Checked options will be applied if set before CI RunConfig/PrepareRunConfig step

#### Run these jobs only (required builds will be added automatically):
- [ ] <!---ci_include_integration--> Integration Tests
- [ ] <!---ci_include_stateless--> Stateless tests
- [ ] <!---ci_include_stateful--> Stateful tests
- [ ] <!---ci_include_unit--> Unit tests
- [ ] <!---ci_include_performance--> Performance tests
- [ ] <!---ci_include_aarch64--> All with aarch64
- [ ] <!---ci_include_asan--> All with ASAN
- [ ] <!---ci_include_tsan--> All with TSAN
- [ ] <!---ci_include_analyzer--> All with Analyzer
- [ ] <!---ci_include_azure --> All with Azure
- [ ] <!---ci_include_KEYWORD--> Add your option here

#### Deny these jobs:
- [ ] <!---ci_exclude_fast--> Fast test
- [ ] <!---ci_exclude_integration--> Integration Tests
- [ ] <!---ci_exclude_stateless--> Stateless tests
- [ ] <!---ci_exclude_stateful--> Stateful tests
- [ ] <!---ci_exclude_performance--> Performance tests
- [ ] <!---ci_exclude_asan--> All with ASAN
- [ ] <!---ci_exclude_tsan--> All with TSAN
- [ ] <!---ci_exclude_msan--> All with MSAN
- [ ] <!---ci_exclude_ubsan--> All with UBSAN
- [ ] <!---ci_exclude_coverage--> All with Coverage
- [ ] <!---ci_exclude_aarch64--> All with Aarch64

#### Extra options:
- [ ] <!---do_not_test--> do not test (only style check)
- [ ] <!---no_merge_commit--> disable merge-commit (no merge from master before tests)
- [ ] <!---no_ci_cache--> disable CI cache (job reuse)

#### Only specified batches in multi-batch jobs:
- [ ] <!---batch_0--> 1
- [ ] <!---batch_1--> 2
- [ ] <!---batch_2--> 3
- [ ] <!---batch_3--> 4

</details>