### PR TITLE
ci: skip flaky groupby_agg_sum timing test on macOS x86_64

### DIFF
--- a/datastore/tests/test_remote_large_table_stress.py
+++ b/datastore/tests/test_remote_large_table_stress.py
@@ -14,6 +14,7 @@ To use an external ClickHouse server:
 """
 
 import os
+import platform
 import subprocess
 import time
 import io
@@ -254,6 +255,10 @@ class TestLargeTableFilterVariants:
         assert all(df["category"] == "alpha")
         assert elapsed < 3.0, f"multi-filter+head took {elapsed:.2f}s"
 
+    @pytest.mark.skipif(
+        platform.system() == "Darwin" and platform.machine() == "x86_64",
+        reason="Timing too tight for macOS x86_64 CI runners",
+    )
     def test_groupby_agg_sum(self, ds_large):
         """groupby + sum should push down to SQL."""
         start = time.monotonic()


### PR DESCRIPTION
Skip `test_groupby_agg_sum` on macOS x86_64 CI runners where the 5s timing threshold is too tight (failed at 5.017s).

https://github.com/chdb-io/chdb/actions/runs/23828810372/job/69457660741