### PR TITLE
Add DataFrame writeback to remote ClickHouse server

### DIFF
--- a/.github/ci/clickhouse-pair.yml
+++ b/.github/ci/clickhouse-pair.yml
@@ -1,0 +1,73 @@
+# Two independent ClickHouse instances used by the writeback integration tests.
+#
+# This file is the single source of truth for the test environment; CI and
+# local developers share it. Bring the pair up with:
+#
+#   docker compose -f .github/ci/clickhouse-pair.yml up -d --wait
+#
+# Tear down with:
+#
+#   docker compose -f .github/ci/clickhouse-pair.yml down -v
+#
+# Once running, point datastore/tests/test_writeback.py at it via:
+#
+#   CHDB_TEST_HOST=ch1:9000              CHDB_TEST_USER=remote_user
+#   CHDB_TEST_PASSWORD=test123           CHDB_TEST_DATABASE=chdb_test
+#   CHDB_TEST_TARGET_HOST=localhost:9001 CHDB_TEST_TARGET_USER=remote_user_2
+#   CHDB_TEST_TARGET_PASSWORD=test456    CHDB_TEST_TARGET_DATABASE=chdb_test_2
+#
+# Both nodes are wired to the same docker network, so a query running on `ch1`
+# can reach `ch2` via the hostname `ch2:9000` (and vice versa). This matches
+# the cross-server scenarios the test suite exercises.
+#
+# Why CHDB_TEST_HOST=ch1:9000 (not localhost:9000): cross-server writeback runs
+# `INSERT ... SELECT ... FROM remote(<source-host>, ...)` *on the target server*
+# (ch2). `localhost:9000` would resolve to ch2 itself there, so the source host
+# must be a name that points to ch1 from both ch2 (docker DNS resolves `ch1`)
+# and from your shell, where the test process + local chDB run. Add a hosts
+# alias so your shell resolves it to the published port too:
+#
+#   echo "127.0.0.1 ch1" | sudo tee -a /etc/hosts
+
+name: chdb-ds-writeback
+
+services:
+  ch1:
+    image: clickhouse/clickhouse-server:24.8
+    container_name: chdb_ds_ch1
+    # Map ch1's native port to the host so test code (running outside the
+    # docker network) can reach it as localhost:9000.
+    ports:
+      - "9000:9000"
+      - "8123:8123"
+    ulimits:
+      nofile:
+        soft: 262144
+        hard: 262144
+    volumes:
+      - ./init-ch1.sql:/docker-entrypoint-initdb.d/init.sql:ro
+    healthcheck:
+      test: ["CMD-SHELL", "wget -qO- http://localhost:8123/ping || exit 1"]
+      interval: 3s
+      timeout: 3s
+      retries: 30
+      start_period: 5s
+
+  ch2:
+    image: clickhouse/clickhouse-server:24.8
+    container_name: chdb_ds_ch2
+    ports:
+      - "9001:9000"
+      - "8124:8123"
+    ulimits:
+      nofile:
+        soft: 262144
+        hard: 262144
+    volumes:
+      - ./init-ch2.sql:/docker-entrypoint-initdb.d/init.sql:ro
+    healthcheck:
+      test: ["CMD-SHELL", "wget -qO- http://localhost:8123/ping || exit 1"]
+      interval: 3s
+      timeout: 3s
+      retries: 30
+      start_period: 5s

--- a/.github/ci/init-ch1.sql
+++ b/.github/ci/init-ch1.sql
@@ -1,0 +1,18 @@
+-- Source ClickHouse instance — referenced as `localhost:9000` from tests and
+-- as `ch1:9000` from inside the docker network.
+--
+-- Files in /docker-entrypoint-initdb.d/ are executed by the official image
+-- exactly once on first container startup, after the server is up. If you
+-- need to re-run them, recreate the volume (`docker compose down -v`).
+
+CREATE DATABASE IF NOT EXISTS chdb_test;
+
+CREATE USER IF NOT EXISTS remote_user
+    IDENTIFIED WITH plaintext_password BY 'test123'
+    HOST ANY;
+
+GRANT ALL ON chdb_test.* TO remote_user;
+
+-- The library probes existence via `SELECT count() FROM remote(..., 'system',
+-- 'tables', ...)`, so the test user must be able to read system metadata.
+GRANT SELECT ON system.* TO remote_user;

--- a/.github/ci/init-ch2.sql
+++ b/.github/ci/init-ch2.sql
@@ -1,0 +1,23 @@
+-- Target ClickHouse instance — referenced as `localhost:9001` from tests and
+-- as `ch2:9000` from inside the docker network.
+--
+-- Distinct credentials from ch1 on purpose: a misrouted connection (e.g. a
+-- code path that accidentally sends source creds to the target) gets
+-- rejected immediately rather than silently passing.
+
+CREATE DATABASE IF NOT EXISTS chdb_test_2;
+
+CREATE USER IF NOT EXISTS remote_user_2
+    IDENTIFIED WITH plaintext_password BY 'test456'
+    HOST ANY;
+
+GRANT ALL ON chdb_test_2.* TO remote_user_2;
+GRANT SELECT ON system.* TO remote_user_2;
+
+-- Cross-server writeback runs `INSERT INTO <target> SELECT ... FROM
+-- remote('ch1:9000', ...)` *on this (target) server*, so remote_user_2 must
+-- hold the global privileges the remote() table function requires. These are
+-- not covered by the database-scoped `GRANT ALL ON chdb_test_2.*` above:
+--   * REMOTE                 — permission to use remote()/remoteSecure()
+--   * CREATE TEMPORARY TABLE — remote() materializes its result set into one
+GRANT REMOTE, CREATE TEMPORARY TABLE ON *.* TO remote_user_2;

--- a/.github/workflows/external_clickhouse_integration.yaml
+++ b/.github/workflows/external_clickhouse_integration.yaml
@@ -1,0 +1,208 @@
+name: External ClickHouse Integration
+
+# Integration tests against a pair of real ClickHouse servers — currently
+# exercises the writeback APIs (to_clickhouse / create_view /
+# create_materialized_view / save) in datastore/tests/test_writeback.py.
+#
+# Only runs on Linux self-hosted runners (x86_64 + arm64). The macOS /
+# Windows wheel-build workflows do NOT run this suite — test_writeback.py's
+# autouse fixture pytest.skip()s when CHDB_TEST_* env vars are unset, so
+# those jobs see all writeback cases as SKIPPED at zero cost.
+#
+# The two ClickHouse servers are launched via docker compose
+# (.github/ci/clickhouse-pair.yml), which is also the file local devs use
+# to reproduce the CI environment.
+
+on:
+  workflow_dispatch:
+  push:
+    branches:
+      - main
+    paths-ignore:
+      - '**/*.md'
+  pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
+    branches:
+      - main
+    paths-ignore:
+      - '**/*.md'
+  # Intentionally NOT triggered on `release: types: [created]` — at release
+  # time the wheel-build workflows take over (build + upload to PyPI). The
+  # writeback / external-ClickHouse integration was already validated at PR
+  # time, and re-running it would only burn self-hosted runner minutes
+  # without adding signal.
+
+jobs:
+  integration:
+    name: External ClickHouse (${{ matrix.arch.name }})
+    if: ${{ !github.event.pull_request.draft }}
+    timeout-minutes: 60
+
+    strategy:
+      fail-fast: false
+      matrix:
+        arch:
+          - name: linux-x86_64
+            runner: [self-hosted, linux, x64, ubuntu-latest]
+          - name: linux-arm64
+            runner: [self-hosted, linux, arm64, ubuntu-latest]
+
+    runs-on: ${{ matrix.arch.runner }}
+
+    # Compose project name + container_name + host port bindings are fixed
+    # (9000/9001/8123/8124, chdb_ds_ch1/ch2). On a self-hosted runner that
+    # picks up multiple PRs in parallel those would collide, so serialize
+    # integration runs per arch. cancel-in-progress=false keeps an in-flight
+    # run intact when a newer push lands — premature kills leave dangling
+    # docker containers.
+    concurrency:
+      group: external-clickhouse-${{ matrix.arch.name }}
+      cancel-in-progress: false
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      # Probe runner for required tooling up front so failures surface
+      # with a clear "this runner is not provisioned correctly" message
+      # instead of a confusing `docker: command not found` deep into the run.
+      - name: Verify runner has docker + compose
+        run: |
+          set -e
+          docker version
+          docker compose version
+          docker info | head -20
+
+      # The wheel-build CI uses pyenv on these same self-hosted runners, so
+      # we reuse the same toolchain. setup-python@v5 may not have 3.14
+      # provisioned on every self-hosted image, but pyenv we know works.
+      - name: Setup Python 3.14 via pyenv
+        run: |
+          set -e
+          if [ ! -d "$HOME/.pyenv" ]; then
+            curl https://pyenv.run | bash
+          fi
+          export PATH="$HOME/.pyenv/bin:$PATH"
+          eval "$(pyenv init -)"
+
+          # A *working* 3.14 must import the C extensions the wheel build /
+          # pytest need. A prior from-source build that lacked the headers
+          # leaves a broken 3.14.x dir behind (_ssl/_bz2/_ctypes/... missing),
+          # so don't trust the version's mere presence — probe it.
+          probe='import ssl, bz2, ctypes, curses, lzma, sqlite3'
+          WORKING=""
+          for v in $(pyenv versions --bare 2>/dev/null | grep '^3\.14\.' || true); do
+            if "$HOME/.pyenv/versions/$v/bin/python" -c "$probe" 2>/dev/null; then
+              WORKING="$v"; break
+            fi
+            echo "Ignoring broken pyenv Python $v (missing C extensions)"
+          done
+
+          if [ -z "$WORKING" ]; then
+            echo "Installing Python 3.14 via pyenv..."
+            # pyenv compiles CPython from source, so its C-extension build deps
+            # must be on the runner or the build fails / yields a crippled
+            # interpreter. Best-effort: a runner that already ships the headers,
+            # or where sudo/apt isn't available, just skips this and proceeds.
+            if command -v apt-get >/dev/null 2>&1; then
+              sudo -n apt-get update -qq || true
+              sudo -n apt-get install -y -qq \
+                build-essential libssl-dev zlib1g-dev libbz2-dev \
+                libreadline-dev libsqlite3-dev libncursesw5-dev xz-utils \
+                tk-dev libxml2-dev libxmlsec1-dev libffi-dev liblzma-dev || true
+            fi
+            # -f overwrites any broken partial build of the same version.
+            pyenv install -f 3.14:latest
+            WORKING=$(pyenv versions --bare | grep '^3\.14\.' | tail -1)
+          fi
+          pyenv global "$WORKING"
+          python --version
+          python -c "$probe"
+          if ! python -m pip --version 2>/dev/null; then
+            curl -sS https://bootstrap.pypa.io/get-pip.py -o /tmp/get-pip.py
+            python /tmp/get-pip.py || python -m ensurepip --upgrade
+          fi
+          python -m pip install --upgrade pip
+
+      # Build the chdb wheel from THIS PR's source so the datastore
+      # changes (which live in the wheel) are what gets tested. Without
+      # this step `pip install chdb` from PyPI would pull the previously
+      # released version and the PR's writeback code would be invisible.
+      # `make wheel` only repackages Python sources — the heavy C++ engine
+      # comes from the chdb-core dependency (PyPI), no compilation here.
+      - name: Build wheel from PR source
+        run: |
+          export PATH="$HOME/.pyenv/bin:$PATH"
+          eval "$(pyenv init -)"
+          python -m pip install setuptools wheel tox
+          make wheel
+          ls -lh dist/
+
+      - name: Install built wheel
+        run: |
+          export PATH="$HOME/.pyenv/bin:$PATH"
+          eval "$(pyenv init -)"
+          python -m pip install dist/*.whl --force-reinstall
+          python -m pip install pytest pandas pyarrow
+          python -c "import chdb; print('chdb', chdb.__version__ if hasattr(chdb, '__version__') else 'unknown')"
+
+      # Defensive cleanup: a previous run that was force-killed (runner
+      # restart, OOM, manual cancel) can leave the pair behind, which would
+      # then make `up` fail with "container name already in use".
+      - name: Clean up any leftover ClickHouse pair
+        run: docker compose -f .github/ci/clickhouse-pair.yml down -v --remove-orphans || true
+
+      - name: Start ClickHouse pair
+        run: |
+          docker compose -f .github/ci/clickhouse-pair.yml up -d --wait
+          docker compose -f .github/ci/clickhouse-pair.yml ps
+
+      - name: Print ClickHouse versions
+        run: |
+          docker exec chdb_ds_ch1 clickhouse-client -q "SELECT version()"
+          docker exec chdb_ds_ch2 clickhouse-client -q "SELECT version()"
+
+      # Cross-server writeback makes the *target* (ch2) pull from the source via
+      # `remote(<source-host>, ...)`. That host string is resolved in two
+      # network contexts and must reach ch1 in both:
+      #   - inside the ch2 container, docker DNS already resolves `ch1`;
+      #   - on this runner, where the test process + local chDB do schema
+      #     inference / existence checks, `ch1` is not a docker name — so map it
+      #     to localhost, where ch1's native port is published (9000).
+      # `localhost:9000` can't be the source host: inside ch2 that is ch2
+      # itself (which only has chdb_test_2 → "Database chdb_test does not
+      # exist"). The target host stays localhost:9001 (only the runner reaches
+      # it, via the published port).
+      - name: Map ch1 -> localhost so the runner resolves the source host
+        run: |
+          # `sudo -n` (non-interactive) so this fails fast on a runner that
+          # would prompt for a password instead of hanging the job.
+          grep -qw ch1 /etc/hosts || echo "127.0.0.1 ch1" | sudo -n tee -a /etc/hosts
+
+      - name: Run external ClickHouse integration tests
+        env:
+          CHDB_TEST_HOST: ch1:9000
+          CHDB_TEST_USER: remote_user
+          CHDB_TEST_PASSWORD: test123
+          CHDB_TEST_DATABASE: chdb_test
+          CHDB_TEST_TARGET_HOST: localhost:9001
+          CHDB_TEST_TARGET_USER: remote_user_2
+          CHDB_TEST_TARGET_PASSWORD: test456
+          CHDB_TEST_TARGET_DATABASE: chdb_test_2
+        run: |
+          export PATH="$HOME/.pyenv/bin:$PATH"
+          eval "$(pyenv init -)"
+          python -m pytest datastore/tests/test_writeback.py -v --tb=short
+
+      - name: Dump ClickHouse logs on failure
+        if: failure()
+        run: |
+          echo "===== ch1 logs ====="
+          docker logs chdb_ds_ch1 || true
+          echo "===== ch2 logs ====="
+          docker logs chdb_ds_ch2 || true
+
+      - name: Stop ClickHouse pair
+        if: always()
+        run: docker compose -f .github/ci/clickhouse-pair.yml down -v --remove-orphans

--- a/datastore/adapters.py
+++ b/datastore/adapters.py
@@ -106,10 +106,19 @@ class SourceAdapter(ABC):
         pass
     
     def _escape_sql_string(self, value: str) -> str:
-        """Escape single quotes in SQL string values."""
+        """Escape a value for embedding inside a ClickHouse single-quoted
+        string literal.
+
+        Every adapter's SQL — ``remote()``, ``mysql()``, ``postgresql()``,
+        ``mongodb()`` table functions — is executed by chDB's ClickHouse
+        engine, where both the single quote AND the backslash are special
+        inside ``'...'``. Escape backslashes first, then double single quotes,
+        so a host / user / password / database / table containing either can't
+        alter the literal's parsing or inject SQL.
+        """
         if value is None:
             return ''
-        return value.replace("'", "''")
+        return value.replace("\\", "\\\\").replace("'", "''")
 
 
 class ClickHouseAdapter(SourceAdapter):
@@ -127,7 +136,7 @@ class ClickHouseAdapter(SourceAdapter):
     
     def get_table_function_name(self) -> str:
         return 'remoteSecure' if self.secure else 'remote'
-    
+
     def list_databases_sql(self) -> str:
         func = self.get_table_function_name()
         host = self._escape_sql_string(self.host)

--- a/datastore/core.py
+++ b/datastore/core.py
@@ -4,6 +4,7 @@ Core DataStore class - main entry point for data operations
 
 import math
 import time
+from contextlib import contextmanager
 from datetime import datetime, date
 import pandas as pd
 import numpy as np
@@ -61,6 +62,11 @@ __all__ = ["DataStore"]
 
 # Sentinel value to distinguish "no argument passed" from "None passed explicitly"
 _MISSING = object()
+
+# Source types that map to a ClickHouse connection (see ADAPTER_MAP in
+# adapters.py, where 'remote'/'remotesecure' both resolve to ClickHouseAdapter).
+# Compare against source_type.lower() since it is stored as given.
+_CLICKHOUSE_SOURCE_TYPES = frozenset({"clickhouse", "remote", "remotesecure"})
 
 
 class DataStore(PandasCompatMixin):
@@ -447,7 +453,7 @@ class DataStore(PandasCompatMixin):
             "postgresql",
             "postgres",
         ]
-        clickhouse_sources = {"clickhouse", "remote", "remotesecure"}
+        clickhouse_sources = _CLICKHOUSE_SOURCE_TYPES
         if source and source.lower() in remote_db_sources:
             # Merge port into host if provided separately
             host_val = kwargs.get("host", "")
@@ -4707,6 +4713,1204 @@ class DataStore(PandasCompatMixin):
         """
         self._delete_flag = True
 
+    # ========== Writeback Methods ==========
+
+    def _run_chdb_query(self, sql: str, output_format: str = "DataFrame", df=None):
+        """
+        Run a one-shot chdb query, reusing the persistent chdb Connection if
+        this DataStore has already established one (avoids the connect/close
+        overhead chdb.query() incurs on every call).
+
+        Falls back to chdb.query() when no Connection exists, to avoid
+        triggering Connection.connect() (which would freeze global
+        chdb_settings) just for a single remote DDL/metadata query.
+
+        Returns the same object types as chdb.query() — for DataFrame format
+        a pandas DataFrame, otherwise a chdb result object.
+
+        Args:
+            df: DataFrame referenced by a ``Python(df)`` table function in
+                ``sql``. chDB resolves ``Python(df)`` by scanning the calling
+                stack for a local named ``df``; accepting it here binds it in
+                the very frame that calls ``query()`` so resolution is explicit
+                and robust, rather than relying on ``df`` living several frames
+                up the call chain (mirrors connection.py ``_execute_df_query``).
+                Leave ``None`` when ``sql`` doesn't reference ``Python(df)``.
+        """
+        # `df` is deliberately a local of this frame: chDB's Python(df) table
+        # function looks it up here, where query() is actually invoked.
+        conn_obj = getattr(self._connection, "_conn", None) if self._connection else None
+        if conn_obj is not None:
+            return conn_obj.query(sql, output_format)
+        import chdb
+
+        return chdb.query(sql, output_format)
+
+    def _execute_remote_ddl(self, sql: str) -> str:
+        """
+        Execute DDL/DML on the remote ClickHouse server via remote(query=...).
+
+        Uses chdb's remote() table function with the query= parameter to send
+        arbitrary SQL (including DDL) over the native TCP protocol.
+
+        Args:
+            sql: SQL statement to execute on the remote server
+
+        Returns:
+            Execution status from the server
+
+        Raises:
+            ExecutionError: If the DDL execution fails
+        """
+        self._require_connection_params()
+
+        # Take host/user/password from the adapter (not raw _remote_params) so
+        # ClickHouse-Cloud / port / secure normalization is applied consistently
+        # with the rest of this file (e.g. _check_remote_table_exists). The
+        # adapter's ClickHouse escaper escapes each interpolated value for safe
+        # embedding inside a single-quoted literal (doubles ' and escapes \) —
+        # the surrounding quotes are added below — so neither a quote nor a
+        # backslash, in a connection param or in the embedded query, can break
+        # out of its literal or inject SQL.
+        adapter = self._get_adapter()
+        esc = adapter._escape_sql_string
+        func = adapter.get_table_function_name()
+        host = esc(adapter.host)
+        user = esc(adapter.user)
+        password = esc(adapter.password)
+        escaped_sql = esc(sql)
+
+        remote_sql = (
+            f"SELECT * FROM {func}('{host}', "
+            f"query = '{escaped_sql}', "
+            f"'{user}', '{password}')"
+        )
+
+        import chdb
+
+        try:
+            result = self._run_chdb_query(remote_sql, "TabSeparated")
+            if hasattr(result, "has_error") and result.has_error():
+                raise ExecutionError(
+                    f"Remote DDL execution failed:\n{result.error_message()}\nSQL: {sql}"
+                )
+            return result.bytes().decode("utf-8") if result else ""
+        except (RuntimeError, chdb.ChdbError) as e:
+            # Normalize both the module-level chdb.query() path (raises
+            # RuntimeError) and the persistent-connection path (raises
+            # chdb.ChdbError, which is NOT a RuntimeError subclass) into a
+            # consistent ExecutionError so callers / tests get one error type.
+            raise ExecutionError(
+                f"Remote DDL execution failed:\n{e}\nSQL: {sql}"
+            ) from e
+
+    def _get_remote_view_sql(self) -> str:
+        """
+        Generate SELECT SQL suitable for execution ON the remote server.
+
+        Replaces remote()/remoteSecure() table function calls with direct
+        database.table references for the primary table and all JOINed tables,
+        so the SQL can be used in VIEW/MV definitions or
+        CREATE TABLE ... AS SELECT on the remote server.
+
+        Returns:
+            SQL string with direct table references
+        """
+        q = self.quote_char
+        # Pick the SELECT form that reproduces _execute() for this pipeline
+        # (execution_format for lazy-op ordering / projections / LazyGroupByAgg,
+        # flat SQL for LazySQLQuery agg) — see _canonical_writeback_sql.
+        sql = self._canonical_writeback_sql()
+
+        def _fold(sql: str, tf, alias: str) -> str:
+            tf_sql = tf.to_sql(quote_char=q)
+            database = tf.params.get("database", "default")
+            table = tf.params.get("table")
+            direct_ref = (
+                f"{format_identifier(database, q)}.{format_identifier(table, q)}"
+            )
+            # Aliased form (flat SQL, and execution SQL when joins force an
+            # alias): "remote(...) AS alias" → "db.tbl" (alias redundant once
+            # folded to a real table reference).
+            sql = sql.replace(
+                f"{tf_sql} AS {format_identifier(alias, q)}", direct_ref
+            )
+            # Bare form: execution SQL renders the table function without an
+            # alias when there are no joins (and inside subqueries), so also
+            # fold any remaining bare "remote(...)" → "db.tbl".
+            sql = sql.replace(tf_sql, direct_ref)
+            return sql
+
+        if self._table_function:
+            sql = _fold(sql, self._table_function, self._get_table_alias())
+
+        for other_ds, _, _ in self._joins:
+            if isinstance(other_ds, DataStore) and other_ds._table_function:
+                sql = _fold(sql, other_ds._table_function, other_ds._get_table_alias())
+
+        return sql
+
+    def _build_view_select_sql(self) -> str:
+        """Build the SELECT body for a (materialized) VIEW definition.
+
+        A VIEW stores its SQL text on the target server, so the pipeline must
+        be entirely SQL-pushable — pandas-only ops (apply/UDF/local file/
+        Python(df)) cannot be persisted into a server-side definition.
+
+        SELECT form mirrors the writeback path:
+          - same_server (target == source server): fold ``remote(source,...)``
+            into direct ``db.tbl`` references so the view reads its source
+            tables locally on the same server.
+          - cross-server: keep ``remote(source,...)`` so each query against
+            the view pulls source data over the target server's own native
+            connection.
+        """
+        if not self._is_fully_sql_pushable():
+            raise QueryError(
+                "Cannot create VIEW: the pipeline contains pandas-only "
+                "operations (apply / UDF / local file / etc.) that cannot "
+                "be expressed as a server-side SQL definition. Materialize "
+                "the data first via to_clickhouse(), then create a view on "
+                "the resulting table."
+            )
+        target_host = self._remote_params["host"]
+        same_server = self._is_all_same_remote_server(target_host)
+        return self._writeback_select_sql(same_server)
+
+    def _uses_execution_format_for_writeback(self) -> bool:
+        """Whether the writeback SELECT should be generated with
+        ``execution_format=True``.
+
+        ``execution_format`` is normally what we want — it reproduces
+        ``_execute()``'s exact semantics: lazy-op ordering (e.g. ``head()``
+        before ``filter()`` → LIMIT before WHERE), column projections, and
+        ``LazyGroupByAgg`` (``groupby().sum()``), none of which the flat
+        ``_generate_select_sql()`` renders (it emits a bare
+        ``SELECT * FROM source``).
+
+        The one exception is a ``LazySQLQuery`` (produced by
+        ``groupby().agg(...)``): ``_build_execution_sql()`` cannot yet render it
+        and drops the aggregation, emitting a broken ``SELECT * ... GROUP BY``.
+        For those pipelines the aggregation is already materialized into
+        ``_select_fields`` / ``_groupby_fields``, so the flat SQL is correct —
+        fall back to it. (This is the limitation documented on
+        ``_is_fully_sql_pushable``.)
+        """
+        from .lazy_ops import LazySQLQuery
+        return not any(isinstance(op, LazySQLQuery) for op in self._lazy_ops)
+
+    def _canonical_writeback_sql(self) -> str:
+        """``remote(source, ...)``-form SELECT that reproduces ``_execute()``,
+        used as the cross-server writeback body, the base for
+        ``_get_remote_view_sql`` (same-server, before folding to ``db.tbl``),
+        and the ``DESCRIBE`` target for schema inference — so all writeback SQL
+        derives from one place and can't drift on lazy-op handling."""
+        return self.to_sql(execution_format=self._uses_execution_format_for_writeback())
+
+    def _writeback_select_sql(self, same_server: bool) -> str:
+        """The SELECT body used for every server-side writeback path
+        (``CREATE ... AS SELECT``, ``INSERT ... SELECT``, VIEW / MV
+        definitions). Centralized so the writeback callers can't drift apart
+        on which SQL form they emit.
+
+        - ``same_server``: fold ``remote(source, ...)`` into direct ``db.tbl``
+          references so the SELECT reads its source tables locally on the
+          target server.
+        - cross-server: keep ``remote(source, ...)`` so the target server
+          pulls source data over its own native connection.
+        """
+        return (
+            self._get_remote_view_sql()
+            if same_server
+            else self._canonical_writeback_sql()
+        )
+
+    def _parse_target_name(self, name: str) -> tuple:
+        """
+        Parse a target name into (database, table).
+
+        Supports "database.table" format. If no database is specified, falls
+        back to the source table function's database, then to the DataStore's
+        default database (set via ``from_clickhouse(..., database=...)`` or
+        ``use(...)``). Raises ``QueryError`` if none of those resolve a
+        database.
+
+        Args:
+            name: Target name, e.g. "mydb.mytable" or "mytable"
+
+        Returns:
+            (database, table) tuple
+
+        Raises:
+            QueryError: If ``name`` has no database and none can be inferred.
+        """
+        if "." in name:
+            parts = name.split(".", 1)
+            return parts[0], parts[1]
+        tf_params = self._table_function.params if self._table_function else {}
+        database = tf_params.get("database") or self._default_database
+        if not database:
+            raise QueryError(
+                f"Cannot resolve database for target '{name}'. "
+                f"Use 'database.table' format or ensure the DataStore "
+                f"has a default database configured."
+            )
+        return database, name
+
+    def _check_remote_table_exists(self, database: str, table: str) -> bool:
+        """
+        Check if a table exists on the remote ClickHouse server.
+
+        Uses a ``remote('host', 'system', 'tables', ...)`` lookup rather than
+        the native ``EXISTS TABLE`` statement, because chDB's
+        ``remote(query=...)`` table function is DDL-style — it returns a
+        per-replica status row (``<n>\\t<host>\\tOK``) regardless of what the
+        wrapped query selects, so ``EXISTS TABLE``'s actual ``0/1`` answer
+        is unreachable through that path.
+
+        Args:
+            database: Database name
+            table: Table name
+
+        Returns:
+            True if the table (or view, materialized view, dictionary) exists
+        """
+        adapter = self._get_adapter()
+        func = adapter.get_table_function_name()
+        host = adapter._escape_sql_string(adapter.host)
+        user = adapter._escape_sql_string(adapter.user)
+        password = adapter._escape_sql_string(adapter.password)
+        db = adapter._escape_sql_string(database)
+        tbl = adapter._escape_sql_string(table)
+
+        sql = (
+            f"SELECT count() AS cnt FROM "
+            f"{func}('{host}', 'system', 'tables', '{user}', '{password}') "
+            f"WHERE database = '{db}' AND name = '{tbl}'"
+        )
+        result = self._run_chdb_query(sql, "DataFrame")
+        return int(result.iloc[0, 0]) > 0
+
+    def _get_remote_table_schema(self, database: str, table: str) -> Dict[str, str]:
+        """
+        Get the schema of a remote table as {column_name: column_type}.
+
+        Args:
+            database: Database name
+            table: Table name
+
+        Returns:
+            Dict mapping column names to ClickHouse type strings
+        """
+        adapter = self._get_adapter()
+        func = adapter.get_table_function_name()
+        host = adapter._escape_sql_string(adapter.host)
+        user = adapter._escape_sql_string(adapter.user)
+        password = adapter._escape_sql_string(adapter.password)
+        db = adapter._escape_sql_string(database)
+        tbl = adapter._escape_sql_string(table)
+
+        sql = (
+            f"SELECT name, type FROM {func}('{host}', 'system', 'columns', "
+            f"'{user}', '{password}') "
+            f"WHERE database = '{db}' AND table = '{tbl}' ORDER BY position"
+        )
+
+        result = self._run_chdb_query(sql, "DataFrame")
+        return dict(zip(result["name"], result["type"]))
+
+    def _get_all_source_tables(self) -> set:
+        """
+        Recursively collect all (database, table) pairs this DataStore's SQL
+        pipeline depends on.
+
+        Includes the primary source table and any tables from SQL JOINs,
+        traversing nested JOINs (e.g., A JOIN (B JOIN C)) to capture all levels.
+        LazyJoin/LazyUnion tables (in _lazy_ops) are not collected here because
+        their data is read inside _execute().
+        """
+        tables: set = set()
+        if self._table_function:
+            db = self._table_function.params.get("database", "default")
+            tbl = self._table_function.params.get("table")
+            if tbl:
+                tables.add((db, tbl))
+        for other_ds, _, _ in self._joins:
+            if hasattr(other_ds, "_get_all_source_tables"):
+                tables.update(other_ds._get_all_source_tables())
+            elif hasattr(other_ds, "_table_function") and other_ds._table_function:
+                db = other_ds._table_function.params.get("database", "default")
+                tbl = other_ds._table_function.params.get("table")
+                if tbl:
+                    tables.add((db, tbl))
+        return tables
+
+    def _is_same_remote_table(self, database: str, table: str) -> bool:
+        """
+        Check if the target database.table overlaps with any of this DataStore's
+        source tables. Used to detect write-back-to-source scenarios.
+        """
+        return (database, table) in self._get_all_source_tables()
+
+    def _is_all_same_remote_server(self, target_host: str) -> bool:
+        """
+        Check if all source tables (primary + JOINs) reside on the same
+        remote ClickHouse server as the target.
+
+        When True + fully_sql, the entire pipeline can execute on the remote
+        server without any data passing through local chDB.
+        """
+        if not target_host:
+            return False
+
+        if not self._table_function:
+            return False
+        src_host = self._table_function.params.get("host", "")
+        if src_host != target_host:
+            return False
+
+        for other_ds, _, _ in self._joins:
+            if hasattr(other_ds, "_table_function") and other_ds._table_function:
+                join_host = other_ds._table_function.params.get("host", "")
+                if join_host != target_host:
+                    return False
+            else:
+                return False
+        return True
+
+    def _describe_query_schema(self, select_sql: str, df=None) -> Dict[str, str]:
+        """
+        Use DESCRIBE to get the exact ClickHouse types for a SELECT query.
+
+        Unlike LIMIT 0 which relies on the database to implicitly infer types
+        during CREATE TABLE ... AS SELECT, this uses DESCRIBE to get precise
+        column names, types, and nullability from the query compiler without
+        executing the query.
+
+        Args:
+            select_sql: A SELECT SQL string (may contain remote() table functions)
+            df: DataFrame to keep in scope when ``select_sql`` references a
+                ``Python(df)`` table function (passed through to
+                ``_run_chdb_query``); ``None`` for remote()-based SELECTs.
+
+        Returns:
+            OrderedDict mapping column names to ClickHouse type strings
+        """
+        from collections import OrderedDict
+
+        describe_sql = f"DESCRIBE ({select_sql})"
+        result = self._run_chdb_query(describe_sql, "DataFrame", df=df)
+        return OrderedDict(zip(result["name"], result["type"]))
+
+    def _is_fully_sql_pushable(self) -> bool:
+        """
+        Check if this DataStore's entire pipeline can be executed as a single
+        server-side SQL statement via INSERT INTO ... SELECT ... FROM remote().
+
+        Reuses QueryPlanner._can_push_op_to_sql() for classification, with
+        one exception: LazySQLQuery (generated by groupby().agg() etc.) is
+        treated as SQL-compatible here. Although plan_segments() classifies it
+        as a "pandas" segment (because it can't merge into a surrounding SQL
+        context), the query it contains IS valid SQL that can run server-side.
+
+        This exception exists because _execute()'s segment-based execution
+        currently cannot handle LazySQLQuery correctly when preceded by
+        SQL-state operations like WHERE + GROUP BY (it generates broken SQL
+        like SELECT * ... GROUP BY without aggregation). The server-side path
+        avoids this by using to_sql(execution_format=True) which delegates
+        to _build_execution_sql() for correct SQL generation.
+
+        Returns:
+            True if the pipeline can run as a single server-side SQL
+        """
+        if not (self._table_function or self.table_name):
+            return False
+
+        if not self._lazy_ops:
+            return True
+
+        from .lazy_ops import LazySQLQuery
+        from .query_planner import QueryPlanner
+
+        planner = QueryPlanner()
+        for i, op in enumerate(self._lazy_ops):
+            if isinstance(op, LazySQLQuery):
+                continue
+            preceding = self._lazy_ops[:i]
+            following = self._lazy_ops[i + 1:]
+            if not planner._can_push_op_to_sql(op, preceding_ops=preceding, following_ops=following):
+                return False
+
+        return True
+
+    def _materialize_for_writeback(
+        self,
+        index: bool,
+        index_label: Optional[Union[str, List[str]]],
+    ) -> "pd.DataFrame":
+        """``_execute()`` then index-normalize in one shot. Centralized so
+        every writeback caller treats the materialized DataFrame the same
+        way (and the ``Optional[DataFrame]`` from ``_execute`` is unwrapped
+        in exactly one place)."""
+        df = self._execute()
+        if df is None:
+            # Not an assert: must hold under `python -O` too, where asserts
+            # are stripped and this would otherwise surface as a cryptic
+            # AttributeError deeper in the writeback path.
+            raise ExecutionError(
+                "_execute() returned no data during writeback materialization"
+            )
+        return self._normalize_index_for_insert(df, index, index_label)
+
+    def _normalize_index_for_insert(
+        self,
+        df: "pd.DataFrame",
+        index: bool,
+        index_label: Optional[Union[str, List[str]]],
+    ) -> "pd.DataFrame":
+        """Apply ``index`` / ``index_label`` semantics to ``df`` once, so the
+        same flattened DataFrame can drive schema inference (``DESCRIBE
+        Python(df)`` in ``_create_target_table`` / ``_apply_schema_evolution``)
+        and the actual ``INSERT ... FROM Python(df)`` later. If we only did
+        this in ``_insert_dataframe_to_remote``, CREATE TABLE would see N
+        columns and the INSERT would push N+1 → ``NUMBER_OF_COLUMNS_DOESNT_MATCH``.
+
+        - ``index=False`` (default): drop the index entirely; mirrors the
+          ``index=False`` behavior of ``DataFrame.to_sql`` / ``to_csv``.
+        - ``index=True``: surface index levels as regular columns. Names
+          follow pandas' own ``reset_index()`` defaults (``"index"`` for an
+          unnamed single Index, ``"level_0"`` / ``"level_1"`` / ... for an
+          unnamed MultiIndex), so ``index_label`` can rename them.
+        """
+        if index:
+            is_multi = isinstance(df.index, pd.MultiIndex)
+            original_index_names = (
+                list(df.index.names) if is_multi else [df.index.name]
+            )
+            df = df.reset_index()
+            if index_label is not None:
+                labels = (
+                    [index_label] if isinstance(index_label, str)
+                    else list(index_label)
+                )
+                # Match pandas' to_sql: index_label must name every index
+                # level. zip() would otherwise silently truncate, leaving the
+                # index columns partially renamed with no error.
+                if len(labels) != len(original_index_names):
+                    raise ValueError(
+                        f"index_label has {len(labels)} name(s) but the index "
+                        f"has {len(original_index_names)} level(s); they must match."
+                    )
+                rename_map = {}
+                for level, (old, new) in enumerate(
+                    zip(original_index_names, labels)
+                ):
+                    if old is not None:
+                        col_name = old
+                    elif is_multi:
+                        col_name = f"level_{level}"
+                    else:
+                        col_name = "index"
+                    if col_name in df.columns and new != col_name:
+                        rename_map[col_name] = new
+                if rename_map:
+                    df = df.rename(columns=rename_map)
+        else:
+            # Drop a non-default index quietly — chDB's Python() adapter
+            # ignores the index but downstream column counts must agree
+            # with what DESCRIBE Python(df) reports above.
+            df = df.reset_index(drop=True)
+        return df
+
+    def _insert_dataframe_to_remote(
+        self,
+        df: "pd.DataFrame",
+        database: str,
+        table: str,
+    ) -> None:
+        """
+        Insert a local pandas DataFrame into a remote ClickHouse table.
+
+        Index handling must already have been applied by
+        ``_normalize_index_for_insert`` so the DataFrame's columns match the
+        target table 1:1.
+        """
+        target_tf = self._build_remote_table_function_sql(database, table)
+        insert_sql = f"INSERT INTO TABLE FUNCTION {target_tf} SELECT * FROM Python(df)"
+        # INSERT returns no rows — request a tabular format (like
+        # _execute_remote_ddl) rather than the default DataFrame, which would
+        # incur a pointless empty-DataFrame conversion. Pass df so chDB's
+        # Python(df) resolves it in the query() frame.
+        self._run_chdb_query(insert_sql, "TabSeparated", df=df)
+
+    def _build_remote_table_function_sql(self, database: str, table: str) -> str:
+        """
+        Build a remote()/remoteSecure() table function call for a target table.
+
+        Args:
+            database: Target database name
+            table: Target table name
+
+        Returns:
+            SQL string like remote('host', 'db', 'table', 'user', 'pass')
+        """
+        adapter = self._get_adapter()
+        return adapter.build_table_function(database, table)
+
+    def to_clickhouse(
+        self,
+        name: str,
+        if_exists: str = "fail",
+        index: bool = False,
+        index_label: Optional[Union[str, List[str]]] = None,
+        engine: str = "MergeTree()",
+        order_by: Optional[Union[str, List[str]]] = None,
+        partition_by: Optional[str] = None,
+        enable_schema_evolution: bool = False,
+        host: Optional[str] = None,
+        user: Optional[str] = None,
+        password: Optional[str] = None,
+        secure: bool = False,
+    ) -> None:
+        """
+        Write DataStore data to a remote ClickHouse table.
+
+        Execution paths (in priority order):
+        1. **Pure remote** — fully SQL-pushable + all sources on the same
+           server as the target → the SELECT references the source tables
+           directly (db.tbl) and the whole statement runs on the target
+           server; no data passes through local chDB.
+        2. **Cross-server SQL** — fully SQL-pushable but sources live on a
+           different server from the target → the CREATE/INSERT still runs on
+           the target server (via _execute_remote_ddl), and its SELECT keeps
+           remote(source, ...) so the target pulls source rows over its own
+           native connection (source → target, one hop). chDB only ships the
+           statement; rows do not round-trip through it.
+        3. **DataFrame upload** — pipeline contains Pandas-only ops →
+           _execute() locally, then upload via the Python() table function.
+
+        For ``if_exists="replace"`` with the pure-remote path,
+        ``CREATE OR REPLACE TABLE … AS SELECT`` is used for atomic
+        replacement (no data-loss window).
+
+        Args:
+            name: Target table name. Supports "database.table" format.
+            if_exists: Behavior when table exists:
+                - "fail": Raise error
+                - "replace": For SQL-pushable pipelines (same- or
+                  cross-server), atomic CREATE OR REPLACE TABLE ... AS SELECT
+                  (no data-loss window). For Pandas-only pipelines (DataFrame
+                  upload), which can't be made atomic, raise if the target
+                  already exists; otherwise create + insert.
+                - "append": INSERT into existing table
+            index: Whether to write the DataFrame index as a column
+            index_label: Column name(s) for the index
+            engine: ClickHouse table engine (default: "MergeTree()")
+            order_by: ORDER BY columns for MergeTree-family engines. Optional —
+                when omitted it defaults to ``ORDER BY tuple()`` (no ordering
+                key), so a key is recommended but not required.
+            partition_by: PARTITION BY expression
+            enable_schema_evolution: Auto-adapt column differences (append only)
+            host: Target ClickHouse host:port. Defaults to source server.
+            user: Target server user. Defaults to source connection user.
+            password: Target server password. Defaults to source connection password.
+            secure: Use encrypted connection to target server.
+
+        Raises:
+            ValueError: If if_exists is not one of "fail"/"replace"/"append".
+            QueryError: For the DataFrame-upload path with if_exists="replace"
+                when the target already exists (a non-atomic overwrite is
+                refused).
+            ExecutionError: If a remote DDL/INSERT fails — including the
+                if_exists="fail" case, where the target already existing is
+                surfaced by ClickHouse rejecting CREATE TABLE (no library-side
+                pre-check), wrapped as ExecutionError.
+        """
+        if if_exists not in ("fail", "replace", "append"):
+            raise ValueError(
+                f"Invalid if_exists='{if_exists}'. "
+                f"Must be one of: 'fail', 'replace', 'append'"
+            )
+
+        with self._target_server_context(host, user, password, secure):
+            self._to_clickhouse_impl(
+                name=name,
+                if_exists=if_exists,
+                index=index,
+                index_label=index_label,
+                engine=engine,
+                order_by=order_by,
+                partition_by=partition_by,
+                enable_schema_evolution=enable_schema_evolution,
+            )
+
+    def _to_clickhouse_impl(
+        self,
+        name: str,
+        if_exists: str,
+        index: bool,
+        index_label: Optional[Union[str, List[str]]],
+        engine: str,
+        order_by: Optional[Union[str, List[str]]],
+        partition_by: Optional[str],
+        enable_schema_evolution: bool,
+    ) -> None:
+        """Core implementation of to_clickhouse, assumes _remote_params
+        already points to the target server."""
+
+        self._require_connection_params()
+        self._require_clickhouse_for_writeback()
+
+        database, table_name = self._parse_target_name(name)
+
+        q = self.quote_char
+        target_ref = (
+            f"{format_identifier(database, q)}.{format_identifier(table_name, q)}"
+        )
+
+        # ---- classify execution path ----
+        fully_sql = self._is_fully_sql_pushable()
+        target_host = self._remote_params["host"]
+        same_server = fully_sql and self._is_all_same_remote_server(target_host)
+
+        engine_clause = self._build_engine_clause(
+            engine, order_by, partition_by, q,
+        )
+
+        # ==================================================================
+        # REPLACE
+        # ==================================================================
+        if if_exists == "replace":
+            if fully_sql:
+                # Atomic CREATE OR REPLACE TABLE ... AS SELECT runs entirely
+                # on the target server — no data-loss window, no local data
+                # transit.
+                # - same_server: SELECT references source tables directly
+                #   (db.tbl), executed locally on that server.
+                # - cross-server: SELECT keeps the remote(source, ...) table
+                #   function, so the target server pulls source data itself
+                #   over its own native connection; chDB only ships the DDL.
+                select_sql = self._writeback_select_sql(same_server)
+                ddl = (
+                    f"CREATE OR REPLACE TABLE {target_ref} "
+                    f"{engine_clause} AS {select_sql}"
+                )
+                self._execute_remote_ddl(ddl)
+            else:
+                # Pandas-only pipeline (always cross-server here, since
+                # same_server implies fully_sql). Data must round-trip
+                # through local chDB, so DROP + CREATE + INSERT cannot be
+                # made atomic. Refuse to overwrite an existing target.
+                if self._check_remote_table_exists(database, table_name):
+                    raise QueryError(
+                        f"Cannot atomically replace '{database}.{table_name}'. "
+                        f"Drop the target table manually first, or pick a "
+                        f"different target name."
+                    )
+                local_df = self._materialize_for_writeback(index, index_label)
+                self._create_target_table(
+                    local_df, target_ref, engine_clause, q,
+                )
+                self._do_insert(
+                    False, local_df, database, table_name,
+                    target_ref, same_server,
+                )
+            return
+
+        # ==================================================================
+        # APPEND
+        # ==================================================================
+        if if_exists == "append":
+            table_exists = self._check_remote_table_exists(database, table_name)
+
+            # Materialize once if the pipeline isn't fully SQL-pushable, then
+            # share the same df with schema evolution, CREATE TABLE and INSERT.
+            local_df = (
+                self._materialize_for_writeback(index, index_label)
+                if not fully_sql else None
+            )
+
+            if enable_schema_evolution and table_exists:
+                self._apply_schema_evolution(
+                    local_df, database, table_name, target_ref, q,
+                )
+
+            if not table_exists:
+                self._create_target_table(
+                    local_df, target_ref, engine_clause, q,
+                )
+
+            self._do_insert(
+                fully_sql, local_df, database, table_name,
+                target_ref, same_server,
+            )
+            return
+
+        # ==================================================================
+        # FAIL (default)
+        # ==================================================================
+        local_df = (
+            self._materialize_for_writeback(index, index_label)
+            if not fully_sql else None
+        )
+        self._create_target_table(
+            local_df, target_ref, engine_clause, q,
+        )
+        self._do_insert(
+            fully_sql, local_df, database, table_name,
+            target_ref, same_server,
+        )
+
+    # ---- internal helpers for to_clickhouse ----
+
+    def _create_target_table(
+        self,
+        df: Optional["pd.DataFrame"],
+        target_ref: str,
+        engine_clause: str,
+        q: str,
+    ) -> None:
+        """CREATE TABLE on the remote server with schema inferred from the pipeline.
+
+        Both branches delegate type inference to chDB's query analyzer so the
+        resulting CREATE TABLE column types match exactly what the subsequent
+        INSERT will produce — no manual pandas-dtype → ClickHouse-type mapping,
+        no schema drift between CREATE and INSERT.
+
+        - ``df is not None``: pipeline contained Pandas-only ops, the
+          DataFrame has already been materialized. Use ``DESCRIBE Python(df)``
+          — chDB resolves ``df`` via stack-frame lookup (see
+          ``PythonTableCache::findQueryableObj``) and its PandasDataFrame
+          adapter (the same one INSERT uses) dictates the schema.
+        - ``df is None``: pipeline is fully SQL-pushable. Use
+          ``DESCRIBE (<select_sql>)`` so the remote server reports the precise
+          output types of the query (Decimal scale, LowCardinality, Nullable,
+          Array, etc.) without executing it.
+        """
+        if df is not None:
+            schema = self._describe_query_schema("SELECT * FROM Python(df)", df=df)
+        else:
+            schema = self._describe_query_schema(self._canonical_writeback_sql())
+
+        col_defs = ", ".join(
+            f"{format_identifier(c, q)} {t}" for c, t in schema.items()
+        )
+
+        create_ddl = f"CREATE TABLE {target_ref} ({col_defs}) {engine_clause}"
+        self._execute_remote_ddl(create_ddl)
+
+    def _do_insert(
+        self,
+        fully_sql: bool,
+        local_df: Optional["pd.DataFrame"],
+        database: str,
+        table_name: str,
+        target_ref: str,
+        same_server: bool,
+    ) -> None:
+        """Insert data into the (already existing) target table.
+
+        Mirrors the REPLACE branch: when the pipeline is SQL-pushable, the
+        INSERT runs entirely on the target server via native TCP — chDB only
+        ships the statement, data never round-trips through it.
+
+        - same_server: SELECT references source tables directly (``db.tbl``);
+          pure server-local INSERT...SELECT, zero network hops for the data.
+        - cross-server: SELECT keeps ``remote(source, ...)`` so the target
+          server pulls source data over its own native connection
+          (source → target, one hop). This avoids the previous
+          ``INSERT INTO TABLE FUNCTION remote(target) ... FROM remote(source)``
+          form, which routed every row through local chDB (two hops).
+        - non-SQL pipeline: pandas-only ops force local materialization, then
+          upload via the Python() table function. ``local_df`` must already
+          have its index normalized via ``_normalize_index_for_insert`` so it
+          matches the schema CREATE TABLE / ALTER TABLE saw.
+        """
+        if fully_sql:
+            select_sql = self._writeback_select_sql(same_server)
+            self._execute_remote_ddl(f"INSERT INTO {target_ref} {select_sql}")
+        else:
+            if local_df is None:
+                # Internal invariant: a non-SQL pipeline must have materialized
+                # local_df before reaching the insert. Use a real exception, not
+                # assert (stripped under `python -O`), to fail deterministically.
+                raise ExecutionError(
+                    "Internal error: DataFrame-upload writeback reached the "
+                    "insert step without a materialized DataFrame."
+                )
+            self._insert_dataframe_to_remote(local_df, database, table_name)
+
+    def _apply_schema_evolution(
+        self,
+        df: Optional["pd.DataFrame"],
+        database: str,
+        table_name: str,
+        target_ref: str,
+        q: str,
+    ) -> None:
+        """ALTER TABLE ADD COLUMN for columns the pipeline will write but the
+        target table is missing.
+
+        Compares the *pipeline output* schema (what INSERT will actually
+        produce) against the target table — not the source table's schema.
+        Projections, renames, joins, computed columns and aggregations are
+        therefore all honored.
+
+        Schema inference shares the exact same path as ``_create_target_table``
+        so CREATE / ALTER / INSERT never disagree on types:
+          - ``df is not None``: pipeline already materialized →
+            ``DESCRIBE Python(df)`` (df name resolved via chDB stack-frame
+            lookup, hence the parameter must be named ``df``).
+          - ``df is None``: fully SQL-pushable → ``DESCRIBE (<select_sql>)``
+            asks chDB's analyzer for the precise output types.
+
+        New columns keep the pipeline's exact type. Rows already in the target
+        get ClickHouse's per-type zero value (0 / "" / [] / 1970-01-01 / ...);
+        no Nullable wrapping is added, so downstream queries don't have to
+        unwrap Optional columns.
+        """
+        target_schema = self._get_remote_table_schema(database, table_name)
+        if df is not None:
+            output_schema = self._describe_query_schema("SELECT * FROM Python(df)", df=df)
+        else:
+            output_schema = self._describe_query_schema(self._canonical_writeback_sql())
+
+        for col_name, col_type in output_schema.items():
+            if col_name in target_schema:
+                continue
+            alter_sql = (
+                f"ALTER TABLE {target_ref} "
+                f"ADD COLUMN IF NOT EXISTS "
+                f"{format_identifier(col_name, q)} {col_type}"
+            )
+            self._execute_remote_ddl(alter_sql)
+
+    def create_view(
+        self,
+        name: str,
+        replace: bool = True,
+        host: Optional[str] = None,
+        user: Optional[str] = None,
+        password: Optional[str] = None,
+        secure: bool = False,
+    ) -> None:
+        """
+        Create a VIEW on the remote ClickHouse server from this DataStore's query.
+
+        The VIEW saves the query definition; data is computed on read.
+
+        Security note: for a *cross-server* source, the stored view definition
+        contains a ``remote('host', 'db', 'tbl', 'user', 'password')`` call, so
+        the source credentials are persisted in the view's SQL text and are
+        readable via ``SHOW CREATE``, ``system.tables`` and the query log. Use a
+        least-privilege / read-only source user, or a named collection, when the
+        view crosses servers. (Same-server views fold the source to ``db.tbl``
+        and embed no credentials.)
+
+        Args:
+            name: View name. Supports "database.view_name" format.
+            replace: If True, uses CREATE OR REPLACE VIEW
+            host: Target ClickHouse host:port. Defaults to source server.
+            user: Target server user.
+            password: Target server password.
+            secure: Use encrypted connection to target server.
+
+        Raises:
+            ExecutionError: If the DDL execution fails
+        """
+        with self._target_server_context(host, user, password, secure):
+            self._require_connection_params()
+            self._require_clickhouse_for_writeback()
+
+            database, view_name = self._parse_target_name(name)
+            q = self.quote_char
+            view_ref = (
+                f"{format_identifier(database, q)}.{format_identifier(view_name, q)}"
+            )
+
+            view_sql = self._build_view_select_sql()
+
+            or_replace = "OR REPLACE " if replace else ""
+            ddl = f"CREATE {or_replace}VIEW {view_ref} AS {view_sql}"
+
+            self._execute_remote_ddl(ddl)
+
+    def create_materialized_view(
+        self,
+        name: str,
+        to: str,
+        engine: str = "MergeTree()",
+        order_by: Optional[Union[str, List[str]]] = None,
+        partition_by: Optional[str] = None,
+        populate: bool = False,
+        if_target_exists: str = "fail",
+        host: Optional[str] = None,
+        user: Optional[str] = None,
+        password: Optional[str] = None,
+        secure: bool = False,
+    ) -> None:
+        """
+        Create a MATERIALIZED VIEW on the remote ClickHouse server, backed by
+        a *separate* physical target table (``CREATE MV ... TO target``).
+
+        Why TO form (and only TO form):
+          - data and trigger are decoupled — DROPping the MV never destroys
+            data;
+          - target table can be ALTERed / TTLed / OPTIMIZEd independently;
+          - multiple MVs can fan-in to the same target;
+          - once ClickHouse ships ``CREATE OR REPLACE MATERIALIZED VIEW``
+            (PR #100539, not yet released), the trigger swap will be atomic
+            without touching ``target``.
+
+        Replacing an existing MV is intentionally **not** supported here. As
+        of current ClickHouse releases:
+          - ``CREATE OR REPLACE MATERIALIZED VIEW`` is not yet implemented
+            (and historically gets silently misparsed as a plain VIEW —
+            dangerous);
+          - emulating it with ``DROP VIEW + CREATE`` opens a window in which
+            source INSERTs are dropped on the floor (no trigger active).
+        Drop the old MV explicitly when you really want to swap it; we'll
+        re-enable replace semantics once the upstream PR lands.
+
+        The target table is auto-created on first use. Schema is inferred
+        from the pipeline output via ``DESCRIBE (<select>)`` so types are
+        guaranteed consistent with the SELECT — same machinery as
+        ``to_clickhouse``.
+
+        Args:
+            name: Materialized view (trigger) name. Supports
+                ``"database.mv_name"`` format. Must not already exist.
+            to: Physical target table name. Supports ``"database.table"``
+                format. Required — see ``if_target_exists`` for handling
+                of an existing target.
+            engine: Storage engine for the target table when auto-created.
+                Defaults to ``"MergeTree()"`` to match ``to_clickhouse`` and
+                avoid surprising the common case (filter / project / simple
+                groupby). For pre-aggregated MVs use
+                ``"AggregatingMergeTree()"`` together with ``-State``
+                aggregate functions in the SELECT.
+            order_by: ORDER BY columns for the target (MergeTree family).
+            partition_by: PARTITION BY expression for the target.
+            populate: If True, backfill existing source rows by issuing
+                ``INSERT INTO target SELECT ...`` after the trigger is
+                installed. Note: emulates ClickHouse's ``POPULATE`` keyword
+                (which is incompatible with ``TO``); rows inserted into the
+                source during the backfill window may be processed twice or
+                missed — backfill large tables only when the source is
+                quiescent, or backfill manually with a deterministic
+                watermark.
+            if_target_exists: How to handle a pre-existing target table:
+                - ``"fail"`` (default): raise ``QueryError``;
+                - ``"append"``: reuse the existing target (fan-in pattern,
+                  multiple MVs writing into one table). The library does
+                  not validate schema compatibility — that's on you.
+            host: Target ClickHouse host:port. Defaults to source server.
+            user, password, secure: Target server credentials.
+
+        Raises:
+            ValueError: If ``if_target_exists`` is invalid.
+            QueryError: If pipeline isn't fully SQL-pushable, if ``fail``
+                was requested for a pre-existing target, or if the MV
+                already exists.
+            ExecutionError: If a DDL execution fails on the remote server.
+        """
+        if if_target_exists not in ("fail", "append"):
+            raise ValueError(
+                f"if_target_exists must be 'fail' or 'append', "
+                f"got '{if_target_exists}'"
+            )
+
+        with self._target_server_context(host, user, password, secure):
+            self._require_connection_params()
+            self._require_clickhouse_for_writeback()
+
+            mv_db, mv_name = self._parse_target_name(name)
+            target_db, target_table = self._parse_target_name(to)
+            q = self.quote_char
+            mv_ref = (
+                f"{format_identifier(mv_db, q)}.{format_identifier(mv_name, q)}"
+            )
+            target_ref = (
+                f"{format_identifier(target_db, q)}."
+                f"{format_identifier(target_table, q)}"
+            )
+
+            select_sql = self._build_view_select_sql()
+
+            # ---- mv trigger: must not already exist ----
+            # We deliberately don't offer a `replace` mode — see method
+            # docstring for why. Check first so we fail before creating the
+            # target table (otherwise a retry would hit the
+            # `if_target_exists` check and require append).
+            if self._check_remote_table_exists(mv_db, mv_name):
+                raise QueryError(
+                    f"Materialized view '{mv_db}.{mv_name}' already exists. "
+                    f"Drop it explicitly before recreating — atomic replace "
+                    f"is not yet supported by ClickHouse for materialized "
+                    f"views (see PR ClickHouse/ClickHouse#100539)."
+                )
+
+            # ---- target table: create or reuse ----
+            if self._check_remote_table_exists(target_db, target_table):
+                if if_target_exists == "fail":
+                    raise QueryError(
+                        f"Target table '{target_db}.{target_table}' already "
+                        f"exists. Use if_target_exists='append' to fan in to "
+                        f"the existing table, or pick a different target."
+                    )
+            else:
+                engine_clause = self._build_engine_clause(
+                    engine, order_by, partition_by, q,
+                )
+                self._create_target_table(
+                    None, target_ref, engine_clause, q,
+                )
+
+            ddl = (
+                f"CREATE MATERIALIZED VIEW {mv_ref} TO {target_ref} "
+                f"AS {select_sql}"
+            )
+            self._execute_remote_ddl(ddl)
+
+            # ---- optional backfill (POPULATE-equivalent for TO form) ----
+            if populate:
+                # ClickHouse rejects POPULATE together with TO, so we emulate
+                # it: trigger is already installed (catches new writes), now
+                # push existing source rows into the target. Same caveat as
+                # native POPULATE — concurrent writes during this window may
+                # be double-counted or missed.
+                self._execute_remote_ddl(
+                    f"INSERT INTO {target_ref} {select_sql}"
+                )
+
+    def _build_engine_clause(
+        self,
+        engine: str,
+        order_by: Optional[Union[str, List[str]]],
+        partition_by: Optional[str],
+        q: str,
+    ) -> str:
+        """Build the ``ENGINE = ... ORDER BY (...) PARTITION BY ... SETTINGS ...``
+        clause used by both ``to_clickhouse`` and ``create_materialized_view``
+        so the two stay in lock-step on engine semantics.
+
+        For MergeTree-family engines we always emit ``SETTINGS
+        allow_nullable_key = 1`` because schema inference goes through
+        ``DESCRIBE`` (of either ``remote()`` or ``Python(df)``), which
+        conservatively wraps column types in ``Nullable(...)``. Without this
+        setting, any ORDER BY referencing such a column is rejected with
+        ``ILLEGAL_COLUMN``. The setting is a no-op for non-nullable columns
+        and never alters write semantics, so it's safe to enable
+        unconditionally.
+        """
+        if order_by is None:
+            order_by_clause = "tuple()"
+        elif isinstance(order_by, list):
+            order_by_clause = ", ".join(
+                format_identifier(c, q) for c in order_by
+            )
+        else:
+            order_by_clause = order_by
+
+        is_mergetree = "MergeTree" in engine
+        parts = [f"ENGINE = {engine}"]
+        if is_mergetree:
+            parts.append(f"ORDER BY ({order_by_clause})")
+        if partition_by:
+            parts.append(f"PARTITION BY ({partition_by})")
+        if is_mergetree:
+            parts.append("SETTINGS allow_nullable_key = 1")
+        return " ".join(parts)
+
+    def save(
+        self,
+        name: str,
+        type: str = "table",
+        if_exists: str = "fail",
+        to: Optional[str] = None,
+    ) -> None:
+        """
+        Unified writeback entry point (writes to the source server).
+
+        Saves the DataStore's data or query definition to a remote ClickHouse
+        target. Delegates to specialized methods based on the type parameter.
+
+        To write to a *different* server, use ``to_clickhouse()``,
+        ``create_view()``, or ``create_materialized_view()`` directly
+        with explicit ``host``/``user``/``password`` arguments.
+
+        Args:
+            name: Target name. Supports "database.name" format. For
+                ``type="materialized_view"`` this is the MV trigger name;
+                the physical target table is given by ``to``.
+            type: Target type:
+                - "table": Permanent table (default)
+                - "view": VIEW (saves query definition, computed on read)
+                - "materialized_view": Materialized view in TO form;
+                  ``to`` is required.
+            if_exists: Behavior when target exists:
+                - For "table": "fail" | "replace" | "append"
+                - For "view": "fail" | "replace"
+                - For "materialized_view": "fail" only — atomic MV replace
+                  is not yet supported by ClickHouse (see
+                  ``create_materialized_view``). The target table is reused if
+                  present; for finer control over it, call
+                  ``create_materialized_view`` directly.
+            to: Required for ``type="materialized_view"`` — the physical
+                target table backing the MV. Ignored for other types.
+
+        Raises:
+            ValueError: If type or if_exists is invalid, or if ``to`` is
+                missing for materialized views.
+            QueryError: For materialized-view validation (e.g. the MV already
+                exists), and for the DataFrame-upload "replace" path when the
+                target exists.
+            ExecutionError: For the table/view paths, an existing target with
+                if_exists="fail" surfaces as a remote CREATE failure wrapped as
+                ExecutionError (not QueryError).
+        """
+        if type not in ("table", "view", "materialized_view"):
+            raise ValueError(
+                f"Invalid type='{type}'. Must be one of: 'table', 'view', 'materialized_view'"
+            )
+
+        if type == "table":
+            self.to_clickhouse(
+                name=name,
+                if_exists=if_exists,
+                enable_schema_evolution=(if_exists == "append"),
+            )
+        elif type == "view":
+            if if_exists not in ("fail", "replace"):
+                raise ValueError(
+                    f"Views only support if_exists='fail' or 'replace', got '{if_exists}'"
+                )
+            self.create_view(name=name, replace=(if_exists == "replace"))
+        elif type == "materialized_view":
+            if if_exists != "fail":
+                raise ValueError(
+                    f"Materialized views currently only support "
+                    f"if_exists='fail' (got '{if_exists}'). Atomic replace "
+                    f"is not yet supported by ClickHouse for MVs — see "
+                    f"create_materialized_view docstring for details. "
+                    f"Drop the MV explicitly if you want to recreate it."
+                )
+            if to is None:
+                raise ValueError(
+                    "save(type='materialized_view', ...) requires `to=` "
+                    "(the physical target table). Materialized views are "
+                    "always created in TO form so data and trigger can be "
+                    "managed independently."
+                )
+            # The target table is assumed to be either fresh (auto-create)
+            # or shared (fan-in via append). For a stricter "fail if target
+            # exists" check, call create_materialized_view directly.
+            self.create_materialized_view(
+                name=name,
+                to=to,
+                if_target_exists="append",
+            )
+
     # ========== Query Building Methods ==========
 
     @immutable
@@ -6167,8 +7371,6 @@ class DataStore(PandasCompatMixin):
         """
         import time
 
-        import chdb
-
         self._require_connection_params()
 
         rewritten_sql = self._rewrite_table_references(query)
@@ -6179,7 +7381,7 @@ class DataStore(PandasCompatMixin):
         sql_preview = rewritten_sql[:80] + "..." if len(rewritten_sql) > 80 else rewritten_sql
 
         start = time.perf_counter()
-        result_df = chdb.query(rewritten_sql, output_format="DataFrame")
+        result_df = self._run_chdb_query(rewritten_sql, "DataFrame")
         elapsed_ms = (time.perf_counter() - start) * 1000
 
         with profiler.step(
@@ -6672,6 +7874,69 @@ class DataStore(PandasCompatMixin):
 
         return new_ds
 
+    @contextmanager
+    def _target_server_context(
+        self,
+        host: Optional[str] = None,
+        user: Optional[str] = None,
+        password: Optional[str] = None,
+        secure: bool = False,
+    ):
+        """Temporarily override ``_remote_params`` so downstream helpers
+        (``_execute_remote_ddl``, ``_get_adapter``, etc.) operate against
+        the specified target server instead of the source server.
+
+        When nothing is overridden the context is a genuine no-op. *host*
+        defaults to the source server, so an explicit *user*/*password* still
+        applies against it even when *host* is omitted. Omitted *user*/
+        *password* fall back to the *source* connection's credentials (a target
+        on the same cluster usually shares them) — as the to_clickhouse /
+        create_view / create_materialized_view docstrings promise; falling back
+        to "default"/"" would silently break writeback whenever the source uses
+        non-default credentials.
+        """
+        original = self._remote_params.copy()
+        # Omitted creds inherit the source connection's values. Use `or` (not a
+        # dict default) so a source connection that stored user/password as
+        # None — key present, value None — still resolves to valid auth
+        # ("default"/"") instead of flowing a None through to the adapter as an
+        # empty username.
+        eff_user = user if user is not None else (original.get("user") or "default")
+        eff_password = (
+            password if password is not None else (original.get("password") or "")
+        )
+
+        if host is None:
+            # No target host → stay on the source server. Always apply the
+            # effective creds: eff_user/eff_password turn a source connection
+            # that stored user/password as None into "default"/"" so
+            # _get_adapter() can't emit an empty username, and an explicit
+            # user/password override takes effect here too. When nothing
+            # actually changes this remains a no-op (new_params == original).
+            new_params = {**original, "user": eff_user, "password": eff_password}
+            # Honor an explicit secure=True (switch the source connection to
+            # TLS / remoteSecure) too. secure defaults to False and a bool can't
+            # distinguish "omitted" from "explicit False", so only upgrade —
+            # never silently downgrade a secure source connection.
+            if secure:
+                new_params["secure"] = True
+        else:
+            from .adapters import normalize_clickhouse_connection
+
+            norm_host, norm_secure = normalize_clickhouse_connection(host, secure)
+            new_params = {
+                "host": norm_host,
+                "user": eff_user,
+                "password": eff_password,
+                "secure": norm_secure,
+            }
+
+        self._remote_params = new_params
+        try:
+            yield
+        finally:
+            self._remote_params = original
+
     def _require_connection_params(self):
         """
         Raise error if connection parameters are missing.
@@ -6685,6 +7950,25 @@ class DataStore(PandasCompatMixin):
             raise DataStoreError(
                 "Cannot perform metadata operation - no connection info.\n"
                 'Hint: DataStore(source="clickhouse", host="...", user="...", password="...")'
+            )
+
+    def _require_clickhouse_for_writeback(self) -> None:
+        """Guard writeback to a ClickHouse connection.
+
+        Writeback drives the remote server through ClickHouse-specific table
+        functions (``remote(..., query=...)`` for DDL, ``Python(df)`` for
+        uploads). For a non-ClickHouse source the adapter would emit
+        ``mysql()`` / ``postgresql()`` / ... which don't accept the ``query=``
+        form, surfacing as a confusing runtime error. Fail early and clearly
+        instead. (Pure-DataFrame stores are caught earlier by
+        ``_require_connection_params`` — they have no host.)
+        """
+        if (self.source_type or "").lower() not in _CLICKHOUSE_SOURCE_TYPES:
+            raise QueryError(
+                f"Writeback (to_clickhouse / create_view / "
+                f"create_materialized_view) requires a ClickHouse connection, "
+                f"but this DataStore's source is '{self.source_type}'. "
+                f"Non-ClickHouse sources are not supported for writeback."
             )
 
     def _get_adapter(self) -> "SourceAdapter":
@@ -6720,13 +8004,11 @@ class DataStore(PandasCompatMixin):
         """
         import time
 
-        import chdb
-
         profiler = get_profiler()
         sql_preview = sql[:80] + "..." if len(sql) > 80 else sql
 
         start = time.perf_counter()
-        result = chdb.query(sql, output_format="DataFrame")
+        result = self._run_chdb_query(sql, "DataFrame")
         elapsed_ms = (time.perf_counter() - start) * 1000
 
         with profiler.step(

--- a/datastore/tests/test_writeback.py
+++ b/datastore/tests/test_writeback.py
@@ -1,0 +1,1281 @@
+"""
+Tests for writeback APIs: to_clickhouse, create_view, create_materialized_view, save.
+
+All tests run against a remote ClickHouse server. Connection is configured
+via environment variables.
+
+Source server (always required — most tests skip without it):
+  CHDB_TEST_HOST            host:port
+  CHDB_TEST_USER            user
+  CHDB_TEST_PASSWORD        password
+  CHDB_TEST_DATABASE        database
+
+Target server (optional — only the cross-server suite needs it). Set this to a
+*different* ClickHouse instance with *different* credentials so a misrouted
+connection (source creds sent to target, etc.) gets rejected immediately
+instead of silently passing:
+
+  CHDB_TEST_TARGET_HOST     host:port  (different port from source)
+  CHDB_TEST_TARGET_USER     user
+  CHDB_TEST_TARGET_PASSWORD password
+  CHDB_TEST_TARGET_DATABASE database
+
+Tests requiring the target server skip automatically when these are unset.
+"""
+
+import os
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).parent.parent))
+
+import pandas as pd
+import pytest
+
+import chdb
+from datastore import DataStore
+from datastore.expressions import col
+from datastore.exceptions import (
+    DataStoreError,
+    ExecutionError,
+    QueryError,
+)
+
+
+# ---------------------------------------------------------------------------
+# Server config (env-driven)
+# ---------------------------------------------------------------------------
+
+
+class _Server:
+    def __init__(self, host, user, password, database):
+        self.host = host
+        self.user = user
+        self.password = password
+        self.database = database
+
+    def configured(self):
+        return bool(self.host and self.user and self.database)
+
+
+SOURCE = _Server(
+    host=os.environ.get("CHDB_TEST_HOST", ""),
+    user=os.environ.get("CHDB_TEST_USER", ""),
+    password=os.environ.get("CHDB_TEST_PASSWORD", ""),
+    database=os.environ.get("CHDB_TEST_DATABASE", ""),
+)
+TARGET = _Server(
+    host=os.environ.get("CHDB_TEST_TARGET_HOST", ""),
+    user=os.environ.get("CHDB_TEST_TARGET_USER", ""),
+    password=os.environ.get("CHDB_TEST_TARGET_PASSWORD", ""),
+    database=os.environ.get("CHDB_TEST_TARGET_DATABASE", ""),
+)
+
+# Back-compat shortcuts so single-server helpers stay terse.
+HOST, USER, PASSWORD, DATABASE = SOURCE.host, SOURCE.user, SOURCE.password, SOURCE.database
+
+requires_target = pytest.mark.skipif(
+    not TARGET.configured(),
+    reason="CHDB_TEST_TARGET_* not set — cross-server tests skipped",
+)
+
+
+# ---------------------------------------------------------------------------
+# Server-aware helpers
+# ---------------------------------------------------------------------------
+
+
+def _remote_func(srv: _Server, db: str, table: str) -> str:
+    return f"remote('{srv.host}', '{db}', '{table}', '{srv.user}', '{srv.password}')"
+
+
+def _ddl(sql: str, srv: _Server = SOURCE) -> None:
+    """Execute DDL on a server via remote(query=...)."""
+    # Escape as a ClickHouse string literal the same way production code does
+    # (escape backslashes, then double single quotes) rather than backslash-
+    # escaping quotes — independent of any backslash-escape parser setting.
+    escaped = sql.replace("\\", "\\\\").replace("'", "''")
+    chdb.query(
+        f"SELECT * FROM remote('{srv.host}', "
+        f"query = '{escaped}', '{srv.user}', '{srv.password}')",
+        "TabSeparated",
+    )
+
+
+def _q(sql: str):
+    return chdb.query(sql, output_format="DataFrame")
+
+
+def _drop(table: str, db: str = DATABASE, srv: _Server = SOURCE) -> None:
+    _ddl(f'DROP TABLE IF EXISTS "{db}"."{table}"', srv=srv)
+
+
+def _drop_view(name: str, db: str = DATABASE, srv: _Server = SOURCE) -> None:
+    _ddl(f'DROP VIEW IF EXISTS "{db}"."{name}"', srv=srv)
+
+
+def _count(table: str, db: str = DATABASE, srv: _Server = SOURCE) -> int:
+    result = _q(f"SELECT count() FROM {_remote_func(srv, db, table)}")
+    return int(result.iloc[0, 0])
+
+
+def _select_all(table: str, db: str = DATABASE, order_by: str = None,
+                srv: _Server = SOURCE):
+    sql = f"SELECT * FROM {_remote_func(srv, db, table)}"
+    if order_by:
+        sql += f" ORDER BY {order_by}"
+    return _q(sql)
+
+
+def _columns(table: str, db: str = DATABASE, srv: _Server = SOURCE):
+    """Return [(name, type), ...] from system.columns on the given server."""
+    sql = (
+        f"SELECT name, type FROM remote('{srv.host}', 'system', 'columns', "
+        f"'{srv.user}', '{srv.password}') "
+        f"WHERE database = '{db}' AND table = '{table}' ORDER BY position"
+    )
+    df = _q(sql)
+    return list(zip(df["name"], df["type"]))
+
+
+def _make_ds(table: str = None, db: str = DATABASE, srv: _Server = SOURCE):
+    return DataStore.from_clickhouse(
+        host=srv.host, database=db, table=table,
+        user=srv.user, password=srv.password,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture(autouse=True)
+def _check_source_server():
+    if not SOURCE.configured():
+        pytest.skip(
+            "Source ClickHouse env vars not set "
+            "(CHDB_TEST_HOST, CHDB_TEST_USER, CHDB_TEST_DATABASE)"
+        )
+    try:
+        _q(f"SELECT 1 FROM remote('{SOURCE.host}', 'system', 'one', "
+           f"'{SOURCE.user}', '{SOURCE.password}')")
+    except Exception as e:
+        pytest.skip(f"Source ClickHouse unreachable: {e}")
+
+
+@pytest.fixture()
+def source_table():
+    table = "wb_source"
+    _drop(table)
+    _ddl(
+        f'CREATE TABLE "{DATABASE}"."{table}" '
+        f"(city String, amount Float64, status String) "
+        f"ENGINE = MergeTree() ORDER BY city"
+    )
+    _ddl(
+        f'INSERT INTO "{DATABASE}"."{table}" VALUES '
+        f"('Beijing', 100.0, 'completed'), "
+        f"('Beijing', 200.0, 'completed'), "
+        f"('Beijing', 50.0, 'pending'), "
+        f"('Shanghai', 300.0, 'completed'), "
+        f"('Shanghai', 150.0, 'pending'), "
+        f"('Guangzhou', 400.0, 'completed'), "
+        f"('Guangzhou', 100.0, 'completed')"
+    )
+    yield table
+    _drop(table)
+
+
+# ============================================================================
+# Parameter / connection validation (does not need a working pipeline)
+# ============================================================================
+
+
+class TestParameterValidation:
+    def test_to_clickhouse_rejects_unknown_if_exists(self, source_table):
+        ds = _make_ds(source_table)
+        with pytest.raises(ValueError, match="Invalid if_exists"):
+            ds.to_clickhouse(f"{DATABASE}.t", if_exists="bogus")
+
+    def test_to_clickhouse_rejects_legacy_truncate(self, source_table):
+        ds = _make_ds(source_table)
+        with pytest.raises(ValueError, match="Invalid if_exists"):
+            ds.to_clickhouse(f"{DATABASE}.t", if_exists="truncate")
+
+    def test_save_rejects_unknown_type(self, source_table):
+        ds = _make_ds(source_table)
+        with pytest.raises(ValueError, match="Invalid type"):
+            ds.save(f"{DATABASE}.t", type="bogus")
+
+    def test_save_view_rejects_append(self, source_table):
+        ds = _make_ds(source_table)
+        with pytest.raises(ValueError, match="Views only support"):
+            ds.save(f"{DATABASE}.t", type="view", if_exists="append")
+
+    def test_save_mv_rejects_replace(self, source_table):
+        ds = _make_ds(source_table)
+        with pytest.raises(ValueError, match="if_exists='fail'"):
+            ds.save(f"{DATABASE}.t", type="materialized_view",
+                    if_exists="replace", to=f"{DATABASE}.tgt")
+
+    def test_save_mv_requires_to(self, source_table):
+        ds = _make_ds(source_table)
+        with pytest.raises(ValueError, match="requires `to=`"):
+            ds.save(f"{DATABASE}.t", type="materialized_view")
+
+    def test_create_mv_rejects_unknown_if_target_exists(self, source_table):
+        ds = _make_ds(source_table)
+        with pytest.raises(ValueError, match="if_target_exists must be"):
+            ds.create_materialized_view(
+                name=f"{DATABASE}.t",
+                to=f"{DATABASE}.tgt",
+                if_target_exists="bogus",
+            )
+
+    def test_local_dataframe_datastore_has_no_connection(self):
+        """Writeback APIs need a remote connection — pure-pandas DataStores
+        must fail with DataStoreError, not silently no-op."""
+        ds = DataStore(pd.DataFrame({"a": [1, 2]}))
+        with pytest.raises(DataStoreError):
+            ds.to_clickhouse(f"{DATABASE}.t")
+        with pytest.raises(DataStoreError):
+            ds.create_view(f"{DATABASE}.v")
+        with pytest.raises(DataStoreError):
+            ds.create_materialized_view(name=f"{DATABASE}.mv",
+                                        to=f"{DATABASE}.tgt")
+
+
+# ============================================================================
+# Internal helpers — small but exercised on every writeback call
+# ============================================================================
+
+
+class TestInternalHelpers:
+    def test_parse_target_name_db_dot_table(self, source_table):
+        ds = _make_ds(source_table)
+        assert ds._parse_target_name("a.b") == ("a", "b")
+
+    def test_parse_target_name_falls_back_to_table_function_db(self, source_table):
+        """from_clickhouse's database flows into _parse_target_name when no
+        explicit db is given."""
+        ds = _make_ds(source_table)
+        db, table = ds._parse_target_name("just_a_name")
+        assert db == DATABASE
+        assert table == "just_a_name"
+
+    def test_parse_target_name_unresolvable_db_raises(self):
+        """A DataStore with no source-table context can't resolve a default db."""
+        ds = DataStore.from_clickhouse(
+            host=SOURCE.host, user=SOURCE.user, password=SOURCE.password,
+        )
+        with pytest.raises(QueryError, match="Cannot resolve database"):
+            ds._parse_target_name("just_a_name")
+
+    def test_check_remote_table_exists_true_and_false(self, source_table):
+        ds = _make_ds(source_table)
+        assert ds._check_remote_table_exists(DATABASE, source_table) is True
+        assert ds._check_remote_table_exists(
+            DATABASE, "wb_definitely_does_not_exist_xyz"
+        ) is False
+
+
+# ============================================================================
+# to_clickhouse — same-server fully-SQL paths
+# ============================================================================
+
+
+class TestToClickHouseSameServer:
+    """Pipeline lives on the source server and is fully SQL-pushable.
+    Covers the fast path: pure remote DDL + INSERT...SELECT, no local
+    DataFrame round trip."""
+
+    def test_fail_creates_new_table(self, source_table):
+        target = "wb_ss_fail_new"
+        _drop(target)
+        try:
+            ds = _make_ds(source_table)
+            ds.to_clickhouse(f"{DATABASE}.{target}",
+                             engine="MergeTree()", order_by="city")
+            assert _count(target) == 7
+        finally:
+            _drop(target)
+
+    def test_fail_when_target_exists_raises(self, source_table):
+        """fail mode lets ClickHouse reject CREATE TABLE naturally —
+        manifests as ExecutionError (not QueryError) since no library-side
+        pre-check is performed for fail."""
+        target = "wb_ss_fail_existing"
+        _drop(target)
+        try:
+            ds = _make_ds(source_table)
+            ds.to_clickhouse(f"{DATABASE}.{target}",
+                             engine="MergeTree()", order_by="city")
+            with pytest.raises(ExecutionError, match="already exists"):
+                ds.to_clickhouse(f"{DATABASE}.{target}",
+                                 engine="MergeTree()", order_by="city")
+        finally:
+            _drop(target)
+
+    def test_replace_new_table_via_create_or_replace(self, source_table):
+        target = "wb_ss_replace_new"
+        _drop(target)
+        try:
+            ds = _make_ds(source_table)
+            ds.to_clickhouse(
+                f"{DATABASE}.{target}",
+                if_exists="replace", engine="MergeTree()", order_by="city",
+            )
+            assert _count(target) == 7
+        finally:
+            _drop(target)
+
+    def test_replace_overwrites_existing_atomically(self, source_table):
+        target = "wb_ss_replace_existing"
+        _drop(target)
+        try:
+            ds = _make_ds(source_table)
+            ds.to_clickhouse(f"{DATABASE}.{target}",
+                             engine="MergeTree()", order_by="city")
+            assert _count(target) == 7
+
+            ds.filter(ds["status"] == "completed").to_clickhouse(
+                f"{DATABASE}.{target}",
+                if_exists="replace", engine="MergeTree()", order_by="city",
+            )
+            assert _count(target) == 5
+            result = _select_all(target)
+            assert all(result["status"] == "completed")
+        finally:
+            _drop(target)
+
+    def test_replace_writes_back_to_source_atomically(self, source_table):
+        ds = _make_ds(source_table)
+        ds.filter(ds["status"] == "completed").to_clickhouse(
+            f"{DATABASE}.{source_table}",
+            if_exists="replace", engine="MergeTree()", order_by="city",
+        )
+        assert _count(source_table) == 5
+        result = _select_all(source_table)
+        assert all(result["status"] == "completed")
+
+    def test_append_creates_then_inserts(self, source_table):
+        target = "wb_ss_append_create"
+        _drop(target)
+        try:
+            ds = _make_ds(source_table)
+            ds.to_clickhouse(f"{DATABASE}.{target}", if_exists="append",
+                             engine="MergeTree()", order_by="city")
+            assert _count(target) == 7
+            ds.to_clickhouse(f"{DATABASE}.{target}", if_exists="append")
+            assert _count(target) == 14
+        finally:
+            _drop(target)
+
+    def test_filter_sort_pipeline(self, source_table):
+        target = "wb_ss_filter_sort"
+        _drop(target)
+        try:
+            ds = _make_ds(source_table)
+            (ds.filter(ds["status"] == "completed")
+               .sort("amount", ascending=False)).to_clickhouse(
+                f"{DATABASE}.{target}", engine="MergeTree()", order_by="city",
+            )
+            result = _select_all(target, order_by="amount DESC")
+            assert len(result) == 5
+            assert float(result.iloc[0]["amount"]) == 400.0
+        finally:
+            _drop(target)
+
+    def test_groupby_agg_pipeline(self, source_table):
+        target = "wb_ss_groupby"
+        _drop(target)
+        try:
+            ds = _make_ds(source_table)
+            summary = (ds.filter(ds["status"] == "completed")
+                         .groupby("city")
+                         .agg(total=col("amount").sum(),
+                              cnt=col("amount").count()))
+            summary.to_clickhouse(f"{DATABASE}.{target}",
+                                  engine="MergeTree()", order_by="city")
+            result = _select_all(target, order_by="city")
+            assert len(result) == 3
+
+            bj = result[result["city"] == "Beijing"]
+            assert float(bj["total"].iloc[0]) == 300.0
+            assert int(bj["cnt"].iloc[0]) == 2
+
+            schema = dict(_columns(target))
+            assert schema["city"].endswith("String")
+            assert "Float64" in schema["total"]
+        finally:
+            _drop(target)
+
+    def test_projection_writes_only_selected_columns(self, source_table):
+        """A column projection must persist only the selected columns. The
+        writeback SELECT has to honor lazy ops (execution_format); the flat
+        SELECT generator emits a bare ``SELECT * FROM source`` and would
+        silently write every source column."""
+        target = "wb_ss_projection"
+        _drop(target)
+        try:
+            ds = _make_ds(source_table)
+            ds[["city", "amount"]].to_clickhouse(
+                f"{DATABASE}.{target}", engine="MergeTree()", order_by="city",
+            )
+            cols = {name for name, _ in _columns(target)}
+            assert cols == {"city", "amount"}
+            assert "status" not in cols
+            assert _count(target) == 7
+            result = _select_all(target, order_by="amount DESC")
+            assert float(result.iloc[0]["amount"]) == 400.0
+        finally:
+            _drop(target)
+
+    def test_limit_before_filter_preserves_pipeline_order(self, source_table):
+        """``head()`` before ``filter()`` must run as LIMIT-then-WHERE (pandas
+        order), not the flat WHERE-then-LIMIT. The two highest amounts (400,
+        300) are both 'completed', so a subsequent status=='pending' filter
+        yields zero rows. The buggy flat SQL (WHERE status='pending' ORDER BY
+        amount DESC LIMIT 2) would instead persist the two 'pending' rows."""
+        target = "wb_ss_limit_order"
+        _drop(target)
+        try:
+            ds = _make_ds(source_table)
+            (ds.sort("amount", ascending=False)
+               .head(2)
+               .filter(ds["status"] == "pending")).to_clickhouse(
+                f"{DATABASE}.{target}", engine="MergeTree()", order_by="city",
+            )
+            assert _count(target) == 0
+        finally:
+            _drop(target)
+
+    def test_order_by_list_and_partition_by(self, source_table):
+        target = "wb_ss_order_partition"
+        _drop(target)
+        try:
+            ds = _make_ds(source_table)
+            ds.to_clickhouse(
+                f"{DATABASE}.{target}",
+                engine="MergeTree()",
+                order_by=["city", "amount"],
+                partition_by="status",
+            )
+            assert _count(target) == 7
+
+            sql_parts = _q(
+                f"SELECT engine_full FROM remote('{HOST}', 'system', 'tables',"
+                f" '{USER}', '{PASSWORD}') "
+                f"WHERE database = '{DATABASE}' AND name = '{target}'"
+            )
+            engine_full = str(sql_parts.iloc[0, 0])
+            assert "PARTITION BY" in engine_full
+            assert "status" in engine_full
+        finally:
+            _drop(target)
+
+    def test_default_engine_is_mergetree(self, source_table):
+        target = "wb_ss_default_engine"
+        _drop(target)
+        try:
+            ds = _make_ds(source_table)
+            ds.to_clickhouse(f"{DATABASE}.{target}", order_by="city")
+            engine = _q(
+                f"SELECT engine FROM remote('{HOST}', 'system', 'tables', "
+                f"'{USER}', '{PASSWORD}') "
+                f"WHERE database = '{DATABASE}' AND name = '{target}'"
+            ).iloc[0, 0]
+            assert engine == "MergeTree"
+        finally:
+            _drop(target)
+
+    def test_summing_mergetree(self, source_table):
+        target = "wb_ss_summing"
+        _drop(target)
+        try:
+            ds = _make_ds(source_table)
+            (ds.groupby("city").agg(total=col("amount").sum())
+             ).to_clickhouse(
+                f"{DATABASE}.{target}",
+                engine="SummingMergeTree()", order_by="city",
+            )
+            engine = _q(
+                f"SELECT engine FROM remote('{HOST}', 'system', 'tables', "
+                f"'{USER}', '{PASSWORD}') "
+                f"WHERE database = '{DATABASE}' AND name = '{target}'"
+            ).iloc[0, 0]
+            assert engine == "SummingMergeTree"
+        finally:
+            _drop(target)
+
+    def test_unqualified_target_uses_default_database(self, source_table):
+        """Target name without 'db.' should pick up from_clickhouse's database."""
+        target = "wb_ss_unqualified"
+        _drop(target)
+        try:
+            ds = _make_ds(source_table)
+            ds.to_clickhouse(target, engine="MergeTree()", order_by="city")
+            assert _count(target) == 7
+        finally:
+            _drop(target)
+
+
+# ============================================================================
+# to_clickhouse — DataFrame-upload fallback (pandas-only ops in the pipeline)
+# ============================================================================
+
+
+class TestToClickHouseDataFrameUpload:
+    """Pipelines that contain pandas-only ops can't be SQL-pushed; the impl
+    materializes locally and re-uploads via the Python() table function.
+    These exercise the non-fully_sql branch end-to-end."""
+
+    def test_python_udf_via_transform(self, source_table):
+        target = "wb_df_udf"
+        _drop(target)
+        try:
+            ds = _make_ds(source_table)
+            ds_udf = (ds.filter(ds["status"] == "completed")
+                        .transform(lambda df: df.assign(
+                            amount_doubled=df["amount"] * 2)))
+            ds_udf.to_clickhouse(f"{DATABASE}.{target}",
+                                 engine="MergeTree()", order_by="city")
+
+            schema = dict(_columns(target))
+            assert "amount_doubled" in schema
+
+            result = _select_all(target, order_by="city, amount")
+            assert len(result) == 5
+            assert all(result["amount_doubled"] == result["amount"] * 2)
+        finally:
+            _drop(target)
+
+    def test_replace_dataframe_path_when_target_missing_creates_it(
+        self, source_table
+    ):
+        """Pandas-only pipeline + replace + target absent → DROP+CREATE+INSERT
+        is allowed (no atomic CREATE OR REPLACE here, but no data to lose
+        either)."""
+        target = "wb_df_replace_new"
+        _drop(target)
+        try:
+            ds = _make_ds(source_table)
+            (ds.transform(lambda df: df.assign(extra=df["amount"] + 1))
+             ).to_clickhouse(
+                f"{DATABASE}.{target}", if_exists="replace",
+                engine="MergeTree()", order_by="city",
+            )
+            assert _count(target) == 7
+            assert "extra" in dict(_columns(target))
+        finally:
+            _drop(target)
+
+    def test_replace_dataframe_path_refuses_to_overwrite_existing(
+        self, source_table
+    ):
+        """Pandas-only pipeline + replace + target present → no atomic path
+        available, so we refuse rather than risk a non-atomic DROP+CREATE
+        window."""
+        target = "wb_df_replace_existing"
+        _drop(target)
+        try:
+            _ddl(
+                f'CREATE TABLE "{DATABASE}"."{target}" (a Int64) '
+                f"ENGINE = MergeTree() ORDER BY a"
+            )
+            ds = _make_ds(source_table)
+            with pytest.raises(QueryError,
+                               match="Cannot atomically replace"):
+                (ds.transform(lambda df: df.assign(extra=1))
+                 ).to_clickhouse(
+                    f"{DATABASE}.{target}", if_exists="replace",
+                    engine="MergeTree()", order_by="city",
+                )
+        finally:
+            _drop(target)
+
+    def test_append_dataframe_path_to_existing(self, source_table):
+        target = "wb_df_append"
+        _drop(target)
+        try:
+            ds = _make_ds(source_table)
+            ds.to_clickhouse(f"{DATABASE}.{target}",
+                             engine="MergeTree()", order_by="city")
+            (ds.transform(lambda df: df.assign(amount=df["amount"] + 1))
+             ).to_clickhouse(f"{DATABASE}.{target}", if_exists="append")
+            assert _count(target) == 14
+        finally:
+            _drop(target)
+
+    def test_index_true_writes_index_column(self, source_table):
+        """index=True must surface the pandas index as a real column on the
+        target table (default name = 'index')."""
+        target = "wb_df_index"
+        _drop(target)
+        try:
+            ds = _make_ds(source_table)
+            (ds.transform(lambda df: df.assign(rn=range(len(df))).set_index("rn"))
+             ).to_clickhouse(
+                f"{DATABASE}.{target}", index=True,
+                engine="MergeTree()", order_by="city",
+            )
+            cols = dict(_columns(target))
+            assert "rn" in cols
+            assert _count(target) == 7
+        finally:
+            _drop(target)
+
+    def test_index_label_renames_index_column(self, source_table):
+        target = "wb_df_index_label"
+        _drop(target)
+        try:
+            ds = _make_ds(source_table)
+            (ds.transform(lambda df:
+                          df.assign(_rn=range(len(df))).set_index("_rn"))
+             ).to_clickhouse(
+                f"{DATABASE}.{target}", index=True, index_label="row_id",
+                engine="MergeTree()", order_by="city",
+            )
+            cols = dict(_columns(target))
+            assert "row_id" in cols
+            assert "_rn" not in cols
+        finally:
+            _drop(target)
+
+
+# ============================================================================
+# Schema evolution
+# ============================================================================
+
+
+class TestSchemaEvolution:
+    def test_missing_columns_added_via_alter(self):
+        """Pipeline produces a column the target table doesn't have →
+        ALTER TABLE ADD COLUMN before INSERT."""
+        source = "wb_evo_source"
+        target = "wb_evo_target"
+        _drop(source)
+        _drop(target)
+        try:
+            _ddl(
+                f'CREATE TABLE "{DATABASE}"."{source}" '
+                f"(id UInt32, name String, email String) "
+                f"ENGINE = MergeTree() ORDER BY id"
+            )
+            _ddl(
+                f'INSERT INTO "{DATABASE}"."{source}" VALUES '
+                f"(1, 'Alice', 'a@x'), (2, 'Bob', 'b@x')"
+            )
+            _ddl(
+                f'CREATE TABLE "{DATABASE}"."{target}" '
+                f"(id UInt32, name String) "
+                f"ENGINE = MergeTree() ORDER BY id"
+            )
+            _ddl(
+                f'INSERT INTO "{DATABASE}"."{target}" VALUES '
+                f"(99, 'pre-existing')"
+            )
+
+            _make_ds(source).to_clickhouse(
+                f"{DATABASE}.{target}", if_exists="append",
+                enable_schema_evolution=True,
+            )
+
+            cols = dict(_columns(target))
+            assert "email" in cols, "schema evolution did not add the new column"
+            assert _count(target) == 3
+
+            existing_email = _q(
+                f"SELECT email FROM {_remote_func(SOURCE, DATABASE, target)} "
+                f"WHERE id = 99"
+            )
+            # CH default zero value for String is empty string; no Nullable wrap.
+            assert existing_email.iloc[0, 0] == ""
+        finally:
+            _drop(source)
+            _drop(target)
+
+    def test_evolution_uses_pipeline_output_not_source_schema(self):
+        """Renames / projections in the pipeline must drive evolution —
+        comparing against the *source* schema would miss them."""
+        source = "wb_evo_pipeline_src"
+        target = "wb_evo_pipeline_tgt"
+        _drop(source)
+        _drop(target)
+        try:
+            _ddl(
+                f'CREATE TABLE "{DATABASE}"."{source}" (id UInt32, v Int64) '
+                f"ENGINE = MergeTree() ORDER BY id"
+            )
+            _ddl(
+                f'INSERT INTO "{DATABASE}"."{source}" VALUES (1, 10), (2, 20)'
+            )
+            _ddl(
+                f'CREATE TABLE "{DATABASE}"."{target}" (id UInt32) '
+                f"ENGINE = MergeTree() ORDER BY id"
+            )
+
+            ds = _make_ds(source)
+            (ds.select("id", (col("v") * 2).as_("v2"))
+             ).to_clickhouse(
+                f"{DATABASE}.{target}", if_exists="append",
+                enable_schema_evolution=True,
+            )
+
+            cols = dict(_columns(target))
+            assert "v2" in cols
+            assert "v" not in cols
+        finally:
+            _drop(source)
+            _drop(target)
+
+
+# ============================================================================
+# create_view
+# ============================================================================
+
+
+class TestCreateView:
+    def test_basic_view_reflects_filter(self, source_table):
+        view = "wb_view_basic"
+        _drop_view(view)
+        try:
+            ds = _make_ds(source_table)
+            ds.filter(ds["status"] == "completed").create_view(
+                f"{DATABASE}.{view}"
+            )
+            result = _select_all(view, order_by="city, amount")
+            assert len(result) == 5
+            assert all(result["status"] == "completed")
+        finally:
+            _drop_view(view)
+
+    def test_view_with_groupby(self, source_table):
+        view = "wb_view_groupby"
+        _drop_view(view)
+        try:
+            ds = _make_ds(source_table)
+            (ds.filter(ds["status"] == "completed")
+               .groupby("city")
+               .agg(total=col("amount").sum())
+            ).create_view(f"{DATABASE}.{view}")
+            result = _select_all(view, order_by="city")
+            bj = result[result["city"] == "Beijing"]
+            assert float(bj["total"].iloc[0]) == 300.0
+        finally:
+            _drop_view(view)
+
+    def test_view_replace_swaps_definition(self, source_table):
+        view = "wb_view_replace"
+        _drop_view(view)
+        try:
+            ds = _make_ds(source_table)
+            ds.filter(ds["status"] == "completed").create_view(
+                f"{DATABASE}.{view}"
+            )
+            assert len(_select_all(view)) == 5
+
+            ds.filter(ds["status"] == "pending").create_view(
+                f"{DATABASE}.{view}", replace=True,
+            )
+            after = _select_all(view)
+            assert len(after) == 2
+            assert all(after["status"] == "pending")
+        finally:
+            _drop_view(view)
+
+    def test_view_replace_false_on_existing_raises(self, source_table):
+        view = "wb_view_no_replace"
+        _drop_view(view)
+        try:
+            ds = _make_ds(source_table)
+            ds.create_view(f"{DATABASE}.{view}")
+            with pytest.raises(ExecutionError, match="already exists"):
+                ds.create_view(f"{DATABASE}.{view}", replace=False)
+        finally:
+            _drop_view(view)
+
+    def test_view_reflects_subsequent_source_inserts(self, source_table):
+        view = "wb_view_live"
+        _drop_view(view)
+        try:
+            ds = _make_ds(source_table)
+            ds.create_view(f"{DATABASE}.{view}")
+            before = _count(view)
+
+            _ddl(
+                f'INSERT INTO "{DATABASE}"."{source_table}" VALUES '
+                f"('Shenzhen', 999.0, 'completed')"
+            )
+            assert _count(view) == before + 1
+        finally:
+            _drop_view(view)
+
+    def test_view_pandas_only_pipeline_rejected(self, source_table):
+        """Views save SQL — a pipeline that requires Python execution can't
+        be pushed and must error out cleanly, not silently materialize."""
+        view = "wb_view_pandas_only"
+        _drop_view(view)
+        try:
+            ds = _make_ds(source_table)
+            with pytest.raises((QueryError, DataStoreError)):
+                (ds.transform(lambda df: df.assign(x=1))
+                 ).create_view(f"{DATABASE}.{view}")
+        finally:
+            _drop_view(view)
+
+
+# ============================================================================
+# create_materialized_view
+# ============================================================================
+
+
+class TestCreateMaterializedView:
+    """All MV tests use the TO form; replace semantics are intentionally
+    unsupported (see method docstring)."""
+
+    def test_default_engine_is_mergetree(self, source_table):
+        mv, target = "wb_mv_engine_default", "wb_mv_engine_default_tgt"
+        _drop_view(mv)
+        _drop(target)
+        try:
+            _make_ds(source_table).create_materialized_view(
+                name=f"{DATABASE}.{mv}",
+                to=f"{DATABASE}.{target}",
+                order_by="city",
+            )
+            engine = _q(
+                f"SELECT engine FROM remote('{HOST}', 'system', 'tables', "
+                f"'{USER}', '{PASSWORD}') "
+                f"WHERE database = '{DATABASE}' AND name = '{target}'"
+            ).iloc[0, 0]
+            assert engine == "MergeTree"
+        finally:
+            _drop_view(mv)
+            _drop(target)
+
+    def test_incremental_writes_land_in_target(self, source_table):
+        mv, target = "wb_mv_incr", "wb_mv_incr_tgt"
+        _drop_view(mv)
+        _drop(target)
+        try:
+            _make_ds(source_table).create_materialized_view(
+                name=f"{DATABASE}.{mv}",
+                to=f"{DATABASE}.{target}",
+                engine="MergeTree()", order_by="city",
+            )
+            before = _count(target)
+            _ddl(
+                f'INSERT INTO "{DATABASE}"."{source_table}" VALUES '
+                f"('Shenzhen', 888.0, 'new')"
+            )
+            assert _count(target) == before + 1
+        finally:
+            _drop_view(mv)
+            _drop(target)
+
+    def test_populate_backfills_existing_rows(self, source_table):
+        mv, target = "wb_mv_populate", "wb_mv_populate_tgt"
+        _drop_view(mv)
+        _drop(target)
+        try:
+            _make_ds(source_table).create_materialized_view(
+                name=f"{DATABASE}.{mv}",
+                to=f"{DATABASE}.{target}",
+                engine="MergeTree()", order_by="city",
+                populate=True,
+            )
+            assert _count(target) == 7
+        finally:
+            _drop_view(mv)
+            _drop(target)
+
+    def test_partition_by_propagates_to_target(self, source_table):
+        mv, target = "wb_mv_partition", "wb_mv_partition_tgt"
+        _drop_view(mv)
+        _drop(target)
+        try:
+            _make_ds(source_table).create_materialized_view(
+                name=f"{DATABASE}.{mv}",
+                to=f"{DATABASE}.{target}",
+                engine="MergeTree()", order_by="city",
+                partition_by="status",
+            )
+            engine_full = _q(
+                f"SELECT engine_full FROM remote('{HOST}', 'system', 'tables', "
+                f"'{USER}', '{PASSWORD}') "
+                f"WHERE database = '{DATABASE}' AND name = '{target}'"
+            ).iloc[0, 0]
+            assert "PARTITION BY" in str(engine_full)
+        finally:
+            _drop_view(mv)
+            _drop(target)
+
+    def test_target_exists_fail_raises(self, source_table):
+        mv, target = "wb_mv_tgt_fail", "wb_mv_tgt_fail_tgt"
+        _drop_view(mv)
+        _drop(target)
+        try:
+            _ddl(
+                f'CREATE TABLE "{DATABASE}"."{target}" (city String, x Int64) '
+                f"ENGINE = MergeTree() ORDER BY city"
+            )
+            with pytest.raises(QueryError, match="already exists"):
+                _make_ds(source_table).create_materialized_view(
+                    name=f"{DATABASE}.{mv}",
+                    to=f"{DATABASE}.{target}",
+                    engine="MergeTree()", order_by="city",
+                )
+        finally:
+            _drop_view(mv)
+            _drop(target)
+
+    def test_target_exists_append_fan_in(self, source_table):
+        """if_target_exists='append' lets multiple MVs feed one target table."""
+        mv1, mv2, target = "wb_mv_fanin1", "wb_mv_fanin2", "wb_mv_fanin_tgt"
+        _drop_view(mv1)
+        _drop_view(mv2)
+        _drop(target)
+        try:
+            ds = _make_ds(source_table)
+            ds.filter(ds["status"] == "completed").create_materialized_view(
+                name=f"{DATABASE}.{mv1}", to=f"{DATABASE}.{target}",
+                engine="MergeTree()", order_by="city", populate=True,
+            )
+            ds.filter(ds["status"] == "pending").create_materialized_view(
+                name=f"{DATABASE}.{mv2}", to=f"{DATABASE}.{target}",
+                if_target_exists="append",
+                engine="MergeTree()", order_by="city", populate=True,
+            )
+            assert _count(target) == 7
+        finally:
+            _drop_view(mv1)
+            _drop_view(mv2)
+            _drop(target)
+
+    def test_mv_already_exists_always_fails(self, source_table):
+        mv, target = "wb_mv_dup", "wb_mv_dup_tgt"
+        _drop_view(mv)
+        _drop(target)
+        try:
+            ds = _make_ds(source_table)
+            ds.create_materialized_view(
+                name=f"{DATABASE}.{mv}", to=f"{DATABASE}.{target}",
+                engine="MergeTree()", order_by="city",
+            )
+            with pytest.raises(QueryError, match="already exists"):
+                ds.create_materialized_view(
+                    name=f"{DATABASE}.{mv}", to=f"{DATABASE}.{target}",
+                    if_target_exists="append",
+                    engine="MergeTree()", order_by="city",
+                )
+        finally:
+            _drop_view(mv)
+            _drop(target)
+
+    def test_pandas_only_pipeline_rejected(self, source_table):
+        mv, target = "wb_mv_pandas_only", "wb_mv_pandas_only_tgt"
+        _drop_view(mv)
+        _drop(target)
+        try:
+            ds = _make_ds(source_table)
+            with pytest.raises((QueryError, DataStoreError)):
+                (ds.transform(lambda df: df.assign(x=1))
+                 ).create_materialized_view(
+                    name=f"{DATABASE}.{mv}", to=f"{DATABASE}.{target}",
+                    engine="MergeTree()", order_by="city",
+                )
+        finally:
+            _drop_view(mv)
+            _drop(target)
+
+
+# ============================================================================
+# save() — delegation matrix
+# ============================================================================
+
+
+class TestSaveDelegation:
+    def test_table_default_fail(self, source_table):
+        target = "wb_save_table"
+        _drop(target)
+        try:
+            _make_ds(source_table).save(f"{DATABASE}.{target}")
+            assert _count(target) == 7
+        finally:
+            _drop(target)
+
+    def test_table_replace(self, source_table):
+        target = "wb_save_table_replace"
+        _drop(target)
+        try:
+            ds = _make_ds(source_table)
+            ds.save(f"{DATABASE}.{target}")
+            ds.filter(ds["status"] == "completed").save(
+                f"{DATABASE}.{target}", if_exists="replace"
+            )
+            assert _count(target) == 5
+        finally:
+            _drop(target)
+
+    def test_table_append_enables_schema_evolution(self):
+        """save(type='table', if_exists='append') must auto-enable schema
+        evolution — that's its whole differentiation from to_clickhouse."""
+        source = "wb_save_evo_src"
+        target = "wb_save_evo_tgt"
+        _drop(source)
+        _drop(target)
+        try:
+            _ddl(
+                f'CREATE TABLE "{DATABASE}"."{source}" '
+                f"(id UInt32, name String, age UInt32) "
+                f"ENGINE = MergeTree() ORDER BY id"
+            )
+            _ddl(
+                f'INSERT INTO "{DATABASE}"."{source}" VALUES '
+                f"(1, 'Alice', 30)"
+            )
+            _ddl(
+                f'CREATE TABLE "{DATABASE}"."{target}" '
+                f"(id UInt32, name String) "
+                f"ENGINE = MergeTree() ORDER BY id"
+            )
+            _make_ds(source).save(f"{DATABASE}.{target}", if_exists="append")
+            assert "age" in dict(_columns(target))
+        finally:
+            _drop(source)
+            _drop(target)
+
+    def test_view_replace(self, source_table):
+        view = "wb_save_view"
+        _drop_view(view)
+        try:
+            (_make_ds(source_table)
+                .filter(col("status") == "completed")
+            ).save(f"{DATABASE}.{view}", type="view", if_exists="replace")
+            assert _count(view) == 5
+        finally:
+            _drop_view(view)
+
+    def test_materialized_view(self, source_table):
+        mv, target = "wb_save_mv", "wb_save_mv_tgt"
+        _drop_view(mv)
+        _drop(target)
+        try:
+            _make_ds(source_table).save(
+                f"{DATABASE}.{mv}",
+                type="materialized_view",
+                to=f"{DATABASE}.{target}",
+            )
+            _ddl(
+                f'INSERT INTO "{DATABASE}"."{source_table}" VALUES '
+                f"('Hangzhou', 777.0, 'completed')"
+            )
+            assert _count(target) >= 1
+        finally:
+            _drop_view(mv)
+            _drop(target)
+
+
+# ============================================================================
+# Cross-server writeback (target host explicitly different from source)
+# ============================================================================
+
+
+@requires_target
+class TestCrossServerToClickHouse:
+    """Pipeline source lives on SOURCE; target lives on TARGET — different
+    server, different credentials. Exercises the cross-server branches of
+    _to_clickhouse_impl."""
+
+    @pytest.fixture(autouse=True)
+    def _check_target(self):
+        try:
+            _q(
+                f"SELECT 1 FROM remote('{TARGET.host}', 'system', 'one', "
+                f"'{TARGET.user}', '{TARGET.password}')"
+            )
+        except Exception as e:
+            pytest.skip(f"Target ClickHouse unreachable: {e}")
+
+    def _drop_target(self, name):
+        _drop(name, db=TARGET.database, srv=TARGET)
+
+    def test_fail_creates_table_on_target_server(self, source_table):
+        target = "wb_cs_fail_new"
+        self._drop_target(target)
+        try:
+            _make_ds(source_table).to_clickhouse(
+                f"{TARGET.database}.{target}",
+                engine="MergeTree()", order_by="city",
+                host=TARGET.host, user=TARGET.user, password=TARGET.password,
+            )
+            assert _count(target, db=TARGET.database, srv=TARGET) == 7
+            # And the table must NOT exist on the source server.
+            assert _count_or_zero(target, db=DATABASE, srv=SOURCE) == 0
+        finally:
+            self._drop_target(target)
+
+    def test_replace_fully_sql_uses_create_or_replace_on_target(
+        self, source_table
+    ):
+        target = "wb_cs_replace_fully_sql"
+        self._drop_target(target)
+        try:
+            ds = _make_ds(source_table)
+            ds.to_clickhouse(
+                f"{TARGET.database}.{target}",
+                engine="MergeTree()", order_by="city",
+                host=TARGET.host, user=TARGET.user, password=TARGET.password,
+            )
+            ds.filter(ds["status"] == "completed").to_clickhouse(
+                f"{TARGET.database}.{target}",
+                if_exists="replace",
+                engine="MergeTree()", order_by="city",
+                host=TARGET.host, user=TARGET.user, password=TARGET.password,
+            )
+            assert _count(target, db=TARGET.database, srv=TARGET) == 5
+        finally:
+            self._drop_target(target)
+
+    def test_replace_dataframe_path_refuses_existing_target(self, source_table):
+        target = "wb_cs_replace_df_existing"
+        self._drop_target(target)
+        try:
+            _ddl(
+                f'CREATE TABLE "{TARGET.database}"."{target}" (a Int64) '
+                f"ENGINE = MergeTree() ORDER BY a", srv=TARGET,
+            )
+            ds = _make_ds(source_table)
+            with pytest.raises(QueryError, match="Cannot atomically replace"):
+                (ds.transform(lambda df: df.assign(extra=1))
+                 ).to_clickhouse(
+                    f"{TARGET.database}.{target}",
+                    if_exists="replace",
+                    engine="MergeTree()", order_by="city",
+                    host=TARGET.host, user=TARGET.user,
+                    password=TARGET.password,
+                )
+        finally:
+            self._drop_target(target)
+
+    def test_append_cross_server(self, source_table):
+        target = "wb_cs_append"
+        self._drop_target(target)
+        try:
+            ds = _make_ds(source_table)
+            ds.to_clickhouse(
+                f"{TARGET.database}.{target}",
+                engine="MergeTree()", order_by="city",
+                host=TARGET.host, user=TARGET.user, password=TARGET.password,
+            )
+            ds.to_clickhouse(
+                f"{TARGET.database}.{target}",
+                if_exists="append",
+                host=TARGET.host, user=TARGET.user, password=TARGET.password,
+            )
+            assert _count(target, db=TARGET.database, srv=TARGET) == 14
+        finally:
+            self._drop_target(target)
+
+    def test_dataframe_path_cross_server(self, source_table):
+        """Pandas-only pipeline + cross-server target → DataFrame is uploaded
+        directly to the target."""
+        target = "wb_cs_df_upload"
+        self._drop_target(target)
+        try:
+            ds = _make_ds(source_table)
+            (ds.transform(lambda df:
+                          df.assign(amount_doubled=df["amount"] * 2))
+             ).to_clickhouse(
+                f"{TARGET.database}.{target}",
+                engine="MergeTree()", order_by="city",
+                host=TARGET.host, user=TARGET.user, password=TARGET.password,
+            )
+            cols = dict(_columns(target, db=TARGET.database, srv=TARGET))
+            assert "amount_doubled" in cols
+            assert _count(target, db=TARGET.database, srv=TARGET) == 7
+        finally:
+            self._drop_target(target)
+
+
+@requires_target
+class TestCrossServerCreateView:
+    @pytest.fixture(autouse=True)
+    def _check_target(self):
+        try:
+            _q(
+                f"SELECT 1 FROM remote('{TARGET.host}', 'system', 'one', "
+                f"'{TARGET.user}', '{TARGET.password}')"
+            )
+        except Exception as e:
+            pytest.skip(f"Target ClickHouse unreachable: {e}")
+
+    def test_view_lives_on_target_server(self, source_table):
+        view = "wb_cs_view"
+        _drop_view(view, db=TARGET.database, srv=TARGET)
+        try:
+            ds = _make_ds(source_table)
+            ds.filter(ds["status"] == "completed").create_view(
+                f"{TARGET.database}.{view}",
+                host=TARGET.host, user=TARGET.user, password=TARGET.password,
+            )
+            assert _count(view, db=TARGET.database, srv=TARGET) == 5
+            # View must NOT exist on the source server.
+            assert _count_or_zero(view, db=DATABASE, srv=SOURCE) == 0
+        finally:
+            _drop_view(view, db=TARGET.database, srv=TARGET)
+
+
+@requires_target
+class TestCrossServerCreateMaterializedView:
+    @pytest.fixture(autouse=True)
+    def _check_target(self):
+        try:
+            _q(
+                f"SELECT 1 FROM remote('{TARGET.host}', 'system', 'one', "
+                f"'{TARGET.user}', '{TARGET.password}')"
+            )
+        except Exception as e:
+            pytest.skip(f"Target ClickHouse unreachable: {e}")
+
+    def test_cross_server_mv_rejected_by_clickhouse(self, source_table):
+        """Cross-server MV is conceptually broken: an MV is triggered by
+        INSERTs on its source table, but if the source lives on another
+        server the trigger never fires. ClickHouse itself rejects this with
+        ``QUERY_IS_NOT_SUPPORTED_IN_MATERIALIZED_VIEW`` because MV's SELECT
+        cannot reference a ``remote()`` table function. We just propagate
+        that error so the user gets a deterministic failure rather than a
+        silently dead MV."""
+        mv, target = "wb_cs_mv_rejected", "wb_cs_mv_rejected_tgt"
+        _drop_view(mv, db=TARGET.database, srv=TARGET)
+        _drop(target, db=TARGET.database, srv=TARGET)
+        try:
+            with pytest.raises(
+                ExecutionError,
+                match=r"QUERY_IS_NOT_SUPPORTED_IN_MATERIALIZED_VIEW",
+            ):
+                _make_ds(source_table).create_materialized_view(
+                    name=f"{TARGET.database}.{mv}",
+                    to=f"{TARGET.database}.{target}",
+                    engine="MergeTree()", order_by="city",
+                    host=TARGET.host, user=TARGET.user,
+                    password=TARGET.password,
+                )
+        finally:
+            _drop_view(mv, db=TARGET.database, srv=TARGET)
+            _drop(target, db=TARGET.database, srv=TARGET)
+
+
+# ---------------------------------------------------------------------------
+# Helper used only by cross-server tests — silently returns 0 if the table
+# doesn't exist (we use this to assert *absence* on the wrong server).
+# ---------------------------------------------------------------------------
+
+
+def _count_or_zero(table: str, db: str, srv: _Server) -> int:
+    try:
+        return _count(table, db=db, srv=srv)
+    except Exception:
+        return 0


### PR DESCRIPTION
Closes #560

Add writeback APIs to DataStore for writing data back to a remote ClickHouse server.

## Changes

- `save()` — unified entry point
- `to_clickhouse()` — write data to a remote table (`fail` / `replace` / `append`)
- `create_view()` / `create_materialized_view()` — create views on remote server
- DataFrame upload fallback for Pandas-only pipelines