### PR TITLE
Unify SQL builder behind a single _build_layer dispatcher

### DIFF
--- a/datastore/core.py
+++ b/datastore/core.py
@@ -1776,14 +1776,26 @@ class DataStore(PandasCompatMixin):
 
         from .query_planner import QueryPlanner
 
-        # Use QueryPlanner to analyze lazy operations (same logic as _execute)
+        # Use QueryPlanner segmented planning (same as _execute). For the
+        # single-source-SQL-segment case used by explain()/to_sql() we take
+        # the plan from the first SQL segment. When the whole chain is
+        # Pandas-only (e.g. ORDER BY without LIMIT under the cost-aware
+        # planner), fall back to the traditional ``SELECT * FROM source``
+        # generation - that is the SQL the executor would issue to fetch
+        # rows before handing off to Pandas.
         planner = QueryPlanner()
         schema = self._schema or {}
-        plan = planner.plan(self._lazy_ops, has_sql_source=True, schema=schema)
+        exec_plan = planner.plan_segments(
+            self._lazy_ops, has_sql_source=True, schema=schema
+        )
+        sql_segment = next(
+            (seg for seg in exec_plan.segments if seg.is_sql() and seg.plan), None
+        )
+        if sql_segment is None:
+            return self._generate_select_sql(self.quote_char)
 
-        # Use SQLExecutionEngine to build SQL from plan
         sql_engine = SQLExecutionEngine(self)
-        result = sql_engine.build_sql_from_plan(plan, schema)
+        result = sql_engine.build_sql_from_plan(sql_segment.plan, schema)
         return result.sql
 
     def _get_table_source(self) -> str:

--- a/datastore/query_planner.py
+++ b/datastore/query_planner.py
@@ -51,36 +51,69 @@ from .sql_executor import CaseWhenExpr, WhereMaskCaseExpr
 @dataclass
 class QueryPlan:
     """
-    Intermediate representation of an execution plan.
+    Intermediate representation of one SQL segment's execution plan.
 
-    This separates operations into SQL-pushable and Pandas-only phases,
-    and captures optimization opportunities like GroupBy SQL pushdown.
+    Produced by :meth:`QueryPlanner.plan_segments` (one ``QueryPlan`` per SQL
+    ``ExecutionSegment``). The SQL build pipeline (``build_sql_from_plan``
+    in :mod:`sql_executor`) consumes a ``QueryPlan`` and produces SQL by
+    chaining :meth:`SQLExecutionEngine._build_layer` over the plan's
+    ``layers``.
+
+    Data flow:
+
+    1. The planner segments lazy ops into SQL / Pandas / SQL / ... segments.
+    2. For each SQL segment, ``_create_segment`` builds a ``QueryPlan``
+       whose ``layers`` contain the FULL op list (including
+       ``LazyGroupByAgg``, ``LazyWhere``, ``LazyMask``, pushable
+       ``LazyApply``) per nested-subquery layer.
+    3. ``build_sql_from_plan`` runs ``_build_layered_sql`` which calls
+       ``_build_layer`` per layer; each layer dispatches by op type.
+    4. Any temp aliases the SQL builders introduce
+       (``temp_alias -> original_alias``) are recorded in
+       ``alias_renames``. After execution the post-processing step in
+       ``core.py`` reads ``alias_renames`` and renames the result
+       DataFrame columns back to the user-visible names.
 
     Attributes:
-        sql_ops: Operations that can be executed via SQL
-        df_ops: Operations that require Pandas execution
-        groupby_agg: Optional GroupBy aggregation that can be pushed to SQL
-        where_ops: List of LazyWhere/LazyMask operations that can be pushed to SQL
-        layers: Nested subquery layers (for LIMIT-before-WHERE patterns)
-        has_sql_source: Whether there's a SQL-compatible data source
-        first_df_op_idx: Index of first DataFrame-only operation in original chain
-        where_columns: Column names referenced in WHERE conditions (for conflict detection)
-        alias_renames: Dict mapping temp alias -> original alias (for conflict resolution)
+        sql_ops: Relational + column-assignment ops in the segment, with
+            special ops (``LazyGroupByAgg``, ``LazyWhere``, ``LazyMask``,
+            pushable ``LazyApply``) excluded. Kept for legacy helpers
+            (``_build_sql_with_builder``, ``_check_limit_before_where``)
+            that only know how to iterate WHERE/ORDER BY/LIMIT/OFFSET/
+            SELECT/ColumnAssignment.
+        df_ops: Operations that require Pandas execution (only used by the
+            removed ``plan()`` method; segmented planning splits these
+            into separate Pandas ``ExecutionSegment``s instead).
+        groupby_agg: Convenience pointer to the (single) ``LazyGroupByAgg``
+            in ``layers`` (or one synthesized from a pushable
+            ``LazyApply``). Read by post-execution code for set_index,
+            MultiIndex conversion, dtype corrections.
+        where_ops: Convenience list of ``LazyWhere``/``LazyMask`` ops in
+            ``layers``. Read by ``_build_sql_for_dataframe`` for CASE
+            WHEN temp alias mapping.
+        layers: Canonical input for SQL building. Each entry is a layer's
+            op list; layer 0 reads from the table source, layers 1+ read
+            from ``(inner_sql) AS __subqN__``.
+        has_sql_source: Whether the segment has a SQL-compatible source.
+        first_df_op_idx: Vestigial - was set by the removed ``plan()``
+            method. Always ``None`` from segmented planning.
+        where_columns: Source-column names referenced in pre-aggregation
+            WHEREs. Drives the planner's source-col / agg-alias conflict
+            detection (which pre-populates ``alias_renames``).
+        alias_renames: Map ``temp_alias -> original_alias``. Written
+            during SQL building, consumed at post-execution to rename
+            result DataFrame columns back to user-visible names.
     """
 
     sql_ops: List[LazyOp] = field(default_factory=list)
     df_ops: List[LazyOp] = field(default_factory=list)
     groupby_agg: Optional[LazyGroupByAgg] = None
-    where_ops: List[LazyOp] = field(
-        default_factory=list
-    )  # LazyWhere/LazyMask for SQL CASE WHEN
+    where_ops: List[LazyOp] = field(default_factory=list)
     layers: List[List[LazyOp]] = field(default_factory=list)
     has_sql_source: bool = False
     first_df_op_idx: Optional[int] = None
     where_columns: Set[str] = field(default_factory=set)
-    alias_renames: Dict[str, str] = field(
-        default_factory=dict
-    )  # temp_alias -> original_alias
+    alias_renames: Dict[str, str] = field(default_factory=dict)
 
     def has_two_phases(self) -> bool:
         """Check if execution requires both SQL and DataFrame phases."""
@@ -93,7 +126,7 @@ class QueryPlan:
     def describe(self) -> str:
         """Return a human-readable description of the plan."""
         lines = []
-        lines.append(f"QueryPlan:")
+        lines.append("QueryPlan:")
         lines.append(f"  SQL source: {self.has_sql_source}")
         lines.append(f"  SQL ops: {len(self.sql_ops)}")
         lines.append(f"  DataFrame ops: {len(self.df_ops)}")
@@ -205,89 +238,67 @@ class QueryPlanner:
     def __init__(self):
         self._logger = get_logger()
 
-    def plan(
-        self,
-        lazy_ops: List[LazyOp],
-        has_sql_source: bool,
-        schema: Dict[str, str] = None,
-    ) -> QueryPlan:
-        """
-        Analyze LazyOp chain and produce an execution plan.
-
-        Args:
-            lazy_ops: List of lazy operations to analyze
-            has_sql_source: Whether there's a SQL-compatible data source
-                           (table_function or table_name)
-            schema: Optional dict mapping column names to types (for type-aware SQL pushdown)
-
-        Returns:
-            QueryPlan with optimized execution strategy
-        """
-        plan = QueryPlan(has_sql_source=has_sql_source)
-
-        if not lazy_ops:
-            return plan
-
-        # Collect WHERE column names for alias conflict detection
-        plan.where_columns = self._collect_where_columns(lazy_ops)
-
-        # Find the SQL/DataFrame boundary
-        plan.first_df_op_idx, plan.groupby_agg, plan.where_ops, plan.alias_renames = (
-            self._find_sql_boundary(
-                lazy_ops, has_sql_source, plan.where_columns, schema
-            )
-        )
-
-        # Split operations
-        if plan.first_df_op_idx is not None:
-            plan.sql_ops = lazy_ops[: plan.first_df_op_idx]
-            plan.df_ops = lazy_ops[plan.first_df_op_idx :]
-        else:
-            plan.sql_ops = lazy_ops.copy()
-            plan.df_ops = []
-
-        # Remove GroupByAgg and converted LazyApply from sql_ops if being pushed separately
-        if plan.groupby_agg:
-            plan.sql_ops = [
-                op
-                for op in plan.sql_ops
-                if not isinstance(op, (LazyGroupByAgg, LazyApply))
-            ]
-
-        # Remove LazyWhere/LazyMask from sql_ops if they're being pushed separately
-        if plan.where_ops:
-            plan.sql_ops = [
-                op for op in plan.sql_ops if not isinstance(op, (LazyWhere, LazyMask))
-            ]
-
-        # Build layers for nested subqueries (LIMIT-before-WHERE patterns)
-        if has_sql_source:
-            plan.layers = self._build_layers(plan.sql_ops)
-
-        self._logger.debug(
-            "Query plan: %d SQL ops, %d DataFrame ops, %d where ops",
-            len(plan.sql_ops),
-            len(plan.df_ops),
-            len(plan.where_ops),
-        )
-
-        return plan
+    # NOTE: the legacy ``plan()`` method (which produced a single QueryPlan
+    # from a flat lazy_ops list) was removed - call sites (``_execute``,
+    # ``_build_execution_sql`` in core.py, and the test suite) now use
+    # ``plan_segments`` and take the plan from the first SQL segment when
+    # they need a single-plan view.
 
     def _collect_where_columns(self, ops: List[LazyOp]) -> Set[str]:
         """
-        Extract column names from WHERE conditions.
+        Extract source-column names referenced in pre-aggregation WHERE clauses.
 
-        This is used to detect alias conflicts when pushing GroupBy to SQL.
+        Convenience wrapper around
+        :meth:`_collect_where_columns_per_segment` that returns the source-col
+        set for the chain *up to* (and used as input by) the first
+        ``LazyGroupByAgg``. The result is consumed by alias-conflict detection:
+        an aggregate output alias that collides with a source column referenced
+        in a pre-agg WHERE has to be renamed to a temp alias so chDB doesn't
+        mis-bind the aggregate inside the WHERE.
+
+        Post-aggregation WHEREs are intentionally excluded - they operate on
+        the *output* of the aggregation (e.g. ``count > 5000``), so treating
+        them as source-col conflicts would force a useless rename and break
+        the outer reference.
 
         Args:
             ops: List of lazy operations
 
         Returns:
-            Set of column names referenced in WHERE conditions
+            Set of column names referenced in pre-aggregation WHERE conditions.
         """
-        where_columns = set()
+        # Plans currently carry at most one LazyGroupByAgg per QueryPlan, so
+        # the per-segment helper collapses to "ops before the (only) agg".
+        return self._collect_where_columns_per_segment(ops, segment_end=None)
 
-        for op in ops:
+    def _collect_where_columns_per_segment(
+        self,
+        ops: List[LazyOp],
+        segment_end: Optional[int] = None,
+    ) -> Set[str]:
+        """
+        Position-aware collector: source columns referenced in WHEREs that
+        come strictly before the chain's first ``LazyGroupByAgg`` (or before
+        ``segment_end`` if supplied).
+
+        This makes the conflict-detection semantics explicit: WHEREs after
+        the boundary act on aggregation output, not source rows, and must not
+        contribute source-col aliases.
+
+        Args:
+            ops: List of lazy operations
+            segment_end: Optional explicit upper bound (exclusive); when None,
+                stops at the first encountered ``LazyGroupByAgg``.
+
+        Returns:
+            Set of column names from WHERE conditions within the segment.
+        """
+        where_columns: Set[str] = set()
+        for idx, op in enumerate(ops):
+            if segment_end is not None and idx >= segment_end:
+                break
+            if segment_end is None and isinstance(op, LazyGroupByAgg):
+                break
             if (
                 isinstance(op, LazyRelationalOp)
                 and op.op_type == "WHERE"
@@ -295,170 +306,10 @@ class QueryPlanner:
             ):
                 try:
                     cond_sql = op.condition.to_sql(quote_char='"')
-                    # Extract quoted column names
                     where_columns.update(re.findall(r'"(\w+)"', cond_sql))
                 except Exception:
                     pass
-
         return where_columns
-
-    def _find_sql_boundary(
-        self,
-        ops: List[LazyOp],
-        has_sql_source: bool,
-        where_columns: Set[str],
-        schema: Dict[str, str] = None,
-    ) -> Tuple[Optional[int], Optional[LazyGroupByAgg], List[LazyOp], Dict[str, str]]:
-        """
-        Find the first operation that cannot be pushed to SQL.
-
-        Also detects GroupByAgg and LazyWhere/LazyMask that can be pushed to SQL.
-
-        Args:
-            ops: List of lazy operations
-            has_sql_source: Whether there's a SQL-compatible data source
-            where_columns: Column names in WHERE conditions (for conflict detection)
-            schema: Optional dict mapping column names to types (for type-aware SQL pushdown)
-
-        Returns:
-            Tuple of (first_df_op_idx, groupby_agg_op, where_ops, alias_renames)
-        """
-        first_df_op_idx = None
-        groupby_agg_op = None
-        where_ops = []  # LazyWhere/LazyMask that can be pushed to SQL
-        alias_renames = {}  # temp_alias -> original_alias for conflict resolution
-        pending_computed_columns = set()  # Track columns added by LazyColumnAssignment
-
-        for i, op in enumerate(ops):
-            if isinstance(op, LazyRelationalOp):
-                # Relational ops can be pushed to SQL
-                continue
-
-            elif isinstance(op, LazyColumnAssignment):
-                # Check if this column assignment can be pushed to SQL
-                if has_sql_source and op.can_push_to_sql():
-                    # Track this as a pending computed column for subsequent ops
-                    pending_computed_columns.add(op.column)
-                    self._logger.debug(
-                        "  [ColumnAssignment] Can push to SQL: %s", op.column
-                    )
-                    continue  # Include in SQL, continue looking
-                else:
-                    # Cannot push to SQL - this operation breaks the SQL chain
-                    self._logger.debug(
-                        "  [ColumnAssignment] Cannot push to SQL: %s", op.column
-                    )
-                    first_df_op_idx = i
-                    break
-
-            elif isinstance(op, LazyGroupByAgg) and groupby_agg_op is None:
-                # Check if GroupByAgg can be pushed to SQL
-                can_push = has_sql_source
-
-                # Special case: first() and last() aggregations cannot be pushed to SQL
-                # when preceded by ORDER BY operations, because SQL's GROUP BY executes
-                # before ORDER BY, making the sort order meaningless for SQL aggregation.
-                # In pandas, sort_values().groupby().first() returns the first row per
-                # group based on the sort order, but SQL's any()/argMax() doesn't respect this.
-                if can_push and op.agg_func in ("first", "last"):
-                    has_preceding_orderby = any(
-                        isinstance(prev_op, LazyRelationalOp)
-                        and prev_op.op_type == "ORDER BY"
-                        for prev_op in ops[:i]
-                    )
-                    if has_preceding_orderby:
-                        can_push = False
-                        self._logger.debug(
-                            "  [GroupBy] %s() cannot be pushed to SQL after ORDER BY",
-                            op.agg_func,
-                        )
-
-                if can_push and op.agg_dict:
-                    # Check for alias conflict with WHERE columns
-                    # ClickHouse has a quirk: if SELECT has `agg(col) AS col` where `col` is
-                    # also referenced in WHERE, ClickHouse will incorrectly try to use the
-                    # aggregate function in the WHERE clause, causing ILLEGAL_AGGREGATION error.
-                    # Example that fails:
-                    #   SELECT category, sum(int_col) AS int_col FROM t WHERE int_col > 200 GROUP BY category
-                    #
-                    # OPTIMIZATION: Instead of falling back to pandas, we use temporary aliases
-                    # for conflicting columns and rename them back after SQL execution.
-                    agg_aliases = self._get_agg_aliases(op, schema)
-                    conflict_aliases = agg_aliases & where_columns
-                    if conflict_aliases:
-                        # Record the aliases that need renaming
-                        for alias in conflict_aliases:
-                            temp_alias = f"__agg_{alias}__"
-                            alias_renames[temp_alias] = alias
-                        self._logger.debug(
-                            "  [GroupBy] Using temp aliases for conflict resolution: %s",
-                            alias_renames,
-                        )
-
-                if can_push:
-                    groupby_agg_op = op
-                    continue  # Include in SQL, continue looking
-                else:
-                    # Cannot push to SQL - this operation breaks the SQL chain
-                    first_df_op_idx = i
-                    break
-
-            elif isinstance(op, LazyApply) and groupby_agg_op is None:
-                # Check if LazyApply can be pushed to SQL
-                # LazyApply with simple aggregation pattern can be converted to GroupByAgg
-                if has_sql_source and op.can_push_to_sql():
-                    # Convert LazyApply to LazyGroupByAgg for SQL execution
-                    agg_func = op.get_detected_agg_func()
-                    groupby_agg_op = LazyGroupByAgg(
-                        groupby_cols=op.groupby_cols,
-                        agg_func=agg_func,
-                        sort=True,  # Default pandas behavior
-                        as_index=True,
-                        dropna=True,
-                    )
-                    self._logger.debug(
-                        "  [Apply] Converted to GroupByAgg: %s -> %s",
-                        op.describe(),
-                        agg_func,
-                    )
-                    continue  # Include in SQL, continue looking
-                else:
-                    # Cannot push to SQL - breaks the chain
-                    self._logger.debug(
-                        "  [Apply] Cannot push to SQL: %s", op.describe()
-                    )
-                    first_df_op_idx = i
-                    break
-
-            elif isinstance(op, (LazyWhere, LazyMask)):
-                # Check if LazyWhere/LazyMask can be pushed to SQL
-                # Pass schema and pending computed columns for type-aware checking
-                if has_sql_source and op.can_push_to_sql(
-                    schema, pending_computed_columns
-                ):
-                    where_ops.append(op)
-                    self._logger.debug("  [Where/Mask] Can push to SQL: CASE WHEN")
-                    continue  # Include in SQL, continue looking
-                else:
-                    # Cannot push to SQL - breaks the chain
-                    # (either function_config or type incompatibility)
-                    self._logger.debug(
-                        "  [Where/Mask] Falling back to Pandas (type incompatibility or config)"
-                    )
-                    first_df_op_idx = i
-                    break
-
-            elif isinstance(op, LazySQLQuery):
-                # LazySQLQuery is a SQL operation but executes via Python() table function
-                # It cannot be pushed further, so it marks a boundary
-                first_df_op_idx = i
-                break
-
-            # Any other operation (LazyGroupByFilter, etc.) breaks the SQL chain
-            first_df_op_idx = i
-            break
-
-        return first_df_op_idx, groupby_agg_op, where_ops, alias_renames
 
     def _get_agg_aliases(
         self, op: LazyGroupByAgg, schema: Dict[str, str] = None
@@ -1043,16 +894,61 @@ class QueryPlanner:
                     elif isinstance(op, (LazyWhere, LazyMask)):
                         plan.where_ops.append(op)
 
-                # Remove special ops from sql_ops (they're handled separately)
+                # Build layers from the FULL op list. We keep LazyGroupByAgg,
+                # LazyWhere, LazyMask, and pushable LazyApply IN the layer
+                # contents so that the per-layer SQL builder
+                # (``_build_layer_sql``) can dispatch by op type and naturally
+                # emit GROUP BY / CASE WHEN / etc. in the correct subquery
+                # layer.
+                #
+                # When LazyApply is converted to a synthetic LazyGroupByAgg
+                # (see above) the layer is patched to use the synthetic op
+                # rather than the original LazyApply so SQL building sees a
+                # uniform representation.
+                raw_layers = self._build_layers(plan.sql_ops)
+
+                synthetic_groupby_agg = (
+                    plan.groupby_agg
+                    if any(
+                        isinstance(op, LazyApply) and op.can_push_to_sql()
+                        for op in plan.sql_ops
+                    )
+                    else None
+                )
+                if synthetic_groupby_agg is not None:
+                    # Replace the originating LazyApply in layers with the
+                    # synthesized LazyGroupByAgg so the layer ops list contains
+                    # the canonical operation to dispatch on.
+                    patched_layers = []
+                    replaced = False
+                    for layer_ops in raw_layers:
+                        new_layer = []
+                        for op in layer_ops:
+                            if (
+                                not replaced
+                                and isinstance(op, LazyApply)
+                                and op.can_push_to_sql()
+                            ):
+                                new_layer.append(synthetic_groupby_agg)
+                                replaced = True
+                            else:
+                                new_layer.append(op)
+                        patched_layers.append(new_layer)
+                    raw_layers = patched_layers
+
+                plan.layers = raw_layers
+
+                # ``plan.sql_ops`` still excludes the special ops because some
+                # legacy paths (e.g. ``_build_sql_with_builder``,
+                # ``_check_limit_before_where``) iterate plan.sql_ops without
+                # the dispatch logic. Keeping that contract avoids touching
+                # those paths in this phase.
                 plan.sql_ops = [
                     op
                     for op in plan.sql_ops
                     if not isinstance(op, (LazyGroupByAgg, LazyWhere, LazyMask))
                     and not (isinstance(op, LazyApply) and op.can_push_to_sql())
                 ]
-
-                # Build layers for nested subqueries
-                plan.layers = self._build_layers(plan.sql_ops)
 
                 segment.plan = plan
 

--- a/datastore/sql_executor.py
+++ b/datastore/sql_executor.py
@@ -385,18 +385,185 @@ def extract_clauses_from_ops(
     return result
 
 
+def rewrite_column_refs_in_expression(expr: Any, rename_map: Dict[str, str]) -> Any:
+    """
+    Recursively rewrite ``Field`` references in an Expression/Condition tree.
+
+    When an inner SQL layer renames a column (e.g. ``SUM(int_col) AS
+    __agg_int_col__`` because of an alias conflict), outer layers that
+    reference the original name (``int_col``) need their references rewritten
+    to the temp alias so the outer SQL is well-formed.
+
+    The rewrite is structural and immutable: a new tree is returned and the
+    original is not mutated. Subqueries inside ``InCondition`` are not
+    descended into (they have their own column scope).
+
+    Args:
+        expr: A Condition, BinaryCondition, CompoundCondition, NotCondition,
+              UnaryCondition, InCondition, BetweenCondition, LikeCondition,
+              NullSafeCondition, ArithmeticExpression, Field, Literal, or
+              any other Expression-like value. ``None`` returns ``None``.
+        rename_map: Dict mapping ``original_name -> new_name``.
+
+    Returns:
+        A rewritten expression (new instance if anything changed, otherwise
+        the original).
+    """
+    if expr is None or not rename_map:
+        return expr
+
+    from .conditions import (
+        BinaryCondition,
+        CompoundCondition,
+        NotCondition,
+        UnaryCondition,
+        InCondition,
+        BetweenCondition,
+        LikeCondition,
+        NullSafeCondition,
+    )
+    from .expressions import ArithmeticExpression, Literal
+
+    if isinstance(expr, Field):
+        original = expr.name.strip("\"'")
+        if original in rename_map:
+            return Field(rename_map[original], table=expr.table, alias=expr.alias)
+        return expr
+
+    if isinstance(expr, Literal):
+        return expr
+
+    if isinstance(expr, BinaryCondition):
+        new_left = rewrite_column_refs_in_expression(expr.left, rename_map)
+        new_right = rewrite_column_refs_in_expression(expr.right, rename_map)
+        if new_left is expr.left and new_right is expr.right:
+            return expr
+        return BinaryCondition(expr.operator, new_left, new_right, expr.alias)
+
+    if isinstance(expr, CompoundCondition):
+        new_left = rewrite_column_refs_in_expression(expr.left, rename_map)
+        new_right = rewrite_column_refs_in_expression(expr.right, rename_map)
+        if new_left is expr.left and new_right is expr.right:
+            return expr
+        return CompoundCondition(expr.operator, new_left, new_right, expr.alias)
+
+    if isinstance(expr, NotCondition):
+        new_inner = rewrite_column_refs_in_expression(expr.condition, rename_map)
+        if new_inner is expr.condition:
+            return expr
+        return NotCondition(new_inner, expr.alias)
+
+    if isinstance(expr, UnaryCondition):
+        new_expr = rewrite_column_refs_in_expression(expr.expression, rename_map)
+        if new_expr is expr.expression:
+            return expr
+        return UnaryCondition(expr.operator, new_expr, expr.alias)
+
+    if isinstance(expr, InCondition):
+        # Don't descend into subqueries (different column scope)
+        new_expr = rewrite_column_refs_in_expression(expr.expression, rename_map)
+        if new_expr is expr.expression:
+            return expr
+        return InCondition(new_expr, expr.values, expr.negate, expr.alias)
+
+    if isinstance(expr, BetweenCondition):
+        new_e = rewrite_column_refs_in_expression(expr.expression, rename_map)
+        new_l = rewrite_column_refs_in_expression(expr.lower, rename_map)
+        new_u = rewrite_column_refs_in_expression(expr.upper, rename_map)
+        if (
+            new_e is expr.expression
+            and new_l is expr.lower
+            and new_u is expr.upper
+        ):
+            return expr
+        return BetweenCondition(
+            new_e, new_l, new_u, expr.inclusive, expr.alias
+        )
+
+    if isinstance(expr, LikeCondition):
+        new_expr = rewrite_column_refs_in_expression(expr.expression, rename_map)
+        if new_expr is expr.expression:
+            return expr
+        return LikeCondition(
+            new_expr,
+            expr.pattern,
+            expr.negate,
+            expr.case_sensitive,
+            expr.alias,
+        )
+
+    if isinstance(expr, NullSafeCondition):
+        new_inner = rewrite_column_refs_in_expression(expr.condition, rename_map)
+        if new_inner is expr.condition:
+            return expr
+        return NullSafeCondition(new_inner, expr.alias)
+
+    if isinstance(expr, ArithmeticExpression):
+        new_left = rewrite_column_refs_in_expression(expr.left, rename_map)
+        new_right = rewrite_column_refs_in_expression(expr.right, rename_map)
+        if new_left is expr.left and new_right is expr.right:
+            return expr
+        rebuilt = ArithmeticExpression(
+            expr.operator, new_left, new_right, expr.alias
+        )
+        if getattr(expr, "_is_string_type", False):
+            rebuilt._is_string_type = True
+        return rebuilt
+
+    return expr
+
+
+def rewrite_column_refs_in_orderby(
+    orderby_fields: List[Tuple[Any, bool]], rename_map: Dict[str, str]
+) -> List[Tuple[Any, bool]]:
+    """
+    Rewrite Field references in an ORDER BY field list.
+
+    Generalizes :func:`apply_alias_renames_to_orderby` to work with any
+    ``rename_map`` (e.g. cross-layer alias propagation), not only the
+    ``temp_alias -> original_alias`` map.
+
+    Args:
+        orderby_fields: List of ``(field, ascending)`` tuples
+        rename_map: Dict mapping ``original_name -> new_name``
+
+    Returns:
+        New list with Field references rewritten where applicable.
+    """
+    if not rename_map or not orderby_fields:
+        return orderby_fields
+
+    new_orderby = []
+    for field_obj, asc in orderby_fields:
+        if isinstance(field_obj, Field):
+            rewritten = rewrite_column_refs_in_expression(field_obj, rename_map)
+            new_orderby.append((rewritten, asc))
+        elif isinstance(field_obj, str) and field_obj in rename_map:
+            new_orderby.append((Field(rename_map[field_obj]), asc))
+        else:
+            new_orderby.append((field_obj, asc))
+
+    return new_orderby
+
+
 def apply_alias_renames_to_orderby(
     orderby_fields: List[Tuple[Any, bool]], alias_renames: Dict[str, str]
 ) -> List[Tuple[Any, bool]]:
     """
-    Handle ORDER BY with alias conflicts.
+    Handle ORDER BY with same-layer alias conflicts (e.g. GroupBy temp aliases).
 
-    If ORDER BY references a column that has a temp alias (due to GroupBy conflict),
-    we need to use the temp alias in ORDER BY.
+    If ORDER BY references a column that has a temp alias (due to GroupBy
+    conflict), we need to use the temp alias in ORDER BY.
+
+    For the same-layer case the rename direction is reversed compared to
+    cross-layer rewrites: ``alias_renames`` maps ``temp_alias ->
+    original_alias`` because the temp alias is what is emitted in SELECT but
+    the user-facing ORDER BY column name is the original. Hence we invert it
+    and reuse :func:`rewrite_column_refs_in_orderby`.
 
     Args:
         orderby_fields: List of (field, ascending) tuples
-        alias_renames: Dict mapping temp_alias -> original_alias
+        alias_renames: Dict mapping ``temp_alias -> original_alias``
 
     Returns:
         Updated orderby_fields with temp aliases applied
@@ -404,47 +571,55 @@ def apply_alias_renames_to_orderby(
     if not alias_renames or not orderby_fields:
         return orderby_fields
 
-    # Build reverse mapping: original_alias -> temp_alias
     reverse_renames = {orig: temp for temp, orig in alias_renames.items()}
-
-    new_orderby = []
-    for field_obj, asc in orderby_fields:
-        field_name = field_obj.name if isinstance(field_obj, Field) else str(field_obj)
-        if field_name in reverse_renames:
-            # Replace with temp alias
-            new_orderby.append((Field(reverse_renames[field_name]), asc))
-        else:
-            new_orderby.append((field_obj, asc))
-
-    return new_orderby
+    return rewrite_column_refs_in_orderby(orderby_fields, reverse_renames)
 
 
 def build_groupby_select_fields(
     groupby_agg: LazyGroupByAgg,
-    alias_renames: Dict[str, str] = None,
+    inherited_alias_renames: Dict[str, str] = None,
     all_columns: List[str] = None,
     computed_columns: Dict[str, Expression] = None,
-) -> Tuple[List[Field], List[Expression]]:
+) -> Tuple[List[Field], List[Expression], Dict[str, str]]:
     """
     Build GROUP BY and SELECT fields from a LazyGroupByAgg operation.
 
-    This centralizes the aggregation SQL building logic.
+    Pure function: does NOT mutate any argument. Returns a fresh
+    ``emitted_renames`` dict describing every temp alias this call's
+    SELECT clause emits (whether the alias was pre-reserved in
+    ``inherited_alias_renames`` or newly created here). Callers can merge
+    it into ``plan.alias_renames`` for post-execution rename-back and
+    propagate it to subsequent layers for cross-layer Field rewriting.
 
     Args:
         groupby_agg: LazyGroupByAgg operation
-        alias_renames: Dict for alias conflict resolution
-        all_columns: All column names (needed for count() to generate COUNT(col) per column)
-        computed_columns: Dict mapping computed column names to their expressions
-                          (for expanding assign() columns in aggregations)
+        inherited_alias_renames: Existing temp-alias map (read-only). Used
+            to detect when an alias is already reserved by an outer scope
+            (e.g. by the planner's source-col/agg-alias conflict
+            detection). The caller's dict is never mutated.
+        all_columns: All column names (needed for count() to generate
+            COUNT(col) per column)
+        computed_columns: Dict mapping computed column names to their
+            expressions (for expanding assign() columns in aggregations)
 
     Returns:
-        Tuple of (groupby_fields, select_fields)
+        Tuple of (groupby_fields, select_fields, emitted_renames).
+        ``emitted_renames`` maps ``temp_alias -> original_alias`` for
+        every temp alias this layer's SELECT clause actually emits.
     """
     from .functions import AggregateFunction, Function
 
-    if alias_renames is None:
-        alias_renames = {}
+    inherited = inherited_alias_renames or {}
+    emitted_renames: Dict[str, str] = {}
     computed_columns = computed_columns or {}
+
+    def reserve_temp(temp: str, original: str) -> None:
+        """Record that this SELECT emits ``temp`` as the alias for ``original``."""
+        emitted_renames[temp] = original
+
+    def has_alias(temp: str) -> bool:
+        """Check if a temp alias is reserved (in inherited or already created)."""
+        return temp in inherited or temp in emitted_renames
 
     def resolve_column(col_name: str) -> Expression:
         """Resolve column name - return expression if computed column, else Field."""
@@ -502,8 +677,9 @@ def build_groupby_select_fields(
         for alias, (col, func) in groupby_agg.named_agg.items():
             # Check if this alias conflicts with WHERE columns
             temp_alias = f"__agg_{alias}__"
-            if temp_alias in alias_renames:
+            if has_alias(temp_alias):
                 final_alias = temp_alias
+                reserve_temp(temp_alias, alias)
             else:
                 final_alias = alias
 
@@ -568,9 +744,9 @@ def build_groupby_select_fields(
                 # When alias == source column name (e.g., sum(amount) AS amount),
                 # chDB interprets it as nested aggregation which is invalid
                 temp_alias = f"__agg_{alias}__"
-                if temp_alias in alias_renames or col == alias:
+                if has_alias(temp_alias) or col == alias:
                     # Use temp alias to avoid conflict, will rename back later
-                    alias_renames[temp_alias] = alias
+                    reserve_temp(temp_alias, alias)
                     alias = temp_alias
 
                 # Resolve column - may be a computed column from assign()
@@ -604,8 +780,9 @@ def build_groupby_select_fields(
             for col in cols_to_agg:
                 # Check if this alias conflicts with WHERE columns
                 temp_alias = f"__agg_{col}__"
-                if temp_alias in alias_renames:
+                if has_alias(temp_alias):
                     alias = temp_alias
+                    reserve_temp(temp_alias, col)
                 else:
                     alias = col
                 # Resolve column - may be a computed column from assign()
@@ -618,7 +795,7 @@ def build_groupby_select_fields(
                 sql_func = map_agg_func(func)
                 select_fields.append(AggregateFunction(sql_func, Star()))
 
-    return groupby_fields, select_fields
+    return groupby_fields, select_fields, emitted_renames
 
 
 @dataclass
@@ -633,6 +810,26 @@ class SQLBuildResult:
     sql: str
     alias_renames: Dict[str, str] = field(default_factory=dict)
     groupby_agg: Optional[LazyGroupByAgg] = None
+
+
+@dataclass
+class LayerBuildResult:
+    """
+    Result of building SQL for a single subquery layer.
+
+    Returned by :meth:`SQLExecutionEngine._build_layer`. The ``renames_introduced``
+    map records temp aliases this layer's SELECT emitted that differ from
+    their user-visible names (``temp_alias -> original_name``). Callers
+    chain layers by feeding the next layer ``inner_renames=visible_to_temp``
+    so its WHERE/ORDER BY refs are rewritten before reaching SQL.
+    """
+
+    sql: str
+    renames_introduced: Dict[str, str] = field(default_factory=dict)
+
+    def visible_to_temp(self) -> Dict[str, str]:
+        """Invert ``renames_introduced`` to a ``visible_name -> temp_alias`` map."""
+        return {orig: temp for temp, orig in self.renames_introduced.items()}
 
 
 class SQLExecutionEngine:
@@ -712,195 +909,507 @@ class SQLExecutionEngine:
         )
         return f"LIMIT 1 BY {limit_by_cols}"
 
-    def build_simple_sql(
-        self,
-        clauses: ExtractedClauses,
-        select_fields: List[Expression] = None,
-        groupby_fields: List[Expression] = None,
-        having_condition: Any = None,
-        distinct: bool = False,
-    ) -> str:
+    def _split_wheres_by_groupby_position(
+        self, layer_ops: List[LazyOp]
+    ) -> Tuple[List[Any], List[Any]]:
         """
-        Build a simple (non-nested) SQL query.
+        Split WHERE conditions in a layer into pre-aggregation and
+        post-aggregation buckets, using the position of the LazyGroupByAgg
+        op (if any) within the layer.
 
-        Args:
-            clauses: Extracted SQL clauses
-            select_fields: Fields to select
-            groupby_fields: GROUP BY fields
-            having_condition: HAVING condition
-            distinct: Whether to use DISTINCT
+        - WHEREs before the LazyGroupByAgg act on source rows -> WHERE clause
+        - WHEREs after the LazyGroupByAgg act on aggregation output ->
+          HAVING clause (SQL HAVING runs after GROUP BY)
 
         Returns:
-            SQL query string
+            (pre_agg_conditions, post_agg_conditions)
         """
-        parts = []
+        pre_agg: List[Any] = []
+        post_agg: List[Any] = []
+        seen_groupby = False
+        for op in layer_ops:
+            if isinstance(op, LazyGroupByAgg):
+                seen_groupby = True
+                continue
+            if (
+                isinstance(op, LazyRelationalOp)
+                and op.op_type == "WHERE"
+                and op.condition is not None
+            ):
+                if seen_groupby:
+                    post_agg.append(op.condition)
+                else:
+                    pre_agg.append(op.condition)
+        return pre_agg, post_agg
 
-        # SELECT (with optional DISTINCT)
-        distinct_keyword = "DISTINCT " if distinct else ""
-        select_fields = select_fields or clauses.select_fields
+    def _build_layer(
+        self,
+        layer_ops: List[LazyOp],
+        *,
+        from_source: Optional[str] = None,
+        is_first_layer: bool,
+        inherited_renames: Optional[Dict[str, str]] = None,
+        previously_emitted_renames: Optional[Dict[str, str]] = None,
+        schema: Optional[Dict[str, str]] = None,
+        sql_select_fields: Optional[List[Expression]] = None,
+        has_column_assignments: bool = False,
+        preserved_orderby: Optional[List[Tuple[Any, bool]]] = None,
+        preserved_orderby_kind: Optional[str] = None,
+    ) -> "LayerBuildResult":
+        """
+        Build SQL for a single nested-subquery layer (unified entry point).
 
+        This is the *only* per-layer SQL builder. It handles every kind of
+        op a layer can contain and is parameterised by ``from_source`` /
+        ``is_first_layer`` so the same function works for:
+
+        - the innermost layer reading from a table function / table name,
+        - subsequent wrapper layers reading ``(inner_sql) AS __subqN__``,
+        - layers reading from a Python() DataFrame source (``__df__``).
+
+        Op-type dispatch (all ops are kept in their natural position in
+        ``layer_ops``):
+
+        - LazyRelationalOp -> WHERE / ORDER BY / LIMIT / OFFSET / SELECT
+        - LazyColumnAssignment (pushable) -> additional SELECT expression
+        - LazyGroupByAgg -> GROUP BY + aggregations; WHEREs in this layer
+          are split by position (before -> WHERE clause, after -> HAVING).
+        - LazyWhere / LazyMask -> CASE WHEN over every column with temp
+          aliases.
+
+        Args:
+            layer_ops: Ops in this layer (relational + special).
+            from_source: Explicit FROM source SQL fragment. ``None`` means
+                "this is the source layer, derive FROM from self.ds" (only
+                valid when ``is_first_layer`` is True).
+            is_first_layer: True for the innermost layer (gets row-order
+                preservation, JOINs, DISTINCT). False for wrapper layers.
+            inherited_renames: ``temp_alias -> original_alias`` map for
+                alias-awareness only. Used by
+                ``build_groupby_select_fields`` to detect when an alias is
+                already reserved (e.g. by the planner's source-col vs
+                agg-alias conflict detection). NOT used to rewrite Field
+                references in WHERE/ORDER BY.
+            previously_emitted_renames: ``temp_alias -> original_alias``
+                map for renames that *previously-built layers* actually
+                emitted under temp aliases. Used to rewrite this layer's
+                WHERE/HAVING/ORDER BY Field references (inverted to
+                ``orig -> temp``). Empty for the first layer.
+            schema: Column schema for type-aware CASE WHEN.
+            sql_select_fields: Pre-computed SELECT exprs from the caller
+                (column assignments etc.). Only used for the first layer.
+            has_column_assignments: Pass-through flag for first-layer
+                ``SELECT *, computed_col`` semantics.
+            preserved_orderby: ORDER BY from a previous layer to keep when
+                this layer has no explicit ORDER BY (wrapper layers only).
+            preserved_orderby_kind: Sort kind for stable sort detection.
+
+        Returns:
+            LayerBuildResult containing the SQL text and every temp alias
+            this layer's SELECT actually emitted
+            (``temp_alias -> original_alias``).
+        """
+        inherited_renames = inherited_renames or {}
+        previously_emitted_renames = previously_emitted_renames or {}
+        schema = schema or {}
+        sql_select_fields = sql_select_fields or []
+
+        # Inverted view of previously_emitted_renames for rewriting Field
+        # refs (visible_name -> emitted_temp_alias). This applies only to
+        # columns that an INNER subquery already emitted under a temp
+        # alias - NOT to planner reservations for this layer's own agg.
+        previously_visible_to_temp: Dict[str, str] = {
+            orig: temp for temp, orig in previously_emitted_renames.items()
+        }
+
+        groupby_agg_op, where_ops = self._extract_special_ops_from_layer(layer_ops)
+        clauses = extract_clauses_from_ops(layer_ops, self.quote_char)
+
+        # 1) Cross-layer rewrite: rewrite Field refs in this layer's
+        # WHERE/ORDER BY/SELECT to point at the inner layer's emitted names.
+        # SELECT rewriting matters when a wrapper layer projects a column
+        # the inner layer renamed (e.g. ``ds_filter['int_col']`` against an
+        # aggregation that emits ``__agg_int_col__``); the projection must
+        # bind to the temp alias and rely on post-execution rename-back.
+        if previously_visible_to_temp:
+            clauses.where_conditions = [
+                rewrite_column_refs_in_expression(c, previously_visible_to_temp)
+                for c in clauses.where_conditions
+            ]
+            clauses.orderby_fields = rewrite_column_refs_in_orderby(
+                clauses.orderby_fields, previously_visible_to_temp
+            )
+            clauses.select_fields = [
+                rewrite_column_refs_in_expression(f, previously_visible_to_temp)
+                for f in clauses.select_fields
+            ]
+            # The caller-supplied SELECT fields (e.g. a column projection
+            # from ColumnExpr) reference user-visible names too; rewrite
+            # them to bind to the inner subquery's actual emitted columns.
+            sql_select_fields = [
+                rewrite_column_refs_in_expression(f, previously_visible_to_temp)
+                for f in sql_select_fields
+            ]
+
+        # 2) Split WHEREs by GroupByAgg position (pre-agg -> WHERE, post-agg
+        # -> HAVING). ``_split_wheres_by_groupby_position`` re-reads from
+        # ``layer_ops`` to preserve position, so we need to rewrite both
+        # halves separately too.
+        having_conditions: List[Any] = []
+        if groupby_agg_op is not None:
+            pre_wheres, post_wheres = self._split_wheres_by_groupby_position(
+                layer_ops
+            )
+            if previously_visible_to_temp:
+                pre_wheres = [
+                    rewrite_column_refs_in_expression(c, previously_visible_to_temp)
+                    for c in pre_wheres
+                ]
+                post_wheres = [
+                    rewrite_column_refs_in_expression(c, previously_visible_to_temp)
+                    for c in post_wheres
+                ]
+            clauses.where_conditions = pre_wheres
+            having_conditions = post_wheres
+
+        # 3) Build SELECT / GROUP BY / WHERE CASE-WHEN tooling.
+        select_fields_for_sql: List[Expression] = sql_select_fields
+        groupby_fields_for_sql: List[Expression] = (
+            self.ds._groupby_fields if is_first_layer else []
+        )
+        where_needs_subquery = False
+        where_needs_temp_alias = False
+        where_temp_alias_columns: List[Tuple[str, str]] = []
+
+        if where_ops:
+            # LazyWhere/LazyMask CASE WHEN: emit a temp-alias SELECT over
+            # every column then rename back on the outer wrapper.
+            all_columns = self.ds._get_all_column_names() if is_first_layer else []
+            if not all_columns and not is_first_layer:
+                # Wrapper-layer CASE WHEN falls back to schema-driven cols if
+                # the source-bound helper has no schema (rare path).
+                all_columns = list(schema.keys())
+            if all_columns:
+                where_needs_temp_alias = True
+                for col in all_columns:
+                    temp_alias = f"__tmp_{col}__"
+                    where_temp_alias_columns.append((temp_alias, col))
+                select_fields_for_sql = [
+                    CaseWhenExpr(
+                        col,
+                        where_ops,
+                        self.quote_char,
+                        schema.get(col, "Unknown"),
+                        alias=f"__tmp_{col}__",
+                    )
+                    for col in all_columns
+                ]
+                if clauses.where_conditions:
+                    where_needs_subquery = True
+
+        if groupby_agg_op is not None:
+            # Determine target columns for aggregation (priority: explicit
+            # SELECT in clauses > caller-supplied select fields > agg spec >
+            # source schema).
+            if clauses.select_fields:
+                all_cols = self._infer_column_names(clauses.select_fields)
+            elif sql_select_fields:
+                all_cols = self._infer_column_names(sql_select_fields)
+            elif (
+                groupby_agg_op.agg_dict is not None
+                and isinstance(groupby_agg_op.agg_dict, dict)
+            ):
+                all_cols = list(groupby_agg_op.agg_dict.keys())
+            elif groupby_agg_op.selected_columns:
+                all_cols = list(groupby_agg_op.selected_columns)
+            else:
+                all_cols = (
+                    self.ds._get_all_column_names()
+                    if hasattr(self.ds, "_get_all_column_names")
+                    else None
+                ) or []
+
+            computed_cols = getattr(self.ds, "_computed_columns", None) or {}
+            (
+                groupby_fields_for_sql,
+                select_fields_for_sql,
+                emitted_renames,
+            ) = build_groupby_select_fields(
+                groupby_agg_op,
+                inherited_alias_renames=inherited_renames,
+                all_columns=all_cols,
+                computed_columns=computed_cols,
+            )
+
+            # Rewrite this layer's HAVING / ORDER BY refs to use the temp
+            # aliases the agg just emitted (visible_name -> temp_alias).
+            agg_visible_to_temp = {
+                orig: temp for temp, orig in emitted_renames.items()
+            }
+            if agg_visible_to_temp:
+                having_conditions = [
+                    rewrite_column_refs_in_expression(c, agg_visible_to_temp)
+                    for c in having_conditions
+                ]
+                clauses.orderby_fields = rewrite_column_refs_in_orderby(
+                    clauses.orderby_fields, agg_visible_to_temp
+                )
+
+            if groupby_agg_op.sort and not clauses.orderby_fields:
+                clauses.orderby_fields = [
+                    (Field(col), True) for col in groupby_agg_op.groupby_cols
+                ]
+            # GROUP BY reshapes rows; inner-layer ORDER BY no longer applies.
+            preserved_orderby = None
+            preserved_orderby_kind = None
+
+        # 4) Render SQL. Two render modes:
+        # - Source-bound first layer (``from_source is None`` and
+        #   ``is_first_layer=True``): full source-bound complexity (JOINs,
+        #   row-order subquery, CASE WHEN subquery, DISTINCT) via
+        #   ``_render_first_layer_sql``.
+        # - Explicit ``from_source`` (wrapper layer OR DataFrame ``__df__``
+        #   source): simple wrap over the given source via
+        #   ``_render_wrapper_layer_sql``. When this is the first layer of
+        #   the DataFrame path, ``add_row_order_fallback`` ensures
+        #   ``ORDER BY _row_id`` is added for deterministic ordering.
+        if from_source is None:
+            assert is_first_layer, "non-first layer must supply from_source"
+            sql = self._render_first_layer_sql(
+                clauses,
+                select_fields_for_sql,
+                groupby_fields_for_sql,
+                having_conditions,
+                where_ops,
+                where_needs_subquery,
+                where_needs_temp_alias,
+                where_temp_alias_columns,
+                groupby_agg_op,
+                has_column_assignments,
+            )
+        else:
+            # Wrapper / DataFrame layer: surface column assignments and
+            # explicit column selections from extract_clauses_from_ops so
+            # SELECT emits ``SELECT *, expr AS alias`` (or explicit cols).
+            wrapper_select_fields = select_fields_for_sql
+            include_star = has_column_assignments
+            if (
+                not wrapper_select_fields
+                and clauses.select_fields
+                and groupby_agg_op is None
+                and not where_ops
+            ):
+                wrapper_select_fields = clauses.select_fields
+                # When explicit_column_selection is set we want SELECT col1, col2;
+                # otherwise these are pure column assignments and we need
+                # ``SELECT *, expr AS alias`` to preserve inherited columns.
+                include_star = not clauses.explicit_column_selection
+            sql = self._render_wrapper_layer_sql(
+                from_source,
+                clauses,
+                wrapper_select_fields,
+                groupby_fields_for_sql,
+                having_conditions,
+                preserved_orderby,
+                preserved_orderby_kind,
+                add_row_order_fallback=is_first_layer,
+                include_star=include_star,
+            )
+
+        # Renames introduced by this layer: aliases its SELECT actually
+        # emitted. Empty when the layer has no LazyGroupByAgg / LazyWhere.
+        introduced: Dict[str, str] = {}
+        if groupby_agg_op is not None:
+            introduced.update(emitted_renames)
+        return LayerBuildResult(sql=sql, renames_introduced=introduced)
+
+    def _infer_column_names(
+        self, fields: List[Expression]
+    ) -> List[str]:
+        """Best-effort extraction of column names from a SELECT field list."""
+        cols: List[str] = []
+        for f in fields:
+            if isinstance(f, Field):
+                cols.append(f.name)
+            elif hasattr(f, "alias") and f.alias:
+                cols.append(f.alias)
+            else:
+                cols.append(str(f))
+        return cols
+
+    def _render_first_layer_sql(
+        self,
+        clauses: ExtractedClauses,
+        select_fields: List[Expression],
+        groupby_fields: List[Expression],
+        having_conditions: List[Any],
+        where_ops: List[Any],
+        where_needs_subquery: bool,
+        where_needs_temp_alias: bool,
+        where_temp_alias_columns: List[Tuple[str, str]],
+        groupby_agg_op: Optional[LazyGroupByAgg],
+        has_column_assignments: bool,
+    ) -> str:
+        """
+        Emit SQL for the innermost layer (bound to the table source).
+
+        Routes to one of three subquery wrappers if needed:
+        - ``build_sql_with_case_when_subquery``: WHERE under CASE WHEN
+        - ``_build_temp_alias_query``: CASE WHEN with row-order capture
+        - ``build_sql_with_row_order_subquery``: row order with WHERE
+
+        Otherwise falls through to ``assemble_sql`` which handles JOINs,
+        DISTINCT, HAVING, stable-sort subqueries and the standard clause
+        layout.
+        """
+        needs_row_order = (
+            clauses.needs_row_order(has_groupby=groupby_agg_op is not None)
+            and not self.source_preserves_row_order()
+        )
+
+        # HAVING is currently only emitted for wrapper layers (post-agg
+        # WHERE in a first-layer plan is folded into source-level WHERE by
+        # the planner). Assert to surface any unexpected case explicitly.
+        if having_conditions:
+            # Fold into the layer's WHERE list as a defensive fallback (the
+            # combine logic in assemble_sql will AND them together correctly
+            # because there's no GROUP BY split between them here).
+            clauses.where_conditions = list(clauses.where_conditions) + list(
+                having_conditions
+            )
+
+        if where_needs_subquery:
+            return self.build_sql_with_case_when_subquery(
+                clauses, select_fields, where_temp_alias_columns
+            )
+        if where_needs_temp_alias and where_temp_alias_columns:
+            return self._build_temp_alias_query(
+                clauses, select_fields, where_temp_alias_columns, needs_row_order
+            )
+        if needs_row_order and clauses.where_conditions and not self.ds._joins:
+            return self.build_sql_with_row_order_subquery(
+                clauses,
+                select_fields,
+                groupby_fields,
+                include_star=has_column_assignments,
+            )
+
+        effective_orderby = clauses.orderby_fields
+        if (
+            needs_row_order
+            and not clauses.orderby_fields
+            and (clauses.where_conditions or self.ds._joins)
+        ):
+            effective_orderby = [("__rowNumberInAllBlocks__", True)]
+
+        # When DISTINCT is active, don't use include_star because it would
+        # expand * to all source columns (defeating column selection +
+        # DISTINCT). Column assignments are already in select_fields.
+        use_include_star = has_column_assignments if has_column_assignments else None
+        if self.ds._distinct and use_include_star:
+            use_include_star = None
+
+        return self.assemble_sql(
+            select_fields,
+            clauses.where_conditions,
+            effective_orderby,
+            clauses.limit_value,
+            clauses.offset_value,
+            joins=self.ds._joins,
+            distinct=self.ds._distinct,
+            groupby_fields=groupby_fields,
+            having_condition=self.ds._having_condition,
+            include_star=use_include_star,
+        )
+
+    def _render_wrapper_layer_sql(
+        self,
+        from_source: str,
+        clauses: ExtractedClauses,
+        select_fields: List[Expression],
+        groupby_fields: List[Expression],
+        having_conditions: List[Any],
+        preserved_orderby: Optional[List[Tuple[Any, bool]]],
+        preserved_orderby_kind: Optional[str],
+        add_row_order_fallback: bool = False,
+        include_star: bool = False,
+    ) -> str:
+        """
+        Emit SQL for a layer that reads from an explicit FROM source:
+        ``SELECT ... FROM {from_source} [WHERE] [GROUP BY] [HAVING]
+        [ORDER BY] [LIMIT] [OFFSET]``.
+
+        Used for both wrapper layers (``(inner_sql) AS __subqN__``) and the
+        DataFrame execution path (``__df__``). No source-level JOINs,
+        DISTINCT or row-order subqueries here - those are exclusive to the
+        table-bound first layer (``_render_first_layer_sql``).
+
+        ``preserved_orderby`` propagates the previous layer's ORDER BY
+        through filter-only wrappers so
+        ``df.sort_values(...).head(10)[df.col > X]`` keeps its sort order.
+
+        ``add_row_order_fallback`` enables ``ORDER BY _row_id`` when the
+        layer has no other ORDER BY but still needs deterministic ordering.
+        Used for the Python() DataFrame first layer where ``_row_id`` is the
+        built-in virtual column carrying source row order.
+
+        ``include_star`` enables ``SELECT *, expr AS alias`` style for
+        column-assignment scenarios where we want to keep all inherited
+        columns plus add the computed ones.
+        """
         if select_fields:
             fields_sql = ", ".join(
                 f.to_sql(quote_char=self.quote_char, with_alias=True)
                 for f in select_fields
             )
-            if self.ds._select_star:
-                parts.append(f"SELECT {distinct_keyword}*, {fields_sql}")
-            else:
-                parts.append(f"SELECT {distinct_keyword}{fields_sql}")
+            select_sql = f"*, {fields_sql}" if include_star else fields_sql
         else:
-            parts.append(f"SELECT {distinct_keyword}*")
+            select_sql = "*"
 
-        # FROM
-        table_source = self.get_table_source()
-        if table_source:
-            # Add alias when joins are present
-            if self.ds._joins:
-                alias = self.ds._get_table_alias()
-                parts.append(
-                    f"FROM {table_source} AS {format_identifier(alias, self.quote_char)}"
-                )
-            else:
-                parts.append(f"FROM {table_source}")
+        parts = [f"SELECT {select_sql}", f"FROM {from_source}"]
 
-        # JOIN clauses
-        if self.ds._joins:
-            for other_ds, join_type, join_condition in self.ds._joins:
-                parts.append(
-                    self._build_join_clause(other_ds, join_type, join_condition)
-                )
-
-        # WHERE
         if clauses.where_conditions:
             combined = clauses.where_conditions[0]
-            for cond in clauses.where_conditions[1:]:
-                combined = combined & cond
+            for c in clauses.where_conditions[1:]:
+                combined = combined & c
             parts.append(f"WHERE {combined.to_sql(quote_char=self.quote_char)}")
 
-        # GROUP BY
         if groupby_fields:
-            groupby_sql = ", ".join(
+            gb_sql = ", ".join(
                 f.to_sql(quote_char=self.quote_char) for f in groupby_fields
             )
-            parts.append(f"GROUP BY {groupby_sql}")
+            parts.append(f"GROUP BY {gb_sql}")
 
-        # HAVING
-        if having_condition:
-            parts.append(
-                f"HAVING {having_condition.to_sql(quote_char=self.quote_char)}"
-            )
+        if having_conditions:
+            combined = having_conditions[0]
+            for c in having_conditions[1:]:
+                combined = combined & c
+            parts.append(f"HAVING {combined.to_sql(quote_char=self.quote_char)}")
 
-        # ORDER BY
-        if clauses.orderby_fields:
-            orderby_sql = build_orderby_clause(
-                clauses.orderby_fields,
-                self.quote_char,
-                stable=is_stable_sort(clauses.orderby_kind),
-            )
-            parts.append(f"ORDER BY {orderby_sql}")
-
-        limit_by = self._build_limit_by_clause()
-        if limit_by:
-            parts.append(limit_by)
-
-        # LIMIT
-        if clauses.limit_value is not None:
-            parts.append(f"LIMIT {clauses.limit_value}")
-
-        # OFFSET
-        if clauses.offset_value is not None:
-            parts.append(f"OFFSET {clauses.offset_value}")
-
-        return " ".join(parts)
-
-    def build_nested_sql(
-        self, layers: List[List[LazyOp]], base_clauses: ExtractedClauses = None
-    ) -> str:
-        """
-        Build nested subquery SQL for complex patterns.
-
-        Multiple layers are needed when:
-        - WHERE follows LIMIT/OFFSET (pandas: slice then filter)
-        - ORDER BY follows LIMIT/OFFSET (pandas: slice then sort)
-
-        Args:
-            layers: List of operation lists, innermost first
-            base_clauses: Clauses for the innermost query
-
-        Returns:
-            SQL query string with nested subqueries
-        """
-        if not layers:
-            return ""
-
-        # Build innermost query (layer 0)
-        inner_clauses = extract_clauses_from_ops(layers[0], self.quote_char)
-
-        sql = self.build_simple_sql(
-            inner_clauses,
-            select_fields=inner_clauses.select_fields or None,
-            groupby_fields=self.ds._groupby_fields or None,
-            having_condition=self.ds._having_condition,
-            distinct=self.ds._distinct,
-        )
-
-        # Wrap with outer layers (layer 1, 2, ...)
-        for layer_idx, layer_ops in enumerate(layers[1:], 1):
-            layer_clauses = extract_clauses_from_ops(layer_ops, self.quote_char)
-            sql = self._wrap_with_layer(sql, layer_clauses, layer_idx)
-
-        return sql
-
-    def _wrap_with_layer(
-        self,
-        inner_sql: str,
-        clauses: ExtractedClauses,
-        layer_idx: int,
-        preserved_orderby: List[Tuple[Any, bool]] = None,
-        preserved_orderby_kind: str = None,
-    ) -> str:
-        """Wrap an inner SQL query with an outer layer.
-
-        Args:
-            inner_sql: The inner SQL query to wrap
-            clauses: Clauses to apply in this layer
-            layer_idx: Index of this layer (for alias naming)
-            preserved_orderby: ORDER BY from inner layers to preserve result ordering
-            preserved_orderby_kind: Sort kind (for stable sort detection)
-        """
-        outer_parts = ["SELECT *"]
-        outer_parts.append(f"FROM ({inner_sql}) AS __subq{layer_idx}__")
-
-        if clauses.where_conditions:
-            combined = clauses.where_conditions[0]
-            for cond in clauses.where_conditions[1:]:
-                combined = combined & cond
-            outer_parts.append(f"WHERE {combined.to_sql(quote_char=self.quote_char)}")
-
-        # Use layer's ORDER BY if present, otherwise use preserved ORDER BY from inner layers
-        # This ensures patterns like (ORDER BY + LIMIT) + WHERE maintain consistent row ordering
         orderby_to_use = (
             clauses.orderby_fields if clauses.orderby_fields else preserved_orderby
         )
         orderby_kind_to_use = (
             clauses.orderby_kind if clauses.orderby_fields else preserved_orderby_kind
         )
-
         if orderby_to_use:
             orderby_sql = build_orderby_clause(
                 orderby_to_use,
                 self.quote_char,
                 stable=is_stable_sort(orderby_kind_to_use),
             )
-            outer_parts.append(f"ORDER BY {orderby_sql}")
+            parts.append(f"ORDER BY {orderby_sql}")
+        elif add_row_order_fallback:
+            # Preserve pandas-like row order for the DataFrame source; _row_id
+            # is chDB's deterministic virtual column for Python() sources.
+            parts.append("ORDER BY _row_id")
 
         if clauses.limit_value is not None:
-            outer_parts.append(f"LIMIT {clauses.limit_value}")
-
+            parts.append(f"LIMIT {clauses.limit_value}")
         if clauses.offset_value is not None:
-            outer_parts.append(f"OFFSET {clauses.offset_value}")
+            parts.append(f"OFFSET {clauses.offset_value}")
 
-        return " ".join(outer_parts)
+        return " ".join(parts)
 
     def _build_join_clause(
         self, other_ds: "DataStore", join_type, join_condition
@@ -1265,47 +1774,21 @@ class SQLExecutionEngine:
                 groupby_agg=groupby_agg_op,
             )
 
-        # Collect SELECT fields from SQL operations (original logic)
-        sql_select_fields = []
-        has_column_assignments = False
-        has_select_star = False  # Track if '*' was in SELECT fields
-        for op in plan.sql_ops:
-            if isinstance(op, LazyRelationalOp):
-                if op.op_type == "SELECT" and op.fields:
-                    for f in op.fields:
-                        if isinstance(f, str):
-                            if f == "*":
-                                has_select_star = (
-                                    True  # Record that we need all columns
-                                )
-                            else:
-                                sql_select_fields.append(Field(f))
-                        else:
-                            sql_select_fields.append(f)
-            # Handle LazyColumnAssignment - add computed column expression
-            elif isinstance(op, LazyColumnAssignment) and op.can_push_to_sql():
-                sql_select_fields.append(op.get_sql_expression())
-                has_column_assignments = True
+        sql_select_fields, has_column_assignments = (
+            self._collect_select_fields_from_sql_ops(plan.sql_ops)
+        )
 
-        # If '*' was in SELECT fields, set has_column_assignments to trigger include_star
-        if has_select_star and sql_select_fields:
-            has_column_assignments = True
-
-        # Handle simple vs nested query
-        if len(layers) <= 1:
-            sql = self._build_simple_query_from_plan(
-                layers[0] if layers else [],
-                sql_select_fields,
-                groupby_agg_op,
-                where_ops,
-                alias_renames,
-                schema,
-                has_column_assignments,
-            )
-        else:
-            sql = self._build_nested_query_from_plan(
-                layers, sql_select_fields, has_column_assignments
-            )
+        # Unified layer loop: layer 0 reads from the table source,
+        # subsequent layers wrap "(inner_sql) AS __subqN__". Any temp
+        # aliases a layer introduces are accumulated and forwarded so
+        # downstream layers rewrite their column references accordingly.
+        sql = self._build_layered_sql(
+            layers if layers else [[]],
+            sql_select_fields,
+            alias_renames,
+            schema,
+            has_column_assignments,
+        )
 
         return SQLBuildResult(
             sql=sql,
@@ -1539,170 +2022,195 @@ class SQLExecutionEngine:
             sql = f"{sql} SETTINGS session_timezone='UTC'"
         return sql
 
-    def _build_simple_query_from_plan(
+    def _extract_special_ops_from_layer(
+        self, layer_ops: List[LazyOp]
+    ) -> Tuple[Optional[LazyGroupByAgg], List[Any]]:
+        """
+        Pull the LazyGroupByAgg (if any) and LazyWhere/LazyMask ops out of a
+        layer's op list, returning them separately for SQL dispatch.
+
+        Returns:
+            (groupby_agg_op, where_ops)
+        """
+        groupby_agg_op: Optional[LazyGroupByAgg] = None
+        where_ops: List[Any] = []
+        for op in layer_ops:
+            if isinstance(op, LazyGroupByAgg) and groupby_agg_op is None:
+                groupby_agg_op = op
+            elif isinstance(op, (LazyWhere, LazyMask)):
+                where_ops.append(op)
+        return groupby_agg_op, where_ops
+
+    def _collect_select_fields_from_sql_ops(
+        self, sql_ops: List[LazyOp]
+    ) -> Tuple[List[Expression], bool]:
+        """
+        Extract SELECT field expressions from ``plan.sql_ops``.
+
+        Walks the plan's pushable relational + column-assignment ops and
+        returns ``(sql_select_fields, has_column_assignments)``. The flag
+        captures both "this plan contains column assignments" and "the
+        plan's SELECT had a literal '*' that should be expanded into
+        ``SELECT *, computed_col`` semantics by ``include_star``.
+        """
+        sql_select_fields: List[Expression] = []
+        has_column_assignments = False
+        has_select_star = False
+
+        for op in sql_ops:
+            if isinstance(op, LazyRelationalOp):
+                if op.op_type == "SELECT" and op.fields:
+                    for f in op.fields:
+                        if isinstance(f, str):
+                            if f == "*":
+                                has_select_star = True
+                            else:
+                                sql_select_fields.append(Field(f))
+                        else:
+                            sql_select_fields.append(f)
+            elif isinstance(op, LazyColumnAssignment) and op.can_push_to_sql():
+                sql_select_fields.append(op.get_sql_expression())
+                has_column_assignments = True
+
+        # SELECT * with additional computed cols triggers include_star.
+        if has_select_star and sql_select_fields:
+            has_column_assignments = True
+
+        return sql_select_fields, has_column_assignments
+
+    def _build_layered_sql(
         self,
-        layer_ops: List[LazyOp],
+        layers: List[List[LazyOp]],
         sql_select_fields: List[Expression],
-        groupby_agg_op: Optional[LazyGroupByAgg],
-        where_ops: List[Any],
         alias_renames: Dict[str, str],
         schema: Dict[str, str],
-        has_column_assignments: bool = False,
+        has_column_assignments: bool,
+        first_layer_from_source: Optional[str] = None,
     ) -> str:
         """
-        Build a simple (non-nested) SQL query from plan components.
+        Build SQL by chaining ``_build_layer`` calls, one per nested
+        subquery layer. This is the canonical implementation of the
+        "compile a QueryPlan to SQL" pipeline.
+
+        Layer 0 reads from the table source (or ``first_layer_from_source``
+        when supplied - used by the Python() DataFrame execution path with
+        ``"__df__"``). Each subsequent layer reads ``(inner_sql) AS
+        __subqN__``. Temp aliases each layer introduces are accumulated
+        and fed to the next layer as ``inner_renames`` so its
+        WHERE/HAVING/ORDER BY ``Field`` references get rewritten to use
+        the actual emitted column names.
+
+        Args:
+            layers: List of per-layer op lists (innermost first). At least
+                one (possibly empty) layer must be supplied.
+            sql_select_fields: SELECT fields collected from
+                ``LazyRelationalOp(SELECT)`` / ``LazyColumnAssignment`` in
+                ``plan.sql_ops``; only used for the first layer.
+            alias_renames: ``plan.alias_renames`` - mutated to record any
+                temp aliases this build introduces (consumed by
+                post-execution rename-back).
+            schema: Column schema for type-aware CASE WHEN.
+            has_column_assignments: First-layer ``SELECT *, computed_col``
+                semantics flag.
+            first_layer_from_source: Optional explicit FROM source for layer
+                0 (e.g. ``"__df__"`` for Python() execution). When ``None``,
+                ``_build_layer`` derives FROM from ``self.ds``.
+
+        Returns:
+            The full nested SQL string.
         """
-        # Extract clauses
-        clauses = extract_clauses_from_ops(layer_ops, self.quote_char)
+        sql = ""
+        # ``inherited_renames`` is the temp_alias -> original_alias map (same
+        # format as ``plan.alias_renames``). It carries planner-seeded
+        # reservations plus everything previously emitted; the per-layer
+        # builder reads it only for ``build_groupby_select_fields`` alias
+        # collision detection. Field references are NOT rewritten through
+        # it - that's what ``previously_emitted_renames`` is for.
+        inherited_renames: Dict[str, str] = dict(alias_renames)
+        # ``previously_emitted_renames`` is the temp_alias -> original_alias
+        # map of renames that *already-built* layers actually emitted under
+        # temp aliases. The next layer's WHERE/ORDER BY Field refs are
+        # rewritten through this (inverted) so they bind to the correct
+        # subquery output column. Empty for the first layer.
+        previously_emitted_renames: Dict[str, str] = {}
+        preserved_orderby: Optional[List[Tuple[Any, bool]]] = None
+        preserved_orderby_kind: Optional[str] = None
 
-        # Apply alias renames to ORDER BY
-        clauses.orderby_fields = apply_alias_renames_to_orderby(
-            clauses.orderby_fields, alias_renames
-        )
+        for layer_idx, layer_ops in enumerate(layers):
+            is_first = layer_idx == 0
+            from_source = (
+                first_layer_from_source
+                if is_first
+                else f"({sql}) AS __subq{layer_idx}__"
+            )
 
-        # Handle LazyWhere/LazyMask SQL pushdown (CASE WHEN)
-        where_needs_subquery = False
-        where_needs_temp_alias = False
-        where_temp_alias_columns = []
-
-        if where_ops:
-            all_columns = self.ds._get_all_column_names()
-            if all_columns:
-                where_needs_temp_alias = True
-                for col in all_columns:
-                    temp_alias = f"__tmp_{col}__"
-                    where_temp_alias_columns.append((temp_alias, col))
-
-                sql_select_fields = [
-                    CaseWhenExpr(
-                        col,
-                        where_ops,
-                        self.quote_char,
-                        schema.get(col, "Unknown"),
-                        alias=f"__tmp_{col}__",
-                    )
-                    for col in all_columns
-                ]
-
-                if clauses.where_conditions:
-                    where_needs_subquery = True
-
-        # Handle LazyGroupByAgg SQL pushdown
-        groupby_fields_for_sql = self.ds._groupby_fields
-        select_fields_for_sql = sql_select_fields
-
-        if groupby_agg_op:
-            # Note: Pre-aggregation ORDER BY (from sort_values() before groupby) is already
-            # handled by the query planner - it won't be pushed to SQL. Any ORDER BY present
-            # here is a post-aggregation sort (e.g., groupby().agg().sort_values('mean'))
-            # and must be preserved.
-
-            # Get columns for aggregation - prioritize explicit column selection from
-            # df[['col1', 'col2']].groupby(...) over all source columns
-            # This ensures that df[['Pclass', 'Survived']].groupby('Pclass').mean()
-            # only aggregates 'Survived', not all columns from the source file
-            if clauses.select_fields:
-                # Use explicitly selected columns (from LazyRelationalOp(SELECT))
-                all_cols = []
-                for f in clauses.select_fields:
-                    if isinstance(f, Field):
-                        all_cols.append(f.name)
-                    elif hasattr(f, "alias") and f.alias:
-                        all_cols.append(f.alias)
-                    else:
-                        all_cols.append(str(f))
-            elif sql_select_fields:
-                # Use columns from passed-in select fields
-                all_cols = []
-                for f in sql_select_fields:
-                    if isinstance(f, Field):
-                        all_cols.append(f.name)
-                    elif hasattr(f, "alias") and f.alias:
-                        all_cols.append(f.alias)
-                    else:
-                        all_cols.append(str(f))
+            # Derive per-layer select fields so each layer only emits its
+            # own column assignments. The plan-wide ``sql_select_fields``
+            # (passed by ``build_sql_from_plan``) is only used for the
+            # first source-bound layer where we still want explicit column
+            # selections to reach ``assemble_sql``; the per-layer fields
+            # cover column assignments belonging to that specific layer.
+            (
+                layer_sql_select_fields,
+                layer_has_column_assignments,
+            ) = self._collect_select_fields_from_sql_ops(layer_ops)
+            if is_first and first_layer_from_source is None:
+                # Source-bound first layer keeps the legacy contract: the
+                # caller may pass a globally-collected ``sql_select_fields``
+                # which already includes this layer's own assignments.
+                effective_select_fields = sql_select_fields
+                effective_has_assignments = has_column_assignments
             else:
-                # Fall back to all source columns
-                all_cols = (
-                    self.ds._get_all_column_names()
-                    if hasattr(self.ds, "_get_all_column_names")
-                    else None
+                effective_select_fields = layer_sql_select_fields
+                effective_has_assignments = layer_has_column_assignments
+
+            result = self._build_layer(
+                layer_ops,
+                from_source=from_source,
+                is_first_layer=is_first,
+                inherited_renames=inherited_renames,
+                previously_emitted_renames=previously_emitted_renames,
+                schema=schema,
+                sql_select_fields=effective_select_fields,
+                has_column_assignments=effective_has_assignments,
+                preserved_orderby=preserved_orderby if not is_first else None,
+                preserved_orderby_kind=(
+                    preserved_orderby_kind if not is_first else None
+                ),
+            )
+            sql = result.sql
+            alias_renames.update(result.renames_introduced)
+            inherited_renames = dict(inherited_renames)
+            inherited_renames.update(result.renames_introduced)
+
+            # Decide what crosses into the next layer's WHERE/ORDER BY rewriter:
+            # - If this layer aggregated, only its own emitted aliases are
+            #   visible downstream (previous source-col renames are gone).
+            # - Otherwise propagate previously-emitted forward unchanged
+            #   (a non-agg wrapper doesn't introduce new emissions).
+            layer_has_agg = any(isinstance(o, LazyGroupByAgg) for o in layer_ops)
+            if layer_has_agg:
+                previously_emitted_renames = dict(result.renames_introduced)
+                preserved_orderby = None
+                preserved_orderby_kind = None
+            else:
+                # WHERE/ORDER BY emissions are not introduced by non-agg
+                # layers; propagate previous map unchanged.
+                layer_clauses = extract_clauses_from_ops(layer_ops, self.quote_char)
+                visible_to_temp = {
+                    orig: temp for temp, orig in previously_emitted_renames.items()
+                }
+                layer_clauses.orderby_fields = rewrite_column_refs_in_orderby(
+                    apply_alias_renames_to_orderby(
+                        layer_clauses.orderby_fields, alias_renames
+                    ),
+                    visible_to_temp,
                 )
-            # Get computed columns for expanding assign() columns in aggregations
-            computed_cols = getattr(self.ds, "_computed_columns", None) or {}
-            groupby_fields_for_sql, select_fields_for_sql = build_groupby_select_fields(
-                groupby_agg_op,
-                alias_renames,
-                all_columns=all_cols,
-                computed_columns=computed_cols,
-            )
-            # Re-apply alias renames to ORDER BY since build_groupby_select_fields may have added new renames
-            # This handles cases like ORDER BY value where value is aggregated (sum(value) AS __agg_value__)
-            clauses.orderby_fields = apply_alias_renames_to_orderby(
-                clauses.orderby_fields, alias_renames
-            )
-            if groupby_agg_op.sort and not clauses.orderby_fields:
-                clauses.orderby_fields = [
-                    (Field(col), True) for col in groupby_agg_op.groupby_cols
-                ]
+                if layer_clauses.orderby_fields:
+                    preserved_orderby = layer_clauses.orderby_fields
+                    preserved_orderby_kind = layer_clauses.orderby_kind
 
-        # Determine if row order preservation is needed
-        # Skip row order preservation if source already preserves order (e.g., Parquet with preserve_order)
-        needs_row_order = (
-            clauses.needs_row_order(has_groupby=groupby_agg_op is not None)
-            and not self.source_preserves_row_order()
-        )
-
-        # Build SQL based on complexity
-        if where_needs_subquery:
-            return self.build_sql_with_case_when_subquery(
-                clauses, select_fields_for_sql, where_temp_alias_columns
-            )
-        elif where_needs_temp_alias and where_temp_alias_columns:
-            return self._build_temp_alias_query(
-                clauses,
-                select_fields_for_sql,
-                where_temp_alias_columns,
-                needs_row_order,
-            )
-        elif needs_row_order and clauses.where_conditions and not self.ds._joins:
-            # Only use row order subquery when there are no JOINs
-            # JOINs require the full _build_sql_from_state path
-            return self.build_sql_with_row_order_subquery(
-                clauses,
-                select_fields_for_sql,
-                groupby_fields_for_sql,
-                include_star=has_column_assignments,
-            )
-        else:
-            # Simple case - use assemble_sql
-            effective_orderby = clauses.orderby_fields
-            if (
-                needs_row_order
-                and not clauses.orderby_fields
-                and (clauses.where_conditions or self.ds._joins)
-            ):
-                effective_orderby = [("__rowNumberInAllBlocks__", True)]
-
-            # When DISTINCT is active, don't use include_star because it would
-            # expand * to all source columns (defeating column selection + DISTINCT).
-            # Column assignments are already in select_fields_for_sql.
-            use_include_star = has_column_assignments if has_column_assignments else None
-            if self.ds._distinct and use_include_star:
-                use_include_star = None
-
-            return self.assemble_sql(
-                select_fields_for_sql,
-                clauses.where_conditions,
-                effective_orderby,
-                clauses.limit_value,
-                clauses.offset_value,
-                joins=self.ds._joins,
-                distinct=self.ds._distinct,
-                groupby_fields=groupby_fields_for_sql,
-                having_condition=self.ds._having_condition,
-                include_star=use_include_star,
-            )
+        return sql
 
     def _build_temp_alias_query(
         self,
@@ -1795,54 +2303,6 @@ class SQLExecutionEngine:
 
         return "\n".join(sql_parts)
 
-    def _build_nested_query_from_plan(
-        self,
-        layers: List[List[LazyOp]],
-        sql_select_fields: List[Expression],
-        has_column_assignments: bool = False,
-    ) -> str:
-        """Build nested subquery SQL for complex patterns."""
-        # Build innermost query (layer 0)
-        inner_clauses = extract_clauses_from_ops(layers[0], self.quote_char)
-
-        sql = self.assemble_sql(
-            sql_select_fields,
-            inner_clauses.where_conditions,
-            inner_clauses.orderby_fields,
-            inner_clauses.limit_value,
-            inner_clauses.offset_value,
-            joins=self.ds._joins,
-            distinct=self.ds._distinct,
-            groupby_fields=self.ds._groupby_fields,
-            having_condition=self.ds._having_condition,
-            include_star=has_column_assignments if has_column_assignments else None,
-        )
-
-        # Track ORDER BY from inner layers to preserve sort order in final result
-        # When we have patterns like ORDER BY + LIMIT + WHERE, the inner ORDER BY
-        # must be applied to the final result to maintain consistent row ordering
-        preserved_orderby = inner_clauses.orderby_fields
-        preserved_orderby_kind = inner_clauses.orderby_kind
-
-        # Wrap with outer layers
-        for layer_idx, layer_ops in enumerate(layers[1:], 1):
-            layer_clauses = extract_clauses_from_ops(layer_ops, self.quote_char)
-
-            # If this layer has ORDER BY, use it; otherwise preserve from inner
-            if layer_clauses.orderby_fields:
-                preserved_orderby = layer_clauses.orderby_fields
-                preserved_orderby_kind = layer_clauses.orderby_kind
-
-            sql = self._wrap_with_layer(
-                sql,
-                layer_clauses,
-                layer_idx,
-                preserved_orderby=preserved_orderby,
-                preserved_orderby_kind=preserved_orderby_kind,
-            )
-
-        return sql
-
     def assemble_sql(
         self,
         select_fields,
@@ -1855,6 +2315,7 @@ class SQLExecutionEngine:
         groupby_fields=None,
         having_condition=None,
         include_star=None,
+        from_source: Optional[str] = None,
     ) -> str:
         """
         Assemble SQL query from given components.
@@ -1868,11 +2329,16 @@ class SQLExecutionEngine:
             orderby_fields: List of (field, ascending) tuples
             limit_value: LIMIT value
             offset_value: OFFSET value
-            joins: List of JOIN tuples
+            joins: List of JOIN tuples (ignored when ``from_source`` is set -
+                wrapper layers don't carry source-level JOINs)
             distinct: Whether to use DISTINCT
             groupby_fields: GROUP BY fields
             having_condition: HAVING condition
             include_star: If True, use SELECT *, computed_cols. If None, use self.ds._select_star
+            from_source: Optional explicit FROM source SQL fragment (e.g.
+                ``"(__inner_sql__) AS __subq1__"`` or ``"__df__"``). When ``None``
+                the FROM clause is derived from ``self.ds._table_function`` /
+                ``self.ds.table_name`` (legacy source-bound behaviour).
 
         Returns:
             SQL query string
@@ -1921,8 +2387,13 @@ class SQLExecutionEngine:
         else:
             parts.append(f"SELECT {distinct_keyword}*")
 
-        # FROM (with alias if joins present)
-        if self.ds._table_function:
+        # FROM clause
+        if from_source is not None:
+            # Caller supplied an explicit source (wrapper layer or DataFrame
+            # source). JOINs are NOT propagated through wrappers - they only
+            # belong to the original table reference.
+            parts.append(f"FROM {from_source}")
+        elif self.ds._table_function:
             # Handle table function objects
             if hasattr(self.ds._table_function, "to_sql"):
                 table_sql = self.ds._table_function.to_sql()
@@ -1939,8 +2410,8 @@ class SQLExecutionEngine:
         elif self.ds.table_name:
             parts.append(f"FROM {self.quote_char}{self.ds.table_name}{self.quote_char}")
 
-        # JOIN clauses
-        if joins:
+        # JOIN clauses (only when using the source-bound FROM path)
+        if joins and from_source is None:
             for other_ds, join_type, join_condition in joins:
                 parts.append(
                     self._build_join_clause(other_ds, join_type, join_condition)
@@ -2220,10 +2691,23 @@ class SQLExecutionEngine:
         """
         schema = schema or {}
 
-        # Check if we have multiple layers (nested LIMIT-WHERE patterns)
+        # Multi-layer plans go through the unified ``_build_layered_sql``
+        # pipeline with ``__df__`` as the FROM source. This ensures any
+        # LazyGroupByAgg / LazyWhere that lives in a non-zero layer is
+        # dispatched correctly (the previous ``_build_nested_sql_for_dataframe``
+        # path silently dropped them just like the source path used to).
         if plan.layers and len(plan.layers) > 1:
-            # Build nested subqueries from layers
-            return self._build_nested_sql_for_dataframe(plan.layers)
+            sql_select_fields, has_column_assignments = (
+                self._collect_select_fields_from_sql_ops(plan.sql_ops)
+            )
+            return self._build_layered_sql(
+                plan.layers,
+                sql_select_fields,
+                plan.alias_renames,
+                schema,
+                has_column_assignments,
+                first_layer_from_source="__df__",
+            )
 
         # Extract clauses for simple/single layer case
         clauses = extract_clauses_from_ops(plan.sql_ops, self.quote_char)
@@ -2243,12 +2727,17 @@ class SQLExecutionEngine:
             df_columns = list(df.columns)
             # Get computed columns for expanding assign() columns in aggregations
             computed_cols = getattr(self.ds, "_computed_columns", None) or {}
-            groupby_fields, select_fields = build_groupby_select_fields(
+            (
+                groupby_fields,
+                select_fields,
+                new_renames,
+            ) = build_groupby_select_fields(
                 plan.groupby_agg,
                 plan.alias_renames,
                 all_columns=df_columns,
                 computed_columns=computed_cols,
             )
+            plan.alias_renames.update(new_renames)
             # Re-apply alias renames to ORDER BY since build_groupby_select_fields may have added new renames
             if plan.alias_renames and clauses.orderby_fields:
                 clauses.orderby_fields = apply_alias_renames_to_orderby(
@@ -2584,110 +3073,3 @@ class SQLExecutionEngine:
 
         return False
 
-    def _build_nested_sql_for_dataframe(self, layers: List[List[LazyOp]]) -> str:
-        """
-        Build nested subquery SQL for DataFrame execution with multiple layers.
-
-        Each layer becomes a subquery wrapping the previous one:
-        Layer 0: SELECT * FROM __df__ WHERE value > 20 ORDER BY a DESC LIMIT 30
-        Layer 1: SELECT * FROM (layer0) WHERE value > 60 ORDER BY a DESC LIMIT 10
-        Layer 2: SELECT * FROM (layer1) WHERE value > 75 ORDER BY a DESC
-
-        ORDER BY from inner layers is preserved in outer layers to maintain consistent
-        row ordering after filters. This ensures patterns like
-        df.sort_values('a').head(7)[df['a'] > 4] return rows in the sorted order.
-
-        Args:
-            layers: List of operation layers from QueryPlan
-
-        Returns:
-            Nested SQL query string
-        """
-        # Build innermost query from layer 0
-        inner_clauses = extract_clauses_from_ops(layers[0], self.quote_char)
-        # add_row_order=True ensures LIMIT/OFFSET with no explicit ORDER BY gets ORDER BY _row_id
-        sql = self._assemble_simple_sql("__df__", inner_clauses, add_row_order=True)
-
-        # Track ORDER BY from inner layer to preserve in outer layers
-        preserved_orderby = inner_clauses.orderby_fields
-
-        # Wrap with outer layers
-        for layer_idx, layer_ops in enumerate(layers[1:], 1):
-            layer_clauses = extract_clauses_from_ops(layer_ops, self.quote_char)
-            subq_alias = f"__subq{layer_idx}__"
-
-            # If this layer has ORDER BY, use it; otherwise preserve from inner layers
-            if layer_clauses.orderby_fields:
-                preserved_orderby = layer_clauses.orderby_fields
-
-            # Each layer also needs deterministic ordering for LIMIT/OFFSET
-            sql = self._assemble_simple_sql(
-                f"({sql}) AS {subq_alias}",
-                layer_clauses,
-                add_row_order=True,
-                preserved_orderby=preserved_orderby,
-            )
-
-        return sql
-
-    def _assemble_simple_sql(
-        self,
-        from_source: str,
-        clauses: ExtractedClauses,
-        add_row_order: bool = False,
-        preserved_orderby: List[Tuple[Any, bool]] = None,
-    ) -> str:
-        """
-        Assemble a simple SQL query from a source and clauses.
-
-        Args:
-            from_source: The FROM clause source (table name or subquery)
-            clauses: Extracted SQL clauses
-            add_row_order: If True and there's LIMIT/OFFSET without explicit ORDER BY,
-                           add ORDER BY _row_id to preserve pandas-like row order
-            preserved_orderby: ORDER BY fields from inner layers to preserve sort order
-
-        Returns:
-            SQL query string
-        """
-        # Build SELECT clause - include computed columns if present
-        if clauses.select_fields:
-            fields_sql = ", ".join(
-                f.to_sql(quote_char=self.quote_char, with_alias=True)
-                for f in clauses.select_fields
-            )
-            parts = [f"SELECT *, {fields_sql}"]
-        else:
-            parts = ["SELECT *"]
-        parts.append(f"FROM {from_source}")
-
-        if clauses.where_conditions:
-            combined = clauses.where_conditions[0]
-            for cond in clauses.where_conditions[1:]:
-                combined = combined & cond
-            parts.append(f"WHERE {combined.to_sql(quote_char=self.quote_char)}")
-
-        # Add ORDER BY - either explicit, preserved from inner, or _row_id for row order preservation
-        # Priority: explicit ORDER BY > preserved ORDER BY > _row_id fallback
-        orderby_to_use = (
-            clauses.orderby_fields if clauses.orderby_fields else preserved_orderby
-        )
-
-        if orderby_to_use:
-            orderby_sql = build_orderby_clause(
-                orderby_to_use, self.quote_char, stable=False
-            )
-            parts.append(f"ORDER BY {orderby_sql}")
-        elif add_row_order:
-            # Add ORDER BY _row_id to preserve pandas-like row order
-            # This ensures filter operations maintain original row order
-            # _row_id is a built-in virtual column in chDB v4.0.0b5+
-            parts.append("ORDER BY _row_id")
-
-        if clauses.limit_value is not None:
-            parts.append(f"LIMIT {clauses.limit_value}")
-
-        if clauses.offset_value is not None:
-            parts.append(f"OFFSET {clauses.offset_value}")
-
-        return " ".join(parts)

--- a/datastore/tests/test_groupby_sql_pushdown.py
+++ b/datastore/tests/test_groupby_sql_pushdown.py
@@ -237,7 +237,8 @@ class TestQueryPlannerAliasRenames(unittest.TestCase):
 
         # Plan the operations
         planner = QueryPlanner()
-        plan = planner.plan(new_ds._lazy_ops, has_sql_source=True)
+        exec_plan = planner.plan_segments(new_ds._lazy_ops, has_sql_source=True)
+        plan = exec_plan.segments[0].plan
 
         # Should detect conflict and create alias_renames
         self.assertIn('__agg_int_col__', plan.alias_renames)
@@ -262,7 +263,8 @@ class TestQueryPlannerAliasRenames(unittest.TestCase):
         )
 
         planner = QueryPlanner()
-        plan = planner.plan(new_ds._lazy_ops, has_sql_source=True)
+        exec_plan = planner.plan_segments(new_ds._lazy_ops, has_sql_source=True)
+        plan = exec_plan.segments[0].plan
 
         # Conflict should be detected (int_col is in both WHERE and agg alias)
         self.assertIn('__agg_int_col__', plan.alias_renames)
@@ -334,6 +336,571 @@ class TestOrderByAliasMapping(unittest.TestCase):
 
         np.testing.assert_array_equal(ds_result.index, pd_result.index)
         np.testing.assert_array_equal(ds_result['a'], pd_result['a'])
+
+
+class TestPostAggregationFilterAfterLimit(unittest.TestCase):
+    """Regression tests for filtering on an aggregated column after sort+head.
+
+    Original report: chaining
+        df[df['verified_purchase'] == True]
+          .groupby('product_category')['star_rating']
+          .agg(['mean','count'])
+          .sort_values('count', ascending=False)
+          .head(10)
+        [<above>['count'] > N]
+    used to emit nested SQL whose inner subquery dropped the GROUP BY +
+    aggregation entirely, producing
+        ``SELECT * FROM source WHERE ... ORDER BY count DESC LIMIT 10``
+    and failing with ``UNKNOWN_IDENTIFIER`` for ``count``.
+
+    These tests verify that boolean indexing, ``.loc[...]``, and
+    ``.query(...)`` on the aggregated column after a sort+head all execute
+    successfully and match pandas.
+    """
+
+    def setUp(self):
+        """Set up test data with enough rows to make filtering meaningful."""
+        np.random.seed(42)
+        self.n_rows = 50000
+        self.df = pd.DataFrame(
+            {
+                'product_category': np.random.choice(
+                    ['Home', 'Books', 'Apparel', 'Beauty', 'Kitchen', 'Mobile_Apps', 'Sports'],
+                    self.n_rows,
+                ),
+                'star_rating': np.random.choice([1, 2, 3, 4, 5], self.n_rows),
+                'verified_purchase': np.random.choice([True, False], self.n_rows, p=[0.7, 0.3]),
+            }
+        )
+        self.temp_dir = tempfile.mkdtemp()
+        self.parquet_path = os.path.join(self.temp_dir, 'amazon_sample.parquet')
+        self.df.to_parquet(self.parquet_path)
+
+    def tearDown(self):
+        """Clean up temporary files."""
+        import shutil
+
+        shutil.rmtree(self.temp_dir)
+
+    def _build_aggregated(self, source):
+        """Mirror code: build the agg+sort+head pipeline on either engine."""
+        return (
+            source[source['verified_purchase'] == True]
+            .groupby('product_category')['star_rating']
+            .agg(['mean', 'count'])
+            .sort_values('count', ascending=False)
+            .head(n=10)
+        )
+
+    def test_boolean_mask_filter_on_agg_count_after_sort_head_matches_pandas(self):
+        """``result[result['count'] > N]`` must keep the inner GROUP BY/aggregation."""
+        ds = DataStore.from_file(self.parquet_path)
+
+        pd_agg = self._build_aggregated(self.df)
+        ds_agg = self._build_aggregated(ds)
+
+        pd_filtered = pd_agg[pd_agg['count'] > 5000]
+        ds_filtered = ds_agg[ds_agg['count'] > 5000]
+
+        np.testing.assert_array_equal(ds_filtered.index, pd_filtered.index)
+        self.assertEqual(list(ds_filtered.columns), list(pd_filtered.columns))
+        np.testing.assert_array_equal(ds_filtered['count'], pd_filtered['count'])
+        np.testing.assert_allclose(ds_filtered['mean'], pd_filtered['mean'], rtol=1e-5)
+
+    def test_loc_filter_on_agg_count_after_sort_head_matches_pandas(self):
+        """``result.loc[result['count'] > N]`` must produce the same data as pandas."""
+        ds = DataStore.from_file(self.parquet_path)
+
+        pd_agg = self._build_aggregated(self.df)
+        ds_agg = self._build_aggregated(ds)
+
+        pd_filtered = pd_agg.loc[pd_agg['count'] > 5000]
+        ds_filtered = ds_agg.loc[ds_agg['count'] > 5000]
+
+        np.testing.assert_array_equal(ds_filtered.index, pd_filtered.index)
+        self.assertEqual(list(ds_filtered.columns), list(pd_filtered.columns))
+        np.testing.assert_array_equal(ds_filtered['count'], pd_filtered['count'])
+        np.testing.assert_allclose(ds_filtered['mean'], pd_filtered['mean'], rtol=1e-5)
+
+    def test_query_filter_on_agg_count_after_sort_head_matches_pandas(self):
+        """``result.query('count > N')`` must produce the same data as pandas."""
+        ds = DataStore.from_file(self.parquet_path)
+
+        pd_agg = self._build_aggregated(self.df)
+        ds_agg = self._build_aggregated(ds)
+
+        pd_filtered = pd_agg.query('count > 5000')
+        ds_filtered = ds_agg.query('count > 5000')
+
+        np.testing.assert_array_equal(ds_filtered.index, pd_filtered.index)
+        self.assertEqual(list(ds_filtered.columns), list(pd_filtered.columns))
+        np.testing.assert_array_equal(ds_filtered['count'], pd_filtered['count'])
+        np.testing.assert_allclose(ds_filtered['mean'], pd_filtered['mean'], rtol=1e-5)
+
+    def test_inner_layer_preserves_group_by_and_aggregation_in_sql(self):
+        """Generated nested SQL must keep the GROUP BY + aggregation in the inner subquery.
+
+        Without the fix, the inner subquery became
+        ``SELECT * FROM source WHERE ... ORDER BY count DESC LIMIT 10`` -
+        which fails because ``count`` is not a source column.
+        """
+        from datastore.query_planner import QueryPlanner
+        from datastore.sql_executor import SQLExecutionEngine
+        from datastore.lazy_ops import LazyGroupByAgg
+
+        ds = DataStore.from_file(self.parquet_path)
+        ds_agg = self._build_aggregated(ds)
+        ds_filtered = ds_agg[ds_agg['count'] > 5000]
+
+        planner = QueryPlanner()
+        exec_plan = planner.plan_segments(
+            ds_filtered._lazy_ops, has_sql_source=True, schema=None
+        )
+        # Expect a single SQL segment for this fully push-downable chain.
+        self.assertEqual(len(exec_plan.segments), 1)
+        seg = exec_plan.segments[0]
+        self.assertEqual(seg.segment_type, 'sql')
+        self.assertIsNotNone(seg.plan)
+        # The LazyGroupByAgg must live inside layer 0 so that the per-layer
+        # SQL builder dispatches GROUP BY into the innermost subquery.
+        self.assertTrue(
+            any(isinstance(op, LazyGroupByAgg) for op in seg.plan.layers[0]),
+            f"Expected LazyGroupByAgg in inner layer, got: {seg.plan.layers}",
+        )
+
+        engine = SQLExecutionEngine(ds_filtered)
+        sql_result = engine.build_sql_from_plan(seg.plan, schema={})
+        sql = sql_result.sql
+
+        # The inner subquery (before the outer WHERE on the agg result) MUST
+        # contain GROUP BY and the aggregation functions for the SQL to be
+        # well-formed and reference ``count``.
+        self.assertIn('GROUP BY', sql)
+        self.assertIn('avg("star_rating")', sql)
+        self.assertIn('count("star_rating")', sql)
+        # The outer WHERE references the aggregate alias.
+        self.assertIn('> 5000', sql)
+
+
+class TestGroupByInNonZeroLayer(unittest.TestCase):
+    """Regression tests for LazyGroupByAgg living in a non-innermost layer.
+
+    A real-world chain like
+        df[x > N].head(K)[y > M].groupby('z').agg('sum')[(agg_col > V)]
+    produces layers:
+        layer 0: [WHERE x>N, LIMIT K]
+        layer 1: [WHERE y>M, LazyGroupByAgg(z, sum), (optional) WHERE agg_col>V]
+    The previous architecture stripped LazyGroupByAgg out of the layer
+    contents and only re-injected it into the innermost layer's SQL builder.
+    When the GroupByAgg lived in layer 1+, the wrapper builder silently
+    dropped it and the query returned raw filtered rows instead of an
+    aggregated result.
+
+    These tests exercise that pattern and assert (a) the SQL contains
+    GROUP BY in the correct subquery layer, and (b) the executed result
+    matches pandas to the row/value.
+    """
+
+    def setUp(self):
+        np.random.seed(42)
+        self.n = 500
+        self.df = pd.DataFrame(
+            {
+                'x': np.random.randint(0, 100, self.n),
+                'y': np.random.randint(0, 100, self.n),
+                'z': np.random.choice(['A', 'B', 'C', 'D'], self.n),
+                'v': np.random.randint(0, 1000, self.n),
+            }
+        )
+        self.temp_dir = tempfile.mkdtemp()
+        self.parquet_path = os.path.join(self.temp_dir, 'test.parquet')
+        self.df.to_parquet(self.parquet_path)
+
+    def tearDown(self):
+        import shutil
+
+        shutil.rmtree(self.temp_dir)
+
+    def _planner_layers(self, ds_chain):
+        from datastore.query_planner import QueryPlanner
+
+        planner = QueryPlanner()
+        exec_plan = planner.plan_segments(
+            ds_chain._lazy_ops, has_sql_source=True, schema=None
+        )
+        self.assertEqual(len(exec_plan.segments), 1)
+        seg = exec_plan.segments[0]
+        self.assertEqual(seg.segment_type, 'sql')
+        self.assertIsNotNone(seg.plan)
+        return seg.plan
+
+    def test_filter_limit_filter_groupby_agg_lives_in_wrapper_layer(self):
+        """``df[x>N].head(K)[y>M].groupby('z').agg('sum')`` puts GroupByAgg
+        into layer 1, and the SQL must wrap with GROUP BY in the outer query."""
+        from datastore.lazy_ops import LazyGroupByAgg
+        from datastore.sql_executor import SQLExecutionEngine
+
+        ds = DataStore.from_file(self.parquet_path)
+        ds_chain = (
+            ds[ds['x'] > 20].head(100)
+        )
+        ds_chain = ds_chain[ds_chain['y'] > 30].groupby('z').agg({'v': 'sum'})
+
+        plan = self._planner_layers(ds_chain)
+        # Two layers, GroupByAgg lives in layer 1 (not layer 0)
+        self.assertEqual(len(plan.layers), 2)
+        self.assertFalse(
+            any(isinstance(op, LazyGroupByAgg) for op in plan.layers[0]),
+            f"Expected layer 0 to not contain LazyGroupByAgg, got {plan.layers[0]}",
+        )
+        self.assertTrue(
+            any(isinstance(op, LazyGroupByAgg) for op in plan.layers[1]),
+            f"Expected layer 1 to contain LazyGroupByAgg, got {plan.layers[1]}",
+        )
+
+        engine = SQLExecutionEngine(ds_chain)
+        sql = engine.build_sql_from_plan(plan, schema={}).sql
+        # The outer subquery (layer 1's SQL) must contain GROUP BY and the
+        # aggregate. Without the fix, it would just be SELECT * FROM (...)
+        # WHERE y > 30 with no aggregation.
+        self.assertIn('GROUP BY', sql)
+        self.assertIn('sum("v")', sql)
+        # And the inner subquery is still the WHERE + LIMIT we expect
+        self.assertIn('"x" > 20', sql)
+        self.assertIn('LIMIT 100', sql)
+
+    def test_filter_limit_filter_groupby_agg_result_matches_pandas(self):
+        """End-to-end: same chain must return the same data as pandas."""
+        ds = DataStore.from_file(self.parquet_path)
+        ds_result = ds[ds['x'] > 20].head(100)
+        ds_result = ds_result[ds_result['y'] > 30].groupby('z').agg({'v': 'sum'})
+
+        pd_result = self.df[self.df['x'] > 20].head(100)
+        pd_result = pd_result[pd_result['y'] > 30].groupby('z').agg({'v': 'sum'})
+
+        ds_sorted = ds_result.sort_index()
+        pd_sorted = pd_result.sort_index()
+        np.testing.assert_array_equal(ds_sorted.index, pd_sorted.index)
+        self.assertEqual(list(ds_sorted.columns), list(pd_sorted.columns))
+        np.testing.assert_array_equal(ds_sorted['v'], pd_sorted['v'])
+
+    def test_filter_limit_filter_groupby_agg_filter_agg_col_matches_pandas(self):
+        """Same chain with an additional post-agg WHERE on the aggregated
+        column - the post-agg WHERE becomes HAVING in the wrapper layer."""
+        ds = DataStore.from_file(self.parquet_path)
+        ds_result = ds[ds['x'] > 20].head(200)
+        ds_result = ds_result[ds_result['y'] > 30].groupby('z').agg({'v': 'sum'})
+        ds_result = ds_result[ds_result['v'] > 5000]
+
+        pd_result = self.df[self.df['x'] > 20].head(200)
+        pd_result = pd_result[pd_result['y'] > 30].groupby('z').agg({'v': 'sum'})
+        pd_result = pd_result[pd_result['v'] > 5000]
+
+        ds_sorted = ds_result.sort_index()
+        pd_sorted = pd_result.sort_index()
+        np.testing.assert_array_equal(ds_sorted.index, pd_sorted.index)
+        self.assertEqual(list(ds_sorted.columns), list(pd_sorted.columns))
+        if len(pd_sorted) > 0:
+            np.testing.assert_array_equal(ds_sorted['v'], pd_sorted['v'])
+
+    def test_dataframe_source_groupby_agg_in_layer_n_matches_pandas(self):
+        """DataFrame-source equivalent of the layer-N GroupByAgg fix.
+
+        Same nested chain but the source is an in-memory DataFrame
+        (Python() table function), exercising the unified ``_build_layer``
+        loop with ``first_layer_from_source='__df__'``. Previously the
+        DataFrame path had its own ``_build_nested_sql_for_dataframe``
+        which silently dropped a GroupByAgg living in layer 1+; the
+        unified pipeline now dispatches it correctly here too.
+        """
+        ds = DataStore(self.df)
+        ds_result = ds[ds['x'] > 20].head(100)
+        ds_result = ds_result[ds_result['y'] > 30].groupby('z').agg({'v': 'sum'})
+
+        pd_result = self.df[self.df['x'] > 20].head(100)
+        pd_result = pd_result[pd_result['y'] > 30].groupby('z').agg({'v': 'sum'})
+
+        ds_sorted = ds_result.sort_index()
+        pd_sorted = pd_result.sort_index()
+        np.testing.assert_array_equal(ds_sorted.index, pd_sorted.index)
+        self.assertEqual(list(ds_sorted.columns), list(pd_sorted.columns))
+        np.testing.assert_array_equal(ds_sorted['v'], pd_sorted['v'])
+
+
+class TestCrossLayerAliasRewriting(unittest.TestCase):
+    """Regression tests for cross-layer alias rewriting.
+
+    When an inner subquery layer is forced to emit a column under a temp
+    alias due to a source-col/agg-alias conflict (e.g. ``SUM(int_col) AS
+    __agg_int_col__``), an outer wrapper layer that references the original
+    name (``int_col``) used to fail because the inner subquery no longer
+    exposed that name. The :func:`rewrite_column_refs_in_expression` /
+    :func:`rewrite_column_refs_in_orderby` helpers plus the
+    ``inner_visible_to_temp`` plumbing now rewrite the outer Field references
+    onto the temp alias.
+    """
+
+    def setUp(self):
+        np.random.seed(42)
+        n = 1000
+        self.df = pd.DataFrame(
+            {
+                'int_col': np.random.randint(0, 1000, n),
+                'float_col': np.random.uniform(0, 1000, n),
+                'category': np.random.choice(['A', 'B', 'C'], n),
+            }
+        )
+        self.temp_dir = tempfile.mkdtemp()
+        self.parquet_path = os.path.join(self.temp_dir, 'test.parquet')
+        self.df.to_parquet(self.parquet_path)
+
+    def tearDown(self):
+        import shutil
+
+        shutil.rmtree(self.temp_dir)
+
+    def test_source_conflict_with_post_limit_filter_on_same_col(self):
+        """Inner layer aliases ``int_col -> __agg_int_col__``; outer WHERE
+        on ``int_col`` must be rewritten to use the temp alias."""
+        pd_result = (
+            self.df[self.df['int_col'] > 200]
+            .groupby('category')
+            .agg({'int_col': 'sum'})
+            .sort_values('int_col', ascending=False)
+            .head(10)
+        )
+        pd_filter = pd_result[pd_result['int_col'] > 50000]
+
+        ds = DataStore.from_file(self.parquet_path)
+        ds_result = (
+            ds[ds['int_col'] > 200]
+            .groupby('category')
+            .agg({'int_col': 'sum'})
+            .sort_values('int_col', ascending=False)
+            .head(10)
+        )
+        ds_filter = ds_result[ds_result['int_col'] > 50000]
+
+        np.testing.assert_array_equal(ds_filter.index, pd_filter.index)
+        np.testing.assert_array_equal(ds_filter['int_col'], pd_filter['int_col'])
+
+    def test_source_conflict_with_post_limit_orderby_on_same_col(self):
+        """Same conflict pattern but the outer layer does ORDER BY on the
+        renamed column instead of WHERE."""
+        pd_base = (
+            self.df[self.df['int_col'] > 200]
+            .groupby('category')
+            .agg({'int_col': 'sum'})
+            .sort_values('int_col', ascending=False)
+            .head(10)
+        )
+        pd_sorted = pd_base.sort_values('int_col', ascending=True)
+
+        ds = DataStore.from_file(self.parquet_path)
+        ds_base = (
+            ds[ds['int_col'] > 200]
+            .groupby('category')
+            .agg({'int_col': 'sum'})
+            .sort_values('int_col', ascending=False)
+            .head(10)
+        )
+        ds_sorted = ds_base.sort_values('int_col', ascending=True)
+
+        np.testing.assert_array_equal(ds_sorted.index, pd_sorted.index)
+        np.testing.assert_array_equal(ds_sorted['int_col'], pd_sorted['int_col'])
+
+    def test_rewrite_column_refs_in_expression_returns_new_tree(self):
+        """The helper must return a new tree without mutating the original."""
+        from datastore.sql_executor import rewrite_column_refs_in_expression
+        from datastore.expressions import Field, Literal
+        from datastore.conditions import BinaryCondition, CompoundCondition
+
+        original = CompoundCondition(
+            'AND',
+            BinaryCondition('>', Field('a'), Literal(1)),
+            BinaryCondition('<', Field('b'), Literal(10)),
+        )
+        rewritten = rewrite_column_refs_in_expression(original, {'a': '__a__'})
+
+        # Original tree untouched
+        self.assertEqual(original.left.left.name, 'a')
+        # Rewritten tree has the new name
+        self.assertEqual(rewritten.left.left.name, '__a__')
+        # Non-targeted field is unchanged
+        self.assertEqual(rewritten.right.left.name, 'b')
+
+    def test_rewrite_column_refs_handles_unary_in_between(self):
+        """The helper recurses through UnaryCondition / InCondition /
+        BetweenCondition with no exceptions and rewrites their nested
+        Field references."""
+        from datastore.sql_executor import rewrite_column_refs_in_expression
+        from datastore.expressions import Field, Literal
+        from datastore.conditions import (
+            UnaryCondition,
+            InCondition,
+            BetweenCondition,
+        )
+
+        rename = {'col': '__col__'}
+
+        unary = UnaryCondition('IS NULL', Field('col'))
+        rewritten_unary = rewrite_column_refs_in_expression(unary, rename)
+        self.assertEqual(rewritten_unary.expression.name, '__col__')
+
+        in_cond = InCondition(Field('col'), [1, 2, 3])
+        rewritten_in = rewrite_column_refs_in_expression(in_cond, rename)
+        self.assertEqual(rewritten_in.expression.name, '__col__')
+
+        between = BetweenCondition(Field('col'), Literal(1), Literal(10))
+        rewritten_between = rewrite_column_refs_in_expression(between, rename)
+        self.assertEqual(rewritten_between.expression.name, '__col__')
+
+
+class TestDispatchByOpType(unittest.TestCase):
+    """Unit tests for :meth:`SQLExecutionEngine._build_layer` op-type
+    dispatch.
+
+    These tests exercise the layer builder directly to confirm it dispatches
+    on LazyGroupByAgg vs LazyWhere vs plain relational ops without relying
+    on end-to-end execution.
+    """
+
+    def setUp(self):
+        np.random.seed(0)
+        self.n = 100
+        self.df = pd.DataFrame(
+            {
+                'a': np.random.randint(0, 100, self.n),
+                'b': np.random.randint(0, 100, self.n),
+                'cat': np.random.choice(['X', 'Y'], self.n),
+            }
+        )
+        self.temp_dir = tempfile.mkdtemp()
+        self.parquet_path = os.path.join(self.temp_dir, 'test.parquet')
+        self.df.to_parquet(self.parquet_path)
+
+    def tearDown(self):
+        import shutil
+
+        shutil.rmtree(self.temp_dir)
+
+    def test_layer_with_groupby_agg_produces_group_by_sql(self):
+        """A layer containing a WHERE + LazyGroupByAgg + ORDER BY must emit
+        SQL containing GROUP BY and the aggregation function."""
+        from datastore.lazy_ops import LazyRelationalOp, LazyGroupByAgg
+        from datastore.sql_executor import SQLExecutionEngine
+        from datastore.expressions import Field, Literal
+        from datastore.conditions import BinaryCondition
+
+        ds = DataStore.from_file(self.parquet_path)
+        where = LazyRelationalOp(
+            'WHERE', 'a > 5', condition=BinaryCondition('>', Field('a'), Literal(5))
+        )
+        agg = LazyGroupByAgg(groupby_cols=['cat'], agg_dict={'a': 'sum'})
+        order = LazyRelationalOp('ORDER BY', '"cat"', fields=[Field('cat')], ascending=True)
+
+        engine = SQLExecutionEngine(ds)
+        result = engine._build_layer(
+            [where, agg, order],
+            from_source=None,
+            is_first_layer=True,
+            inherited_renames={},
+            schema={},
+            sql_select_fields=[],
+        )
+        sql = result.sql
+        self.assertIn('GROUP BY', sql)
+        self.assertIn('sum("a")', sql)
+        self.assertIn('WHERE "a" > 5', sql)
+
+    def test_layer_without_groupby_agg_skips_group_by(self):
+        """A layer with only WHERE/ORDER BY/LIMIT must not emit GROUP BY."""
+        from datastore.lazy_ops import LazyRelationalOp
+        from datastore.sql_executor import SQLExecutionEngine
+        from datastore.expressions import Field, Literal
+        from datastore.conditions import BinaryCondition
+
+        ds = DataStore.from_file(self.parquet_path)
+        where = LazyRelationalOp(
+            'WHERE', 'a > 5', condition=BinaryCondition('>', Field('a'), Literal(5))
+        )
+        limit = LazyRelationalOp('LIMIT', '10', limit_value=10)
+
+        engine = SQLExecutionEngine(ds)
+        result = engine._build_layer(
+            [where, limit],
+            from_source=None,
+            is_first_layer=True,
+            inherited_renames={},
+            schema={},
+            sql_select_fields=[],
+        )
+        sql = result.sql
+        self.assertNotIn('GROUP BY', sql)
+        self.assertIn('WHERE "a" > 5', sql)
+        self.assertIn('LIMIT 10', sql)
+
+    def test_extract_special_ops_finds_groupby_and_where_mask(self):
+        """The helper that scans a layer for special ops should find
+        LazyGroupByAgg and LazyWhere/LazyMask but not LazyRelationalOp."""
+        from datastore.lazy_ops import (
+            LazyRelationalOp,
+            LazyGroupByAgg,
+            LazyWhere,
+            LazyMask,
+        )
+        from datastore.sql_executor import SQLExecutionEngine
+        from datastore.expressions import Field, Literal
+        from datastore.conditions import BinaryCondition
+
+        ds = DataStore.from_file(self.parquet_path)
+        engine = SQLExecutionEngine(ds)
+
+        where_rel = LazyRelationalOp(
+            'WHERE', 'a > 5', condition=BinaryCondition('>', Field('a'), Literal(5))
+        )
+        agg = LazyGroupByAgg(groupby_cols=['cat'], agg_func='sum')
+        lazy_where = LazyWhere(
+            BinaryCondition('>', Field('a'), Literal(0)), other=0
+        )
+        lazy_mask = LazyMask(
+            BinaryCondition('>', Field('b'), Literal(0)), other=0
+        )
+
+        gb, wheres = engine._extract_special_ops_from_layer(
+            [where_rel, agg, lazy_where, lazy_mask]
+        )
+        self.assertIs(gb, agg)
+        self.assertEqual(wheres, [lazy_where, lazy_mask])
+
+    def test_split_wheres_by_groupby_position(self):
+        """WHEREs strictly before LazyGroupByAgg go to pre_agg (WHERE),
+        WHEREs after go to post_agg (HAVING)."""
+        from datastore.lazy_ops import LazyRelationalOp, LazyGroupByAgg
+        from datastore.sql_executor import SQLExecutionEngine
+        from datastore.expressions import Field, Literal
+        from datastore.conditions import BinaryCondition
+
+        ds = DataStore.from_file(self.parquet_path)
+        engine = SQLExecutionEngine(ds)
+
+        pre_where = LazyRelationalOp(
+            'WHERE', 'a > 1', condition=BinaryCondition('>', Field('a'), Literal(1))
+        )
+        agg = LazyGroupByAgg(groupby_cols=['cat'], agg_dict={'a': 'sum'})
+        post_where = LazyRelationalOp(
+            'WHERE', 'a > 5', condition=BinaryCondition('>', Field('a'), Literal(5))
+        )
+
+        pre, post = engine._split_wheres_by_groupby_position(
+            [pre_where, agg, post_where]
+        )
+        self.assertEqual(len(pre), 1)
+        self.assertEqual(len(post), 1)
+        # Pre-agg condition is on the source column
+        self.assertIs(pre[0], pre_where.condition)
+        # Post-agg condition is on the aggregation output
+        self.assertIs(post[0], post_where.condition)
 
 
 class TestGroupBySQLPushdownPerformance(unittest.TestCase):


### PR DESCRIPTION
## Summary

Replaces the SQL builder's tangle of partially-overlapping helpers (`_build_layer_sql` / `_build_wrapper_layer_sql` / `_build_simple_query_from_plan` / `_build_nested_query_from_plan` / `_build_nested_sql_for_dataframe` / `_assemble_simple_sql` / `build_simple_sql` / `build_nested_sql` / `_wrap_with_layer`) with a single per-layer SQL builder.

The previous architecture kept `LazyGroupByAgg` / `LazyWhere` / `LazyMask` in side-channel fields (`plan.groupby_agg`, `plan.where_ops`) and relied on each call site to re-inject them into the right subquery layer. When a `GroupByAgg` landed in a non-innermost layer the wrapper builder silently dropped it, producing queries like `SELECT * FROM (...) WHERE count > 5000` against a base table that has no `count` column (the bug Mark reported on Slack). The DataFrame source had its own parallel `_build_nested_sql_for_dataframe` path with the same latent bug. Cross-layer alias rewriting (source-col vs agg-alias conflicts that span subquery boundaries) was patched in with snapshot/diff bookkeeping around a shared mutable `plan.alias_renames` dict.

> Depends on #576 — commit `fe26a87` (the explain() display fix) is included here as a prerequisite. Once #576 lands, rebase will leave just the unification commit.

### Architecture

- **`_build_layer(layer_ops, from_source, is_first_layer, inherited_renames, previously_emitted_renames, ...)`** is the only per-layer SQL function. Dispatches on op type, returns `LayerBuildResult(sql, renames_introduced)`. Used by both the source path and the DataFrame path.
- **`_build_layered_sql`** chains `_build_layer` over every layer in a plan; layer 0 reads the table source (or `__df__` for the DataFrame path), layers 1+ wrap `(inner_sql) AS __subqN__`.
- **`_render_first_layer_sql` / `_render_wrapper_layer_sql`** are the two rendering strategies (table-bound first layer with JOINs / row-order subquery / CASE WHEN subquery vs simple wrap over an explicit `from_source`).
- **`build_groupby_select_fields`** is now pure: takes `inherited_alias_renames` read-only and returns `(groupby_fields, select_fields, new_renames)`. No more mutation of shared state.
- **`assemble_sql`** takes an optional `from_source`. When set, JOINs are skipped (wrapper layers don't carry source-level joins) and the FROM is the supplied SQL fragment.
- **Cross-layer renames** travel through two explicit dicts: `inherited_renames` for alias-collision detection inside `build_groupby_select_fields`, and `previously_emitted_renames` for WHERE/ORDER BY Field rewriting. No more snapshot/diff bookkeeping.

### Functions removed (dead after the unification)

`query_planner.py`: `plan()`, `_find_sql_boundary()`
`sql_executor.py`: `build_simple_sql`, `build_nested_sql`, `_wrap_with_layer`, `_build_layer_sql`, `_build_wrapper_layer_sql`, `_build_simple_query_from_plan`, `_build_nested_query_from_plan`, `_build_nested_sql_for_dataframe`, `_assemble_simple_sql`

`_build_execution_sql` in `core.py` now uses `plan_segments` and picks the first SQL segment's plan, mirroring `_execute`.

### Bugs fixed along the way

1. **Layer-N `GroupByAgg` on file source**: `df[df['verified_purchase']==True].groupby('product_category')['star_rating'].agg(['mean','count']).sort_values('count', ascending=False).head(10)[result['count'] > 5000]` now returns the aggregated result instead of crashing with `UNKNOWN_IDENTIFIER: count`.
2. **Layer-N `GroupByAgg` on DataFrame source**: same fix, now applied to the Python() execution path through the unified dispatcher.
3. **Cross-layer alias rewriting**: when the inner subquery emits `SUM(int_col) AS __agg_int_col__` due to a source-col/agg-alias conflict, the outer `WHERE int_col > 50000` is now rewritten to use the temp alias.

### Tests

- **`TestPostAggregationFilterAfterLimit`** — covers Mark's original report with all four filter styles (`mask` / `loc` / `query` / `filter`) matching pandas.
- **`TestGroupByInNonZeroLayer`** — end-to-end and structural assertions for the wrapper-layer `GroupByAgg` case, plus `test_dataframe_source_groupby_agg_in_layer_n_matches_pandas` exercising the same fix on a Python() DataFrame source.
- **`TestCrossLayerAliasRewriting`** — source-col / agg-alias conflict spanning subquery boundaries (WHERE and ORDER BY variants), plus unit tests on `rewrite_column_refs_in_expression` for `BinaryCondition` / `CompoundCondition` / `UnaryCondition` / `InCondition` / `BetweenCondition`.
- **`TestDispatchByOpType`** — drives `_build_layer` directly to lock in dispatch behaviour for `LazyGroupByAgg` vs plain relational layers, plus the `_extract_special_ops_from_layer` and `_split_wheres_by_groupby_position` helpers.

## Test plan

- [x] `pytest datastore/tests/test_groupby_sql_pushdown.py -v` — 30 passed (12 new regression tests included)
- [x] `pytest datastore/tests/ -q --ignore=tests/test_concurrency.py` — **9274 passed**, 7 skipped, 88 xfailed, 1 xpassed (baseline 9262 + 12 new tests)
- [x] Manually verified Mark's original scenario returns pandas-matching output for all four filter styles
- [x] Manually verified the DataFrame-source `head().filter().groupby().agg()` pattern now returns the aggregated result instead of dropping the GROUP BY