### PR TITLE
Fix pre-load _chdb.abi3.so with RTLD_DEEPBIND to avoid host libstdc++ conflicts

### DIFF
--- a/.github/workflows/build_linux_arm64_wheels-gh.yml
+++ b/.github/workflows/build_linux_arm64_wheels-gh.yml
@@ -117,7 +117,7 @@ jobs:
 
               pyenv shell $version
               python -m pip install dist/*.whl --force-reinstall
-              python -m pip install pytest pytest-cov "$PANDAS_CONSTRAINT"
+              python -m pip install pytest pytest-cov ray "$PANDAS_CONSTRAINT"
               echo "Installed pandas version:"
               python -c "import pandas; print(pandas.__version__)"
 

--- a/.github/workflows/build_linux_x86_wheels.yml
+++ b/.github/workflows/build_linux_x86_wheels.yml
@@ -140,7 +140,7 @@ jobs:
 
               pyenv shell $version
               python -m pip install dist/*.whl --force-reinstall
-              python -m pip install pytest pytest-cov "$PANDAS_CONSTRAINT"
+              python -m pip install pytest pytest-cov ray "$PANDAS_CONSTRAINT"
               echo "Installed pandas version:"
               python -c "import pandas; print(pandas.__version__)"
 

--- a/chdb/__init__.py
+++ b/chdb/__init__.py
@@ -52,9 +52,25 @@ try:
 except Exception:
     core_version = "unknown"
 
+def _preload_chdb_with_deepbind():
+    if sys.platform != "linux":
+        return
+    import ctypes
+    _RTLD_DEEPBIND = 0x00008
+    for candidate_dir in [_this_dir] + [p for p in __path__ if p != _this_dir]:
+        _abi3 = os.path.join(candidate_dir, "_chdb.abi3.so")
+        if os.path.exists(_abi3):
+            try:
+                ctypes.CDLL(_abi3, mode=sys.getdlopenflags() | _RTLD_DEEPBIND)
+            except OSError:
+                pass
+            return
+
+
 if sys.version_info[:2] >= (3, 7):
     cwd = os.getcwd()
     os.chdir(_this_dir)
+    _preload_chdb_with_deepbind()
     try:
         from . import _chdb  # noqa
     except ImportError:

--- a/datastore/tests/test_import_crossstl_isolation.py
+++ b/datastore/tests/test_import_crossstl_isolation.py
@@ -1,0 +1,62 @@
+import subprocess
+import sys
+import textwrap
+import unittest
+
+
+def _run(snippet, timeout=60):
+    proc = subprocess.run(
+        [sys.executable, "-c", textwrap.dedent(snippet)],
+        capture_output=True,
+        text=True,
+        timeout=timeout,
+        cwd="/tmp",
+    )
+    return proc.returncode, (proc.stdout or "") + (proc.stderr or "")
+
+
+def _ray_available():
+    try:
+        import ray  # noqa
+        return True
+    except ImportError:
+        return False
+
+
+@unittest.skipUnless(sys.platform.startswith("linux"), "Linux-only")
+@unittest.skipUnless(_ray_available(), "ray not installed")
+class TestImportCrossStlIsolation(unittest.TestCase):
+
+    def test_import_ray_then_chdb_does_not_crash(self):
+        rc, out = _run("""
+            import ray  # noqa
+            import chdb  # noqa
+            print('ok')
+        """)
+        self.assertEqual(rc, 0, f"exit {rc}, output:\n{out}")
+        self.assertIn("ok", out)
+        self.assertNotEqual(rc, 134, f"SIGABRT, output:\n{out}")
+
+    def test_import_chdb_then_ray_does_not_crash(self):
+        rc, out = _run("""
+            import chdb  # noqa
+            import ray  # noqa
+            print('ok')
+        """)
+        self.assertEqual(rc, 0, f"exit {rc}, output:\n{out}")
+        self.assertIn("ok", out)
+
+    def test_query_after_ray_first_import_returns_correct_value(self):
+        rc, out = _run("""
+            import ray  # noqa
+            import chdb
+            r = chdb.query('SELECT 1+1 AS x', 'CSV')
+            print('result:', str(r).strip())
+        """)
+        self.assertEqual(rc, 0, f"exit {rc}, output:\n{out}")
+        self.assertIn("result:", out)
+        self.assertIn("2", out, f"unexpected output:\n{out}")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Fixes #571.

`import ray; import chdb` on Linux + Python 3.11/3.12 aborts with `free(): invalid pointer` because the chdb wrapper's `__init__.py` overwrites chdb-core's at install time and drops the `RTLD_DEEPBIND` preload. This PR restores it here.

## Changes

- `chdb/__init__.py`: add `_preload_chdb_with_deepbind()`, invoked before `from . import _chdb`.
- `datastore/tests/test_import_crossstl_isolation.py`: 3 subprocess-based regression tests (`import ray; import chdb`, reverse order, and a query smoke check).
- `.github/workflows/build_linux_{x86,arm64}_wheels*.yml`: install `ray` so the new tests aren't silently skipped.

## Verification

Locally on Python 3.12 + chdb-core 26.3.0 + ray 2.55.1, Linux x86_64:
- Pre-fix: `exit 134` / `free(): invalid pointer`.
- Post-fix: all three orders (`ray;chdb`, `chdb;ray`, `ray;chdb+query`) exit 0, query returns the expected value.
- Sanity check: temporarily reverting the preload call makes the new tests fail with SIGABRT, confirming they catch the bug.