### PR TITLE
Fix reading Parquet files from S3

### DIFF
--- a/datastore/pandas_api.py
+++ b/datastore/pandas_api.py
@@ -406,6 +406,8 @@ def read_parquet(path, columns=None, **kwargs) -> "DataStoreType":
     if needs_pandas:
         pandas_df = pd.read_parquet(path, columns=columns, **kwargs)
         return DataStore.from_df(pandas_df)
+    elif isinstance(path, str) and path.startswith("s3://"):
+        return DataStore.from_s3(path, format="Parquet")
     else:
         # Use chDB SQL engine
         return DataStore.from_file(path, format="Parquet")

--- a/datastore/table_functions.py
+++ b/datastore/table_functions.py
@@ -171,7 +171,7 @@ class FileTableFunction(TableFunction):
         Returns:
             True if row order is guaranteed to be preserved
         """
-        format_name = self.params.get("format", "").lower()
+        format_name = (self.params.get("format") or "").lower()
 
         # For Parquet files, check if preserve_order setting is enabled
         if format_name == "parquet":
@@ -331,7 +331,7 @@ class S3TableFunction(TableFunction):
         Returns:
             True if row order is guaranteed to be preserved
         """
-        format_name = self.params.get("format", "").lower()
+        format_name = (self.params.get("format") or "").lower()
 
         if format_name == "parquet":
             if format_settings:

--- a/datastore/tests/test_s3_and_parquet_fixes.py
+++ b/datastore/tests/test_s3_and_parquet_fixes.py
@@ -1,0 +1,100 @@
+"""
+Tests for fixes to None format handling and read_parquet S3 support.
+
+Regression tests for:
+- DataStore.from_s3() without explicit format crashing with 'NoneType' has no attr 'lower'
+- DataStore.from_file() without explicit format crashing with 'NoneType' has no attr 'lower'
+- read_parquet('s3://...') routing to S3 table function
+"""
+
+import pytest
+import pandas as pd
+import numpy as np
+from datastore import DataStore, read_parquet
+from datastore.table_functions import S3TableFunction, FileTableFunction
+
+
+@pytest.fixture
+def sample_df():
+    return pd.DataFrame({
+        'id': [1, 2, 3, 4, 5],
+        'name': ['Alice', 'Bob', 'Charlie', 'Diana', 'Eve'],
+        'value': [10, 20, 30, 40, 50],
+    })
+
+
+@pytest.fixture
+def parquet_file(sample_df, tmp_path):
+    path = tmp_path / "test_data.parquet"
+    sample_df.to_parquet(path, index=False)
+    return str(path)
+
+
+class TestPreservesRowOrderNoneFormat:
+    """
+    preserves_row_order() crashed with 'NoneType' has no attribute 'lower'
+    when format=None was stored in params (dict.get("format", "") returns None
+    when the key exists with value None, not the default "").
+    """
+
+    def test_s3_table_function_preserves_row_order_no_format(self):
+        """S3TableFunction.preserves_row_order() must not crash when format is None."""
+        tf = S3TableFunction(url="s3://bucket/data.parquet", nosign=True)
+        # format key exists with value None in params
+        assert tf.params.get("format") is None
+        # must not raise
+        result = tf.preserves_row_order()
+        assert isinstance(result, bool)
+
+    def test_file_table_function_preserves_row_order_no_format(self):
+        """FileTableFunction.preserves_row_order() must not crash when format is None."""
+        tf = FileTableFunction(path="/some/file.parquet", format=None)
+        assert tf.params.get("format") is None
+        result = tf.preserves_row_order()
+        assert isinstance(result, bool)
+
+    def test_from_s3_no_format_does_not_crash(self):
+        """DataStore.from_s3() without format must not crash on creation."""
+        ds = DataStore.from_s3("s3://bucket/data.parquet", nosign=True)
+        assert ds is not None
+        assert ds.source_type == "s3"
+        assert ds._table_function is not None
+        assert ds._table_function.params.get("format") is None
+
+    def test_from_file_no_format_does_not_crash(self, parquet_file):
+        """DataStore.from_file() without format must not crash on creation."""
+        ds = DataStore.from_file(parquet_file)
+        assert ds is not None
+        assert ds._table_function is not None
+
+    def test_from_file_no_format_reads_data(self, parquet_file, sample_df):
+        """DataStore.from_file() without format must correctly read parquet data."""
+        ds = DataStore.from_file(parquet_file)
+        pd_result = sample_df
+
+        assert list(ds.columns) == list(pd_result.columns)
+        assert len(ds) == len(pd_result)
+
+
+class TestReadParquetS3:
+    """read_parquet('s3://...') must route to S3 table function, not from_file."""
+
+    def test_read_parquet_s3_url_creates_s3_datastore(self):
+        """read_parquet with s3:// path must create an S3-backed DataStore."""
+        ds = read_parquet("s3://bucket/data.parquet")
+        assert ds is not None
+        assert ds.source_type == "s3"
+        assert isinstance(ds._table_function, S3TableFunction)
+
+    def test_read_parquet_s3_url_sets_parquet_format(self):
+        """read_parquet with s3:// path must pass format=Parquet to the table function."""
+        ds = read_parquet("s3://bucket/data.parquet")
+        assert ds._table_function.params.get("format") == "Parquet"
+
+    def test_read_parquet_local_file_reads_data(self, parquet_file, sample_df):
+        """read_parquet with a local file path must correctly read data."""
+        ds = read_parquet(parquet_file)
+        pd_result = sample_df
+
+        assert list(ds.columns) == list(pd_result.columns)
+        assert len(ds) == len(pd_result)


### PR DESCRIPTION
## Summary

Two fixes to enable reading Parquet files from S3.

### 1. `read_parquet` doesn't work with S3 URLs

```python
In [2]: pd.read_parquet('s3://datasets-documentation/amazon_reviews/amazon_reviews_2015.snappy.parquet')
Out[2]: E [chDB] Query failed: Code: 400. DB::ErrnoException: Cannot stat file /Users/markhneedham/projects/videos/20241029-chdbPandas/s3:/datasets-documentation/amazon_reviews/amazon_reviews_2015.snappy.parquet: , errno: 2, strerror: No such file or directory: The table structure cannot be extracted from a Parquet format file. You can specify the structure manually: (in file/uri /Users/markhneedham/projects/videos/20241029-chdbPandas/s3:/datasets-documentation/amazon_reviews/amazon_reviews_2015.snappy.parquet). (CANNOT_STAT)
...
SQL: DESCRIBE file('s3://datasets-documentation/amazon_reviews/amazon_reviews_2015.snappy.parquet', 'Parquet')
```

`s3://` paths were being routed to `from_file()`, which treats them as local paths. Fixed by routing `s3://` paths in `read_parquet()` to `DataStore.from_s3()` instead.

### 2. `DataStore.from_s3()` crashes without an explicit format

```python
In [3]: pd.DataStore.from_s3('s3://datasets-documentation/amazon_reviews/amazon_reviews_2015.snappy.parquet', nosign=True)
Out[3]: DataStore(execution failed: 'NoneType' object has no attribute 'lower')
```

**Root cause:** `from_s3()` stores `{"format": None}` in table function params when no format is specified. `dict.get("format", "")` returns `None` (not `""`) when the key exists with value `None` — the default only applies when the key is absent entirely. `None.lower()` then crashes in `preserves_row_order()`.

Fixed by using `(self.params.get("format") or "").lower()` in both `FileTableFunction` and `S3TableFunction`.

## Changes

- **`datastore/pandas_api.py`**: Route `s3://` paths in `read_parquet()` to `DataStore.from_s3()`
- **`datastore/table_functions.py`**: Fix `None.lower()` crash in `FileTableFunction.preserves_row_order()` and `S3TableFunction.preserves_row_order()`

## Test plan

- [ ] `read_parquet("s3://...")` routes to S3 table function instead of crashing
- [ ] `DataStore.from_s3("s3://...", nosign=True)` no longer raises `'NoneType' object has no attribute 'lower'`
- [ ] `DataStore.from_file("data.parquet")` with no explicit format still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)