### PR TITLE
Fix explain() mislabeling pushed-down GroupBy/apply as Pandas

### DIFF
--- a/datastore/lazy_ops.py
+++ b/datastore/lazy_ops.py
@@ -1184,8 +1184,14 @@ class LazyGroupByAgg(LazyOp):
         return True
 
     def execution_engine(self) -> str:
-        """Return which engine this operation should use."""
-        return "SQL"
+        """Return which engine this operation should use.
+
+        Returns 'chDB' when the aggregation can be pushed down to SQL,
+        otherwise 'Pandas'. Returning the canonical literal lets
+        DataStore.explain() label this op consistently with the segment
+        it lives in.
+        """
+        return "chDB" if self.can_push_to_sql() else "Pandas"
 
 
 class LazyDataFrameSource(LazyOp):
@@ -1683,9 +1689,15 @@ class LazyApply(LazyOp):
         return self._is_simple_agg
 
     def execution_engine(self) -> str:
-        """Return which engine this operation should use."""
+        """Return which engine this operation should use.
+
+        Returns the canonical 'chDB' / 'Pandas' literal so that
+        DataStore.explain() can label this op consistently with the
+        segment it lives in. Returning 'SQL' here previously caused
+        pushed-down apply() ops to be mislabeled as Pandas in the plan.
+        """
         if self.can_push_to_sql():
-            return "SQL"
+            return "chDB"
         return "Pandas"
 
 

--- a/datastore/tests/test_explain_method.py
+++ b/datastore/tests/test_explain_method.py
@@ -389,5 +389,144 @@ class TestExplainMethod(unittest.TestCase):
         self.assertLess(order_pos, limit_pos, "sort should come before limit")
 
 
+class TestExplainEngineLabelingForPushedOps(unittest.TestCase):
+    """Regression tests: ops pushed into a chDB segment must be labeled [chDB] in explain().
+
+    These tests pin down a previous bug where LazyGroupByAgg.execution_engine() and
+    LazyApply.execution_engine() returned the non-canonical literal 'SQL'. The
+    explain() renderer only recognizes 'chDB'/'Pandas', so 'SQL' silently fell into
+    the Pandas branch and the GroupBy/apply lines were rendered as 🐼 [Pandas] even
+    though the segment header said [chDB] and the generated SQL clearly contained
+    GROUP BY pushed to chDB.
+    """
+
+    def setUp(self):
+        self.temp_dir = tempfile.mkdtemp()
+        self.parquet_file = os.path.join(self.temp_dir, "amazon_sample.parquet")
+
+        import pandas as pd
+        pd.DataFrame({
+            'product_category': ['A', 'B', 'A', 'B', 'C'] * 10,
+            'star_rating': [5, 4, 3, 5, 2] * 10,
+            'verified_purchase': [True, False, True, True, True] * 10,
+        }).to_parquet(self.parquet_file)
+
+    def tearDown(self):
+        if os.path.exists(self.parquet_file):
+            os.unlink(self.parquet_file)
+        if os.path.exists(self.temp_dir):
+            os.rmdir(self.temp_dir)
+
+    def _extract_op_line(self, output: str, op_number: int) -> str:
+        """Return the single explain() line beginning with ' [<op_number>] '."""
+        prefix = f" [{op_number}]"
+        for line in output.splitlines():
+            if line.startswith(prefix):
+                return line
+        raise AssertionError(
+            f"Could not find op [{op_number}] line in explain output:\n{output}"
+        )
+
+    def test_explain_labels_pushable_groupby_agg_dict_list_as_chdb(self):
+        """Mirrors the user-reported scenario: agg({'col': ['mean', 'count']}).
+
+        The GroupBy is pushed to chDB (GROUP BY appears in the generated SQL),
+        so explain() must label that op as [chDB], not [Pandas].
+        """
+        ds = DataStore.from_file(self.parquet_file)
+        res = (
+            ds[ds['verified_purchase'] == True]
+            .groupby('product_category')
+            .agg({'star_rating': ['mean', 'count']})
+        )
+
+        output = _capture_explain(res)
+
+        # Segment header must say chDB from source
+        self.assertIn("Segment 1 [chDB] (from source)", output)
+
+        # The GroupBy op line must be labeled chDB, not Pandas
+        groupby_line = next(
+            line for line in output.splitlines() if "GroupBy(" in line
+        )
+        self.assertIn("[chDB]", groupby_line)
+        self.assertNotIn("[Pandas]", groupby_line)
+
+        # Sanity: GROUP BY must actually appear in the pushed-down SQL
+        self.assertIn("GROUP BY", output)
+
+    def test_explain_labels_pushable_groupby_agg_func_as_chdb(self):
+        """Simple groupby('col').mean() must also render as [chDB]."""
+        ds = DataStore.from_file(self.parquet_file)
+        res = ds.groupby('product_category').mean()
+
+        output = _capture_explain(res)
+
+        groupby_line = next(
+            line for line in output.splitlines() if "GroupBy(" in line
+        )
+        self.assertIn("[chDB]", groupby_line)
+        self.assertNotIn("[Pandas]", groupby_line)
+        self.assertIn("GROUP BY", output)
+
+    def test_explain_labels_non_pushable_groupby_agg_list_as_pandas(self):
+        """When agg_dict is itself a list (not a dict-of-lists), it cannot be
+        pushed to chDB, so the GroupBy op line must render as [Pandas]."""
+        from datastore.lazy_ops import LazyGroupByAgg
+        ds = DataStore.from_file(self.parquet_file)
+
+        op = LazyGroupByAgg(
+            groupby_cols=['product_category'],
+            agg_dict=['sum', 'mean'],  # list, not dict -> cannot push
+        )
+        self.assertFalse(op.can_push_to_sql())
+        self.assertEqual(op.execution_engine(), 'Pandas')
+
+    def test_explain_labels_pushable_apply_as_chdb(self):
+        """groupby().apply(lambda x: x.sum()) is detected as a simple aggregation
+        and pushed to chDB, so explain() must label that op as [chDB]."""
+        ds = DataStore.from_file(self.parquet_file)
+        res = ds.groupby('product_category').apply(lambda x: x.sum())
+
+        output = _capture_explain(res)
+
+        apply_line = next(
+            (line for line in output.splitlines() if "apply" in line.lower()),
+            None,
+        )
+        if apply_line is not None:
+            self.assertIn("[chDB]", apply_line)
+            self.assertNotIn("[Pandas]", apply_line)
+
+    def test_lazy_groupby_agg_execution_engine_returns_canonical_literal(self):
+        """Direct unit test: LazyGroupByAgg.execution_engine() must return the
+        canonical 'chDB'/'Pandas' literal that explain() understands.
+
+        Returning 'SQL' here previously caused explain() to mislabel pushed-down
+        GroupBy ops as Pandas.
+        """
+        from datastore.lazy_ops import LazyGroupByAgg
+
+        pushable = LazyGroupByAgg(
+            groupby_cols=['product_category'], agg_func='mean'
+        )
+        self.assertTrue(pushable.can_push_to_sql())
+        self.assertEqual(pushable.execution_engine(), 'chDB')
+
+        pushable_dict = LazyGroupByAgg(
+            groupby_cols=['product_category'],
+            agg_dict={'star_rating': ['mean', 'count']},
+        )
+        self.assertTrue(pushable_dict.can_push_to_sql())
+        self.assertEqual(pushable_dict.execution_engine(), 'chDB')
+
+        non_pushable = LazyGroupByAgg(
+            groupby_cols=['product_category'],
+            agg_dict=['sum', 'mean'],
+        )
+        self.assertFalse(non_pushable.can_push_to_sql())
+        self.assertEqual(non_pushable.execution_engine(), 'Pandas')
+
+
 if __name__ == '__main__':
     unittest.main()

--- a/datastore/tests/test_groupby_apply_sql_pushdown.py
+++ b/datastore/tests/test_groupby_apply_sql_pushdown.py
@@ -129,7 +129,7 @@ class TestLazyApplySQLPushdown(unittest.TestCase):
         """Test that simple aggregation can be pushed to SQL."""
         apply = LazyApply(lambda x: x.sum(), groupby_cols=['category'])
         self.assertTrue(apply.can_push_to_sql())
-        self.assertEqual(apply.execution_engine(), 'SQL')
+        self.assertEqual(apply.execution_engine(), 'chDB')
         self.assertEqual(apply.get_detected_agg_func(), 'sum')
 
     def test_cannot_push_without_groupby(self):
@@ -380,9 +380,9 @@ class TestGroupByApplySQLVerification(unittest.TestCase):
 
         logs = self.get_logs()
 
-        # Verify the LazyApply indicates SQL engine
+        # Verify the LazyApply indicates chDB engine (canonical literal used by explain())
         apply = LazyApply(lambda x: x.sum(), groupby_cols=['category'])
-        self.assertEqual(apply.execution_engine(), 'SQL', "Simple sum aggregation should use SQL engine")
+        self.assertEqual(apply.execution_engine(), 'chDB', "Simple sum aggregation should use chDB engine")
 
     def test_pandas_fallback_for_complex(self):
         """Verify Pandas is used for complex aggregations."""


### PR DESCRIPTION
## Summary

`DataStore.explain()` was labeling `GroupBy` / `groupby().apply()` ops as 🐼 `[Pandas]` even when they were clearly pushed down to chDB — the segment header said `[chDB]` and the generated SQL contained `GROUP BY`, but the per-op line lied.

### Root cause

The base `LazyOp.execution_engine()` contract (`lazy_ops.py:113-126`) requires returning the canonical literals `"chDB"` or `"Pandas"`. `DataStore.explain()` (`core.py:801-816`) only branches on `"chDB"`; anything else falls into the Pandas branch.

Two implementations returned the non-canonical literal `"SQL"`:
- `LazyGroupByAgg.execution_engine()` always returned `"SQL"`.
- `LazyApply.execution_engine()` returned `"SQL"` in its pushable branch.

So pushed-down GroupBy and apply ops silently rendered as Pandas. Display-only bug — execution path was unaffected; no consumer was matching on `"SQL"`.

### Reproduction (before fix)

```python
ds = DataStore.from_file('amazon_sample.parquet')
res = (
    ds[ds['verified_purchase'] == True]
    .groupby('product_category')
    .agg({'star_rating': ['mean', 'count']})
)
res.explain()
```

Before:

```
    Segment 1 [chDB] (from source): Operations 2-5
 [2] 🚀 [chDB] WHERE: "verified_purchase" = TRUE
 [3] 🐼 [Pandas] GroupBy(['product_category']).{'star_rating': ['mean', 'count']}()   <-- wrong
 ...
SELECT "product_category", avg("star_rating") AS "mean", ...
  FROM file('amazon_sample.parquet', 'Parquet') WHERE ... GROUP BY ...                <-- chDB!
```

After:

```
    Segment 1 [chDB] (from source): Operations 2-3
 [2] 🚀 [chDB] WHERE: "verified_purchase" = TRUE
 [3] 🚀 [chDB] GroupBy(['product_category']).{'star_rating': ['mean', 'count']}()
```

### Changes

- `datastore/lazy_ops.py`: `LazyGroupByAgg.execution_engine()` and `LazyApply.execution_engine()` now return `"chDB"` / `"Pandas"` based on `can_push_to_sql()`.
- `datastore/tests/test_groupby_apply_sql_pushdown.py`: two existing assertions had baked in the buggy `"SQL"` literal — updated to `"chDB"`.
- `datastore/tests/test_explain_method.py`: new `TestExplainEngineLabelingForPushedOps` class with 5 regression tests covering the original user scenario (agg dict-of-list), simple `.mean()` agg, the non-pushable case (must stay Pandas), `groupby().apply(sum)` pushdown, and a direct unit test on the canonical-literal contract.

## Test plan

- [x] `pytest datastore/tests/test_explain_method.py` — 22 passed
- [x] `pytest datastore/tests/test_groupby_apply_sql_pushdown.py` — 28 passed
- [x] `pytest test_explain_segmented_execution.py test_comprehensive_segmented_execution.py test_sql_vs_pandas_filter.py test_lazy_chain_engine_verification.py test_lazy_execution.py test_case_when.py test_nullable_sql_pushdown.py` — 203 passed, 1 xfailed (pre-existing, unrelated)
- [x] Manually verified the original user scenario now labels GroupBy as `[chDB]`.