### PR TITLE
Resolve 3 SQL builder bugs found by user-path tests

### DIFF
--- a/.cursor/rules/chdb-ds.mdc
+++ b/.cursor/rules/chdb-ds.mdc
@@ -119,6 +119,52 @@ alwaysApply: true
    def test_sql_pandas_sql_segments_exact_values_and_structure(self):
    ```
 
+5. **Multi-Step Mirror for Bug-Fix Tests (>=5 ops chain)**
+
+   The Mark/Slack ``amazon_sample.parquet`` bug (PR #577) was a
+   single-op (``GROUP BY``) dispatcher bug, but it only surfaced as
+   part of a 5-step user chain
+   (``filter -> groupby -> agg -> sort -> head -> filter``).
+   Tests that only reproduced the smallest failing op pair would have
+   left it hidden.
+
+   When you fix a bug discovered by a multi-step chain, the regression
+   test MUST mirror the user's full chain length (typically >= 5 ops).
+
+   FORBIDDEN:
+   - Adding a regression test that only reproduces the smallest
+     failing op or op pair when the original user code was longer
+   - Splitting one user chain into multiple shorter tests "for clarity"
+   - Using synthetic data that doesn't exercise the column-name
+     conflict / null pattern / size class the user hit
+
+   REQUIRED:
+   - Verbatim mirror of the user's chain (read top to bottom and it
+     should look like what the user wrote)
+   - Either include a structural assertion (SQL substring /
+     ``plan.layers`` shape inspection) or add the matching shape to
+     ``test_sql_snapshot_assertions.py`` /
+     ``test_plan_invariants.py``
+   - Put the test under ``datastore/tests/journeys/`` with a name
+     that traces back to the user / issue (e.g.
+     ``test_mark_slack_amazon_reviews.py``)
+
+6. **Property-Based Sweep for Compositional Bugs**
+
+   For dispatcher / planner / SQL builder changes, run the
+   ``test_property_based_chains.py`` hypothesis sweep locally before
+   submitting. When hypothesis finds a falsifying example:
+
+   - Do NOT add the example to the property test's skip filter as the
+     first response - that hides the bug
+   - DO copy the falsifying chain into a verbatim regression test
+     under ``datastore/tests/journeys/`` with ``@unittest.expectedFailure``
+   - DO add a skip filter to the property test referencing the
+     journey test by name, so the property test stays green while the
+     bug is open
+   - When the bug is fixed, flip the ``expectedFailure`` and remove
+     the skip filter in the same commit
+
 **Self-Check Before Submitting Test:**
 - [ ] Does every comment about "expected behavior" have a corresponding assertion?
 - [ ] Are actual data values verified, not just lengths?
@@ -128,6 +174,8 @@ alwaysApply: true
 - [ ] Is segment structure (type, ops, is_first_segment) fully verified?
 - [ ] Are error messages descriptive for debugging?
 - [ ] Would this test catch a real bug, or just pass trivially?
+- [ ] If this is a bug-fix test, does the chain length match the user's original?
+- [ ] If this is a dispatcher/planner change, did property-based sweep pass locally?
 
 ---
 

--- a/.github/workflows/build_linux_arm64_wheels-gh.yml
+++ b/.github/workflows/build_linux_arm64_wheels-gh.yml
@@ -117,7 +117,7 @@ jobs:
 
               pyenv shell $version
               python -m pip install dist/*.whl --force-reinstall
-              python -m pip install pytest pytest-cov ray "$PANDAS_CONSTRAINT"
+              python -m pip install pytest pytest-cov hypothesis ray "$PANDAS_CONSTRAINT"
               echo "Installed pandas version:"
               python -c "import pandas; print(pandas.__version__)"
 

--- a/.github/workflows/build_linux_x86_wheels.yml
+++ b/.github/workflows/build_linux_x86_wheels.yml
@@ -140,7 +140,7 @@ jobs:
 
               pyenv shell $version
               python -m pip install dist/*.whl --force-reinstall
-              python -m pip install pytest pytest-cov ray "$PANDAS_CONSTRAINT"
+              python -m pip install pytest pytest-cov hypothesis ray "$PANDAS_CONSTRAINT"
               echo "Installed pandas version:"
               python -c "import pandas; print(pandas.__version__)"
 

--- a/.github/workflows/build_macos_arm64_wheels.yml
+++ b/.github/workflows/build_macos_arm64_wheels.yml
@@ -95,7 +95,7 @@ jobs:
 
               pyenv shell $version
               python -m pip install dist/*.whl --force-reinstall
-              python -m pip install pytest pytest-cov "$PANDAS_CONSTRAINT"
+              python -m pip install pytest pytest-cov hypothesis "$PANDAS_CONSTRAINT"
               echo "Installed pandas version:"
               python -c "import pandas; print(pandas.__version__)"
 

--- a/.github/workflows/build_macos_x86_wheels.yml
+++ b/.github/workflows/build_macos_x86_wheels.yml
@@ -117,7 +117,7 @@ jobs:
 
               pyenv shell $version
               python -m pip install dist/*.whl --force-reinstall
-              python -m pip install pytest pytest-cov "$PANDAS_CONSTRAINT"
+              python -m pip install pytest pytest-cov hypothesis "$PANDAS_CONSTRAINT"
               echo "Installed pandas version:"
               python -c "import pandas; print(pandas.__version__)"
 

--- a/datastore/core.py
+++ b/datastore/core.py
@@ -1776,26 +1776,32 @@ class DataStore(PandasCompatMixin):
 
         from .query_planner import QueryPlanner
 
-        # Use QueryPlanner segmented planning (same as _execute). For the
-        # single-source-SQL-segment case used by explain()/to_sql() we take
-        # the plan from the first SQL segment. When the whole chain is
-        # Pandas-only (e.g. ORDER BY without LIMIT under the cost-aware
-        # planner), fall back to the traditional ``SELECT * FROM source``
-        # generation - that is the SQL the executor would issue to fetch
-        # rows before handing off to Pandas.
+        # Use QueryPlanner segmented planning (same as _execute). This
+        # method models "the SQL ``_execute()`` would issue against the
+        # original source" - i.e. the FIRST step the executor runs.
+        # Cases:
+        # - First segment is SQL: return that segment's SQL.
+        # - First segment is Pandas (cost-aware planner, e.g. ORDER BY
+        #   without LIMIT): the executor first materializes data via a
+        #   plain ``SELECT * FROM source``, so return that. Returning a
+        #   later SQL-on-DataFrame segment would be misleading - its
+        #   FROM is ``Python(__df__)``, not the original source.
+        # - No segments / single Pandas-only segment: same fallback.
         planner = QueryPlanner()
         schema = self._schema or {}
         exec_plan = planner.plan_segments(
             self._lazy_ops, has_sql_source=True, schema=schema
         )
-        sql_segment = next(
-            (seg for seg in exec_plan.segments if seg.is_sql() and seg.plan), None
-        )
-        if sql_segment is None:
+        first_segment = exec_plan.segments[0] if exec_plan.segments else None
+        if (
+            first_segment is None
+            or not first_segment.is_sql()
+            or first_segment.plan is None
+        ):
             return self._generate_select_sql(self.quote_char)
 
         sql_engine = SQLExecutionEngine(self)
-        result = sql_engine.build_sql_from_plan(sql_segment.plan, schema)
+        result = sql_engine.build_sql_from_plan(first_segment.plan, schema)
         return result.sql
 
     def _get_table_source(self) -> str:

--- a/datastore/core.py
+++ b/datastore/core.py
@@ -1452,8 +1452,14 @@ class DataStore(PandasCompatMixin):
                         settings_parts.append(f"{key}={value}")
                 sql = f"{sql} SETTINGS {', '.join(settings_parts)}"
 
+            # Use a generous truncation limit so debug logs preserve the
+            # full SQL of typical multi-clause queries (was 200 chars, which
+            # truncated mid-clause for remote ``GROUP BY`` queries with
+            # ``dropna`` IS NOT NULL filters - breaking log-based
+            # assertions in ``tests/test_remote_lazy_chain_pushdown.py``).
             self._logger.debug(
-                "  Executing SQL: %s", sql[:200] + "..." if len(sql) > 200 else sql
+                "  Executing SQL: %s",
+                sql[:2000] + "..." if len(sql) > 2000 else sql,
             )
 
             # For PythonTableFunction, use query_df to ensure row order preservation

--- a/datastore/query_planner.py
+++ b/datastore/query_planner.py
@@ -495,6 +495,20 @@ class QueryPlanner:
                 # new layer so the LIMIT applies to the inner subquery
                 # (i.e. ``SELECT ... FROM (SELECT ... LIMIT N) GROUP BY``).
                 _start_new_layer_with(op)
+            elif isinstance(op, LazyGroupByAgg) and any(
+                isinstance(prev, (LazyWhere, LazyMask)) for prev in current_layer
+            ):
+                # ``mask(cond, other).groupby(...).agg(...)`` (or ``where``)
+                # semantics: the mask must run BEFORE the GROUP BY so the
+                # aggregation sees masked values. In the same SQL layer,
+                # the wrapper-layer CASE-WHEN temp-alias machinery
+                # (``__tmp_<col>__``) collides with the agg's own select
+                # list (the inner SELECT only emits aggregations, not
+                # ``__tmp_*__``). Split into a new layer so the mask runs
+                # in the inner subquery and the GROUP BY runs on the
+                # masked output:
+                # ``SELECT ... agg() FROM (SELECT CASE WHEN ...) GROUP BY``.
+                _start_new_layer_with(op)
             else:
                 # Other operations - add pending column assignments first, then this op
                 if pending_column_assignments:

--- a/datastore/query_planner.py
+++ b/datastore/query_planner.py
@@ -349,6 +349,14 @@ class QueryPlanner:
         - OFFSET follows LIMIT (pandas: chained slices like [10:50][5:20])
         - LIMIT follows LIMIT (pandas: chained limits like [:50][:20])
         - WHERE follows computed column that came after LIMIT (dependency)
+        - LazyGroupByAgg follows LIMIT/OFFSET (pandas: ``head(N).groupby()``
+          aggregates over the first N rows; emitting LIMIT in the same SQL
+          layer as GROUP BY would otherwise mean "first N groups" instead).
+        - A pure-projection SELECT (e.g. ``df[['a','b']]``) follows a
+          WHERE in the same layer and the WHERE references columns that
+          would be dropped by the projection. This split keeps the
+          WHERE's columns alive in the inner subquery before the outer
+          layer projects them away.
 
         This preserves pandas-like execution order semantics in SQL.
 
@@ -364,6 +372,68 @@ class QueryPlanner:
         seen_offset = False  # Have we seen an OFFSET in current layer?
         pending_column_assignments = []  # Column assignments after LIMIT/OFFSET
         computed_columns_after_limit = set()  # Computed columns added after LIMIT
+
+        def _is_pure_projection_select(op):
+            """Pure projection SELECT = ``SELECT col1, col2, ...`` with no
+            ``*`` marker (pandas ``df[[cols]]``). Assignment-style SELECTs
+            (``df.assign(c=...)``) carry a ``*`` and stay in the same
+            layer so the assignments survive."""
+            return (
+                isinstance(op, LazyRelationalOp)
+                and op.op_type == "SELECT"
+                and op.fields
+                and not any(isinstance(f, str) and f == "*" for f in op.fields)
+            )
+
+        def _projection_field_names(op):
+            names = set()
+            for f in op.fields or []:
+                name = None
+                if isinstance(f, str):
+                    name = f
+                elif hasattr(f, "name"):
+                    name = getattr(f, "name", None)
+                if isinstance(name, str):
+                    names.add(name.strip('"`'))
+            return names
+
+        def _where_refs_columns_not_in(op_set, layer):
+            """Does any WHERE in ``layer`` reference a column outside
+            ``op_set`` (e.g. one created by an assignment-style
+            SELECT/LazyColumnAssignment in the same layer)? If yes, the
+            outer projection would drop that column before the WHERE
+            could bind to it, so we must split into a new layer that
+            wraps the inner WHERE."""
+            wheres = [
+                prev
+                for prev in layer
+                if isinstance(prev, LazyRelationalOp)
+                and prev.op_type == "WHERE"
+                and prev.condition is not None
+            ]
+            if not wheres:
+                return False
+            for w in wheres:
+                refs = self._extract_referenced_columns(w.condition)
+                if refs - op_set:
+                    return True
+            return False
+
+        def _start_new_layer_with(op):
+            """Push current_layer, drop any pending assignments into it
+            first, then begin a fresh layer containing ``op``."""
+            nonlocal current_layer, seen_limit, seen_offset
+            nonlocal computed_columns_after_limit, pending_column_assignments
+            if pending_column_assignments:
+                current_layer.extend(pending_column_assignments)
+                pending_column_assignments = []
+            layers.append(current_layer)
+            current_layer = [op]
+            seen_limit = isinstance(op, LazyRelationalOp) and op.op_type == "LIMIT"
+            seen_offset = (
+                isinstance(op, LazyRelationalOp) and op.op_type == "OFFSET"
+            )
+            computed_columns_after_limit = set()
 
         for op in ops:
             if isinstance(op, LazyRelationalOp):
@@ -383,19 +453,17 @@ class QueryPlanner:
                     # Second LIMIT means chained limits like [:50][:20]
                     # The second limit operates on the result of the first
                     needs_new_layer = True
+                elif _is_pure_projection_select(op):
+                    proj_fields = _projection_field_names(op)
+                    if _where_refs_columns_not_in(proj_fields, current_layer):
+                        # Pure projection that drops a column the layer's
+                        # WHERE depends on (e.g. ``assign(x=...)[where x>0][[id]]``).
+                        # Split into a new layer so the outer SELECT
+                        # projects after the inner WHERE has run.
+                        needs_new_layer = True
 
                 if needs_new_layer and current_layer:
-                    # Before starting new layer, add any pending column assignments
-                    # to ensure they're computed before WHERE/ORDER BY
-                    if pending_column_assignments:
-                        current_layer.extend(pending_column_assignments)
-                        pending_column_assignments = []
-
-                    layers.append(current_layer)
-                    current_layer = [op]
-                    seen_limit = op.op_type == "LIMIT"
-                    seen_offset = op.op_type == "OFFSET"
-                    computed_columns_after_limit = set()  # Reset for new layer
+                    _start_new_layer_with(op)
                 else:
                     # Add pending column assignments to current layer first
                     if pending_column_assignments:
@@ -418,6 +486,15 @@ class QueryPlanner:
                 else:
                     # No LIMIT/OFFSET yet, add directly to current layer
                     current_layer.append(op)
+            elif isinstance(op, LazyGroupByAgg) and (seen_limit or seen_offset):
+                # ``head(N).groupby(...).agg(...)`` semantics: pandas
+                # aggregates over the first N rows. If LIMIT and GROUP BY
+                # live in the same SQL layer we end up emitting
+                # ``... GROUP BY ... LIMIT N``, which limits the number of
+                # GROUPS instead of the number of input rows. Split into a
+                # new layer so the LIMIT applies to the inner subquery
+                # (i.e. ``SELECT ... FROM (SELECT ... LIMIT N) GROUP BY``).
+                _start_new_layer_with(op)
             else:
                 # Other operations - add pending column assignments first, then this op
                 if pending_column_assignments:

--- a/datastore/sql_executor.py
+++ b/datastore/sql_executor.py
@@ -1469,8 +1469,13 @@ class SQLExecutionEngine:
                     stable=is_stable_sort(orderby_kind_to_use),
                 )
                 outer_parts.append(f"ORDER BY {orderby_sql}")
-            elif row_order_fallback_allowed:
-                outer_parts.append("ORDER BY _row_id")
+            # ``ORDER BY _row_id`` is intentionally skipped when wrapping
+            # in ``__case_subq__``: the virtual ``_row_id`` from
+            # ``Python(__df__)`` is not propagated through the inner
+            # CASE-WHEN SELECT, so referencing it on the outer rename
+            # layer would fail with UNKNOWN_IDENTIFIER. CASE-WHEN is
+            # row-preserving, so the source order naturally flows up
+            # through the wrapper.
             if clauses.limit_value is not None:
                 outer_parts.append(f"LIMIT {clauses.limit_value}")
             if clauses.offset_value is not None:

--- a/datastore/sql_executor.py
+++ b/datastore/sql_executor.py
@@ -1069,6 +1069,21 @@ class SQLExecutionEngine:
                     rewrite_column_refs_in_expression(c, previously_visible_to_temp)
                     for c in post_wheres
                 ]
+            # pandas default ``dropna=True`` excludes NULL group keys; SQL
+            # ``GROUP BY`` would group them. Emit ``col IS NOT NULL``
+            # filters as pre-agg WHEREs unless the user opted out via
+            # ``dropna=False`` or the global performance mode.
+            from .config import is_performance_mode as _is_perf_mode
+
+            if (
+                not _is_perf_mode()
+                and getattr(groupby_agg_op, "dropna", True)
+                and groupby_agg_op.groupby_cols
+            ):
+                dropna_conditions = [
+                    Field(col).notnull() for col in groupby_agg_op.groupby_cols
+                ]
+                pre_wheres = pre_wheres + dropna_conditions
             clauses.where_conditions = pre_wheres
             having_conditions = post_wheres
 
@@ -1204,6 +1219,13 @@ class SQLExecutionEngine:
                 # otherwise these are pure column assignments and we need
                 # ``SELECT *, expr AS alias`` to preserve inherited columns.
                 include_star = not clauses.explicit_column_selection
+            if groupby_agg_op is not None or where_needs_temp_alias:
+                # ``SELECT *`` is invalid alongside GROUP BY and would
+                # double-emit columns when CASE-WHEN temp aliases already
+                # cover every source column. The fully enumerated
+                # select_fields_for_sql already includes group keys /
+                # aggregations / temp aliases.
+                include_star = False
             sql = self._render_wrapper_layer_sql(
                 from_source,
                 clauses,
@@ -1214,6 +1236,9 @@ class SQLExecutionEngine:
                 preserved_orderby_kind,
                 add_row_order_fallback=is_first_layer,
                 include_star=include_star,
+                where_temp_alias_columns=(
+                    where_temp_alias_columns if where_needs_temp_alias else None
+                ),
             )
 
         # Renames introduced by this layer: aliases its SELECT actually
@@ -1267,15 +1292,18 @@ class SQLExecutionEngine:
             and not self.source_preserves_row_order()
         )
 
-        # HAVING is currently only emitted for wrapper layers (post-agg
-        # WHERE in a first-layer plan is folded into source-level WHERE by
-        # the planner). Assert to surface any unexpected case explicitly.
+        # Post-aggregation WHEREs become HAVING. Combine the planner-derived
+        # ``having_conditions`` list with any existing ``self.ds._having_condition``
+        # via boolean AND so user-level ``ds.having(...)`` still composes.
+        effective_having = self.ds._having_condition
         if having_conditions:
-            # Fold into the layer's WHERE list as a defensive fallback (the
-            # combine logic in assemble_sql will AND them together correctly
-            # because there's no GROUP BY split between them here).
-            clauses.where_conditions = list(clauses.where_conditions) + list(
-                having_conditions
+            combined_having = having_conditions[0]
+            for cond in having_conditions[1:]:
+                combined_having = combined_having & cond
+            effective_having = (
+                combined_having
+                if effective_having is None
+                else (effective_having & combined_having)
             )
 
         if where_needs_subquery:
@@ -1318,7 +1346,7 @@ class SQLExecutionEngine:
             joins=self.ds._joins,
             distinct=self.ds._distinct,
             groupby_fields=groupby_fields,
-            having_condition=self.ds._having_condition,
+            having_condition=effective_having,
             include_star=use_include_star,
         )
 
@@ -1333,6 +1361,7 @@ class SQLExecutionEngine:
         preserved_orderby_kind: Optional[str],
         add_row_order_fallback: bool = False,
         include_star: bool = False,
+        where_temp_alias_columns: Optional[List[Tuple[str, str]]] = None,
     ) -> str:
         """
         Emit SQL for a layer that reads from an explicit FROM source:
@@ -1356,7 +1385,15 @@ class SQLExecutionEngine:
         ``include_star`` enables ``SELECT *, expr AS alias`` style for
         column-assignment scenarios where we want to keep all inherited
         columns plus add the computed ones.
+
+        ``where_temp_alias_columns`` (list of ``(temp_alias, orig_name)``)
+        opts in to LazyWhere/LazyMask CASE-WHEN temp-alias wrapping: the
+        inner SELECT emits ``... AS __tmp_col__`` and we wrap with an outer
+        ``SELECT __tmp_col__ AS col, ...`` so the final result keeps the
+        user-visible column names. ORDER BY / LIMIT / OFFSET are pushed to
+        the outer layer so they bind to the user-visible names.
         """
+        wrap_temp_aliases = bool(where_temp_alias_columns)
         if select_fields:
             fields_sql = ", ".join(
                 f.to_sql(quote_char=self.quote_char, with_alias=True)
@@ -1368,7 +1405,13 @@ class SQLExecutionEngine:
 
         parts = [f"SELECT {select_sql}", f"FROM {from_source}"]
 
-        if clauses.where_conditions:
+        # When LazyMask/LazyWhere temp aliases wrap this layer, any
+        # WHERE in ``clauses.where_conditions`` semantically filters the
+        # MASKED values: ``mask(...)[mask] -> [filter]`` means filter
+        # after mask. Push the WHERE to the OUTER (post-rename) layer
+        # so it binds to the user-visible column names (= masked values).
+        # Otherwise emit it inline on the source columns as usual.
+        if clauses.where_conditions and not wrap_temp_aliases:
             combined = clauses.where_conditions[0]
             for c in clauses.where_conditions[1:]:
                 combined = combined & c
@@ -1392,6 +1435,48 @@ class SQLExecutionEngine:
         orderby_kind_to_use = (
             clauses.orderby_kind if clauses.orderby_fields else preserved_orderby_kind
         )
+
+        # ``ORDER BY _row_id`` only makes sense pre-GROUP-BY: SQL doesn't
+        # let us reference an ungrouped, non-aggregate column after GROUP BY,
+        # and post-aggregation row order is already determined by the agg
+        # itself (or by an explicit ORDER BY on the agg output).
+        row_order_fallback_allowed = add_row_order_fallback and not groupby_fields
+
+        if wrap_temp_aliases:
+            # When CASE-WHEN temp aliases are present, postpone WHERE /
+            # ORDER BY / LIMIT / OFFSET to the outer rename layer so they
+            # reference user-visible column names (= the masked values).
+            inner_sql = " ".join(parts)
+            outer_select = ", ".join(
+                f"{self.quote_char}{temp}{self.quote_char} AS {self.quote_char}{orig}{self.quote_char}"
+                for temp, orig in where_temp_alias_columns
+            )
+            outer_parts = [
+                f"SELECT {outer_select}",
+                f"FROM ({inner_sql}) AS __case_subq__",
+            ]
+            if clauses.where_conditions:
+                combined = clauses.where_conditions[0]
+                for c in clauses.where_conditions[1:]:
+                    combined = combined & c
+                outer_parts.append(
+                    f"WHERE {combined.to_sql(quote_char=self.quote_char)}"
+                )
+            if orderby_to_use:
+                orderby_sql = build_orderby_clause(
+                    orderby_to_use,
+                    self.quote_char,
+                    stable=is_stable_sort(orderby_kind_to_use),
+                )
+                outer_parts.append(f"ORDER BY {orderby_sql}")
+            elif row_order_fallback_allowed:
+                outer_parts.append("ORDER BY _row_id")
+            if clauses.limit_value is not None:
+                outer_parts.append(f"LIMIT {clauses.limit_value}")
+            if clauses.offset_value is not None:
+                outer_parts.append(f"OFFSET {clauses.offset_value}")
+            return " ".join(outer_parts)
+
         if orderby_to_use:
             orderby_sql = build_orderby_clause(
                 orderby_to_use,
@@ -1399,7 +1484,7 @@ class SQLExecutionEngine:
                 stable=is_stable_sort(orderby_kind_to_use),
             )
             parts.append(f"ORDER BY {orderby_sql}")
-        elif add_row_order_fallback:
+        elif row_order_fallback_allowed:
             # Preserve pandas-like row order for the DataFrame source; _row_id
             # is chDB's deterministic virtual column for Python() sources.
             parts.append("ORDER BY _row_id")
@@ -2691,12 +2776,19 @@ class SQLExecutionEngine:
         """
         schema = schema or {}
 
-        # Multi-layer plans go through the unified ``_build_layered_sql``
-        # pipeline with ``__df__`` as the FROM source. This ensures any
-        # LazyGroupByAgg / LazyWhere that lives in a non-zero layer is
-        # dispatched correctly (the previous ``_build_nested_sql_for_dataframe``
-        # path silently dropped them just like the source path used to).
-        if plan.layers and len(plan.layers) > 1:
+        # Plans that contain LazyGroupByAgg / LazyWhere / LazyMask (or have
+        # >1 layer) go through the unified ``_build_layered_sql`` pipeline
+        # with ``__df__`` as the FROM source. ``_build_layer`` correctly
+        # splits WHEREs by GROUP BY position (pre-agg -> WHERE, post-agg
+        # -> HAVING) and rewrites Field references to the agg's emitted
+        # temp aliases, both of which the legacy single-layer inline path
+        # below does not handle.
+        needs_layered_pipeline = bool(plan.layers) and (
+            len(plan.layers) > 1
+            or plan.groupby_agg is not None
+            or bool(plan.where_ops)
+        )
+        if needs_layered_pipeline:
             sql_select_fields, has_column_assignments = (
                 self._collect_select_fields_from_sql_ops(plan.sql_ops)
             )

--- a/datastore/tests/journeys/__init__.py
+++ b/datastore/tests/journeys/__init__.py
@@ -1,0 +1,29 @@
+"""
+Real-user-path regression tests for chdb-ds.
+
+This subpackage exists *exclusively* to hold tests that mirror chains of
+operations a real user actually wrote (Slack reports, GitHub issues,
+StackOverflow questions, notebook transcripts). Every file here should
+follow these rules:
+
+1. **Verbatim mirror**: the test code should look as close as possible to
+   what the user wrote, including any "wrong" or sub-optimal patterns.
+   Resist the temptation to "clean it up" - the user wrote it that way
+   for a reason and that reason is the test case.
+
+2. **Mirror pandas**: each user path is run on both ``pandas`` and
+   ``DataStore`` with the same code, and outputs are compared via
+   :func:`datastore.tests.test_utils.assert_datastore_equals_pandas`.
+
+3. **Long chains are the point**: most chains here are 5+ operations.
+   Single-op behaviour is covered by the feature-oriented test files
+   under ``datastore/tests/``; this subpackage focuses on the
+   compositional space those tests do not reach.
+
+4. **One file per user / scenario** when feasible, so that a future
+   git-blame on a failing test points back to the original report.
+
+Adding a new file is encouraged the moment a user-reported bug lands -
+even before the fix. ``xfail`` markers are fine while the bug is open;
+removing them is the definition of "fixed".
+"""

--- a/datastore/tests/journeys/test_agg_then_use_result.py
+++ b/datastore/tests/journeys/test_agg_then_use_result.py
@@ -1,0 +1,187 @@
+"""
+Real user journey: treating an aggregation result as a DataFrame again.
+
+Pandas users naturally think of ``groupby().agg(...)`` as producing a
+DataFrame that they can immediately keep operating on - filter it, sort
+it, project a column out, aggregate it again, merge it, etc. This is the
+"result-as-input" mental model.
+
+Most of chdb-ds's pre-Mark test suite tested aggregations as the END of
+a chain. This file tests the OTHER half of the mental model: every
+aggregation is a STARTING POINT for further work.
+
+Each test mirrors the same code on pandas and chdb-ds and demands
+identical output. The cross product is 5 aggregations x 5 follow-ons =
+25 user paths covered.
+"""
+
+import unittest
+from itertools import product
+
+import numpy as np
+import pandas as pd
+
+from datastore import DataStore
+
+from tests.test_utils import assert_datastore_equals_pandas
+
+
+def _make_dataset():
+    np.random.seed(7)
+    n = 2000
+    return pd.DataFrame(
+        {
+            'category': np.random.choice(['A', 'B', 'C', 'D'], n),
+            'subcat': np.random.choice(['x', 'y', 'z'], n),
+            'value': np.random.randint(0, 1000, n),
+            'score': np.random.uniform(0, 100, n),
+        }
+    )
+
+
+# Aggregations a user reaches for first: each returns a DataStore/DataFrame
+# with ``category`` as the index. Lambda takes the source, returns the
+# aggregated result.
+AGG_BUILDERS = [
+    ('sum_on_value',  lambda df: df.groupby('category').agg({'value': 'sum'})),
+    ('mean_on_score', lambda df: df.groupby('category').agg({'score': 'mean'})),
+    ('count_on_value', lambda df: df.groupby('category').agg({'value': 'count'})),
+    ('min_on_score',  lambda df: df.groupby('category').agg({'score': 'min'})),
+    ('max_on_value',  lambda df: df.groupby('category').agg({'value': 'max'})),
+]
+
+# Follow-ons a user does AFTER seeing the aggregate. Each lambda takes
+# the result and the column name produced by the aggregation.
+FOLLOWUPS = [
+    (
+        'filter_by_mask',
+        lambda r, c: r[r[c] > r[c].median()],
+    ),
+    (
+        'sort_descending',
+        lambda r, c: r.sort_values(c, ascending=False),
+    ),
+    (
+        'head_top_2',
+        lambda r, c: r.sort_values(c, ascending=False).head(2),
+    ),
+    (
+        'select_only_agg_col',
+        lambda r, c: r[[c]],
+    ),
+    (
+        'filter_then_head',
+        # Use the median rather than a literal threshold like ``> 0``.
+        # Reason: when the aggregation output column name matches a
+        # source column name (e.g. ``count(value) AS value``), a literal
+        # threshold can accidentally resolve against the source column's
+        # value range and silently mask a name-shadowing bug. Using the
+        # result's own median guarantees we filter against the aggregate
+        # output. See ``test_agg_output_name_shadows_source_column`` for
+        # the explicit regression covering that bug.
+        lambda r, c: r[r[c] > r[c].median()].head(2),
+    ),
+]
+
+
+def _agg_col(agg_name: str) -> str:
+    """Return the column name the aggregation produces."""
+    # All current builders aggregate a single column with a single func,
+    # so the output column name = the source column name.
+    return agg_name.split('_on_')[1]
+
+
+class TestAggThenUseResult(unittest.TestCase):
+    """``result = df.groupby().agg(...); use(result)`` for many shapes."""
+
+    @classmethod
+    def setUpClass(cls):
+        cls.pd_df = _make_dataset()
+
+    def _run_case(self, agg_name, agg_fn, follow_name, follow_fn):
+        col = _agg_col(agg_name)
+        pd_result = follow_fn(agg_fn(self.pd_df), col)
+        ds = DataStore(self.pd_df)
+        ds_result = follow_fn(agg_fn(ds), col)
+        # When the follow-on returns a Series-shaped result we still want
+        # value-by-value equality; use the helper which delegates.
+        assert_datastore_equals_pandas(
+            ds_result,
+            pd_result,
+            check_index=True,
+            check_row_order=isinstance(pd_result, pd.DataFrame) and pd_result.index.is_monotonic_increasing
+            or isinstance(pd_result, pd.Series),
+        )
+
+
+# Dynamically attach a test method per (agg, follow) pair so failures
+# point at the exact combination. We deliberately do NOT bind the helper
+# or the loop variables at module scope (avoids accidental pytest
+# collection of the leftover names as tests).
+def _attach_combinations():
+    def _make_test(agg_name, agg_fn, follow_name, follow_fn):
+        def _runner(self):
+            self._run_case(agg_name, agg_fn, follow_name, follow_fn)
+
+        _runner.__name__ = f'test_{agg_name}__then__{follow_name}'
+        _runner.__doc__ = (
+            f'After {agg_name}, apply {follow_name} and verify match with pandas.'
+        )
+        return _runner
+
+    for (agg_name, agg_fn), (follow_name, follow_fn) in product(
+        AGG_BUILDERS, FOLLOWUPS
+    ):
+        method = _make_test(agg_name, agg_fn, follow_name, follow_fn)
+        setattr(TestAggThenUseResult, method.__name__, method)
+
+
+_attach_combinations()
+
+
+# ---------------------------------------------------------------------------
+# Permanent regression for the agg-output-shadows-source-column bug found
+# via this journey file. ``filter_then_head`` originally used ``r[r[c] > 0]``,
+# which on ``count(value)`` against a source column also called ``value``
+# (range 0..999) accidentally exercised the SOURCE column instead of the
+# AGG output column - dropping the ~2 source rows that had value == 0
+# and causing every group's count to drop by exactly 1. Fixed by routing
+# DataFrame-source single-layer plans with ``LazyGroupByAgg`` through
+# ``_build_layered_sql`` (which splits WHEREs by GROUP BY position and
+# emits HAVING for post-agg conditions, rewriting Field refs to the
+# agg's emitted ``__agg_*__`` temp aliases).
+# ---------------------------------------------------------------------------
+
+
+class TestAggOutputShadowsSourceColumn(unittest.TestCase):
+    """``result = df.groupby('cat').agg({'col': 'count'})`` followed by
+    ``result[result['col'] > 0]`` correctly binds the WHERE to the
+    aggregated output, not the source column of the same name.
+    """
+
+    def test_agg_output_name_shadows_source_column(self):
+        np.random.seed(7)
+        n = 2000
+        df = pd.DataFrame(
+            {
+                'category': np.random.choice(['A', 'B', 'C', 'D'], n),
+                # ``value`` has a few literal zeros - the smoking gun.
+                'value': np.random.randint(0, 1000, n),
+            }
+        )
+
+        pd_agg = df.groupby('category').agg({'value': 'count'})
+        pd_filtered = pd_agg[pd_agg['value'] > 0]
+
+        ds = DataStore(df)
+        ds_agg = ds.groupby('category').agg({'value': 'count'})
+        ds_filtered = ds_agg[ds_agg['value'] > 0]
+
+        # When the bug is fixed both sides return the same row counts.
+        assert_datastore_equals_pandas(
+            ds_filtered, pd_filtered, check_index=True
+        )
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/datastore/tests/journeys/test_kaggle_style_exploration.py
+++ b/datastore/tests/journeys/test_kaggle_style_exploration.py
@@ -1,0 +1,320 @@
+"""
+Real user journeys: Kaggle-style exploratory data analysis pipelines.
+
+Each test is a 6-10 step chain that mirrors the kind of code a data
+analyst writes in a notebook cell. Inspirations are noted in each
+docstring; the data is synthetic and self-contained.
+
+What distinguishes these tests from existing per-feature unit tests:
+- chain length is intentionally long (>=6 ops)
+- each step uses the OUTPUT of the previous step (result-as-input)
+- the chain mixes filter/groupby/agg/sort/head/assign/join
+- pandas runs the same code path - any divergence is a real bug
+
+Most journeys read from a parquet file (the Kaggle default workflow) so
+that the source-bound SQL path is exercised. A small number of tests
+are explicitly tagged with ``DataStore(df)`` to cover the Python() table
+function path - some of these are ``@unittest.expectedFailure`` because
+they expose known latent bugs that are out of scope for the current PR.
+"""
+
+import os
+import tempfile
+import unittest
+
+import numpy as np
+import pandas as pd
+
+from datastore import DataStore
+
+from tests.test_utils import assert_datastore_equals_pandas
+
+
+def _write_temp_parquet(df, dirpath, name):
+    path = os.path.join(dirpath, name)
+    df.to_parquet(path)
+    return path
+
+
+def _seed_orders_dataset(seed=42, n=3000):
+    """E-commerce-style orders table with customer / product / amount."""
+    rng = np.random.default_rng(seed)
+    return pd.DataFrame(
+        {
+            'order_id': np.arange(1, n + 1),
+            'customer_id': rng.integers(1, 200, n),
+            'product_category': rng.choice(
+                ['Electronics', 'Books', 'Apparel', 'Home', 'Beauty'],
+                n,
+            ),
+            'region': rng.choice(['NA', 'EU', 'APAC', 'LATAM'], n),
+            'amount': rng.uniform(5, 500, n).round(2),
+            'quantity': rng.integers(1, 8, n),
+            'rating': rng.choice([1, 2, 3, 4, 5, np.nan], n),
+        }
+    )
+
+
+def _seed_visits_dataset(seed=123, n=5000):
+    """Web-visit-style table with timestamp / user / page / duration."""
+    rng = np.random.default_rng(seed)
+    return pd.DataFrame(
+        {
+            'session_id': np.arange(1, n + 1),
+            'user_id': rng.integers(1, 500, n),
+            'page': rng.choice(
+                ['home', 'product', 'cart', 'checkout', 'about'],
+                n,
+                p=[0.5, 0.25, 0.12, 0.08, 0.05],
+            ),
+            'device': rng.choice(['mobile', 'desktop', 'tablet'], n),
+            'duration_sec': rng.exponential(scale=60, size=n).round(1),
+        }
+    )
+
+
+class TestTopProductCategoriesByRegion(unittest.TestCase):
+    """Inspiration: 'Which product categories drive revenue in each region?'
+
+    Typical EDA cell: filter to recent orders -> compute revenue per
+    (region, category) -> rank within each region -> take the top 3.
+    A 7-op chain with filter, assign, groupby, agg, sort, head, filter.
+    """
+
+    @classmethod
+    def setUpClass(cls):
+        cls.pd_df = _seed_orders_dataset()
+        cls.temp_dir = tempfile.mkdtemp()
+        cls.parquet_path = _write_temp_parquet(
+            cls.pd_df, cls.temp_dir, 'orders.parquet'
+        )
+
+    @classmethod
+    def tearDownClass(cls):
+        import shutil
+
+        shutil.rmtree(cls.temp_dir)
+
+    def test_top_three_revenue_categories_per_region_from_parquet(self):
+        # pandas reference
+        pd_chain = (
+            self.pd_df[self.pd_df['amount'] >= 50]
+            .assign(revenue=lambda x: x['amount'] * x['quantity'])
+            .groupby(['region', 'product_category'])
+            .agg({'revenue': 'sum'})
+            .sort_values('revenue', ascending=False)
+            .head(20)
+        )
+        # post-filter: only categories where revenue clears a threshold
+        pd_result = pd_chain[pd_chain['revenue'] > 5000]
+
+        # mirror on DataStore reading from parquet (Kaggle default)
+        ds = DataStore.from_file(self.parquet_path)
+        ds_chain = (
+            ds[ds['amount'] >= 50]
+            .assign(revenue=ds['amount'] * ds['quantity'])
+            .groupby(['region', 'product_category'])
+            .agg({'revenue': 'sum'})
+            .sort_values('revenue', ascending=False)
+            .head(20)
+        )
+        ds_result = ds_chain[ds_chain['revenue'] > 5000]
+
+        assert_datastore_equals_pandas(
+            ds_result,
+            pd_result,
+            check_index=True,
+            check_row_order=False,
+        )
+
+    def test_top_three_revenue_dataframe_source_assign_before_groupby(self):
+        """Same pipeline against the in-memory DataFrame source.
+
+        Originally failed with NOT_AN_AGGREGATE: the SQL emitted
+        ``SELECT *, ..., sum(...) AS __agg_revenue__ ... GROUP BY ...``
+        because the LazyColumnAssignment for ``revenue`` triggered
+        include_star, which is invalid under GROUP BY. Fixed by routing
+        DataFrame-source single-layer plans with ``LazyGroupByAgg``
+        through ``_build_layered_sql`` and forcing ``include_star=False``
+        whenever the layer has a groupby_agg (the agg's emitted
+        select_fields already cover the group keys and aggregations).
+        """
+        pd_chain = (
+            self.pd_df[self.pd_df['amount'] >= 50]
+            .assign(revenue=lambda x: x['amount'] * x['quantity'])
+            .groupby(['region', 'product_category'])
+            .agg({'revenue': 'sum'})
+            .sort_values('revenue', ascending=False)
+            .head(20)
+        )
+        pd_result = pd_chain[pd_chain['revenue'] > 5000]
+
+        ds = DataStore(self.pd_df)
+        ds_chain = (
+            ds[ds['amount'] >= 50]
+            .assign(revenue=ds['amount'] * ds['quantity'])
+            .groupby(['region', 'product_category'])
+            .agg({'revenue': 'sum'})
+            .sort_values('revenue', ascending=False)
+            .head(20)
+        )
+        ds_result = ds_chain[ds_chain['revenue'] > 5000]
+        assert_datastore_equals_pandas(
+            ds_result, pd_result, check_index=True, check_row_order=False
+        )
+
+
+class TestCustomerOrderHistogram(unittest.TestCase):
+    """Inspiration: 'Show me the distribution of orders per customer.'
+
+    Standard cohort analysis: count orders per customer -> bucket by
+    count -> compute size of each bucket -> sort by bucket. 7+ ops.
+    """
+
+    @classmethod
+    def setUpClass(cls):
+        cls.pd_df = _seed_orders_dataset()
+
+    def test_orders_per_customer_buckets(self):
+        # pandas: per-customer order count, then bucketed
+        pd_per_customer = (
+            self.pd_df.groupby('customer_id')
+            .agg({'order_id': 'count'})
+            .rename(columns={'order_id': 'order_count'})
+        )
+        # bucket the counts manually (avoid pd.cut to keep portable)
+        pd_per_customer['bucket'] = pd_per_customer['order_count'].apply(
+            lambda x: 'high' if x >= 20 else 'mid' if x >= 10 else 'low'
+        )
+        pd_bucket_sizes = (
+            pd_per_customer.groupby('bucket')
+            .agg({'order_count': 'sum'})
+            .sort_values('order_count', ascending=False)
+        )
+
+        # mirror on DataStore - same shape, using pandas-compat APIs
+        ds = DataStore(self.pd_df)
+        ds_per_customer = (
+            ds.groupby('customer_id')
+            .agg({'order_id': 'count'})
+            .rename(columns={'order_id': 'order_count'})
+        )
+        ds_per_customer['bucket'] = ds_per_customer['order_count'].apply(
+            lambda x: 'high' if x >= 20 else 'mid' if x >= 10 else 'low'
+        )
+        ds_bucket_sizes = (
+            ds_per_customer.groupby('bucket')
+            .agg({'order_count': 'sum'})
+            .sort_values('order_count', ascending=False)
+        )
+
+        assert_datastore_equals_pandas(
+            ds_bucket_sizes,
+            pd_bucket_sizes,
+            check_index=True,
+            check_row_order=False,
+        )
+
+
+class TestTopKActiveUsersPerDevice(unittest.TestCase):
+    """Inspiration: 'Top-K users on each device'.
+
+    Visits-style data: filter to long sessions -> compute per-user
+    totals -> sort -> head per device. 6-op chain with the result-as-
+    input pattern repeated twice.
+    """
+
+    @classmethod
+    def setUpClass(cls):
+        cls.pd_df = _seed_visits_dataset()
+
+    def test_top_5_users_overall_after_filter(self):
+        # pandas: long sessions only, total per user, top 5 globally
+        pd_long = self.pd_df[self.pd_df['duration_sec'] >= 30]
+        pd_by_user = pd_long.groupby('user_id').agg(
+            {'duration_sec': 'sum', 'session_id': 'count'}
+        )
+        pd_sorted = pd_by_user.sort_values('duration_sec', ascending=False)
+        pd_top = pd_sorted.head(5)
+        # post-filter the top by another condition: sessions >= 5
+        pd_result = pd_top[pd_top['session_id'] >= 5]
+
+        # mirror
+        ds = DataStore(self.pd_df)
+        ds_long = ds[ds['duration_sec'] >= 30]
+        ds_by_user = ds_long.groupby('user_id').agg(
+            {'duration_sec': 'sum', 'session_id': 'count'}
+        )
+        ds_sorted = ds_by_user.sort_values('duration_sec', ascending=False)
+        ds_top = ds_sorted.head(5)
+        ds_result = ds_top[ds_top['session_id'] >= 5]
+
+        assert_datastore_equals_pandas(
+            ds_result,
+            pd_result,
+            check_index=True,
+            check_row_order=False,
+        )
+
+
+class TestMultiStageRevenueFilter(unittest.TestCase):
+    """Inspiration: data-quality + cohort analysis crossover.
+
+    9-step chain:
+    1. drop rows with null rating
+    2. filter high-value orders
+    3. assign discount column
+    4. assign net amount
+    5. groupby region
+    6. agg net amount sum, order count
+    7. sort descending by net
+    8. head top regions
+    9. filter regions whose net exceeds threshold
+    """
+
+    @classmethod
+    def setUpClass(cls):
+        cls.pd_df = _seed_orders_dataset()
+
+    def test_full_revenue_pipeline(self):
+        pd_clean = self.pd_df.dropna(subset=['rating'])
+        pd_highvalue = pd_clean[pd_clean['amount'] >= 100]
+        pd_with_discount = pd_highvalue.assign(
+            discount=pd_highvalue['amount'] * 0.1
+        )
+        pd_with_net = pd_with_discount.assign(
+            net=pd_with_discount['amount'] - pd_with_discount['discount']
+        )
+        pd_by_region = pd_with_net.groupby('region').agg(
+            {'net': 'sum', 'order_id': 'count'}
+        )
+        pd_sorted = pd_by_region.sort_values('net', ascending=False)
+        pd_top = pd_sorted.head(3)
+        pd_result = pd_top[pd_top['net'] >= 10000]
+
+        ds = DataStore(self.pd_df)
+        ds_clean = ds.dropna(subset=['rating'])
+        ds_highvalue = ds_clean[ds_clean['amount'] >= 100]
+        ds_with_discount = ds_highvalue.assign(
+            discount=ds_highvalue['amount'] * 0.1
+        )
+        ds_with_net = ds_with_discount.assign(
+            net=ds_with_discount['amount'] - ds_with_discount['discount']
+        )
+        ds_by_region = ds_with_net.groupby('region').agg(
+            {'net': 'sum', 'order_id': 'count'}
+        )
+        ds_sorted = ds_by_region.sort_values('net', ascending=False)
+        ds_top = ds_sorted.head(3)
+        ds_result = ds_top[ds_top['net'] >= 10000]
+
+        assert_datastore_equals_pandas(
+            ds_result,
+            pd_result,
+            check_index=True,
+            check_row_order=False,
+        )
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/datastore/tests/journeys/test_mark_slack_amazon_reviews.py
+++ b/datastore/tests/journeys/test_mark_slack_amazon_reviews.py
@@ -1,0 +1,363 @@
+"""
+Real user journey: Mark Needham's Slack report on Amazon reviews pipeline.
+
+Original report (paraphrased from Slack):
+    import chdb.datastore as pd_chdb
+    df_chdb = pd_chdb.read_parquet("amazon_sample.parquet")
+    result = (df_chdb[df_chdb['verified_purchase'] == True]
+        .groupby('product_category')['star_rating']
+        .agg(['mean', 'count'])
+        .sort_values('count', ascending=False)
+        .head(n=10))
+    # So far so good. But if I try to filter on count:
+    result.filter(result['count'] > 50000)
+    # E [chDB] Query failed: Unknown expression identifier `count` ...
+
+He then tried boolean indexing, ``.loc[]``, and ``.query()`` looking for
+something that would work. Three of those silently produced wrong /
+crashed SQL because the dispatcher dropped the GROUP BY in the inner
+subquery; ``.query()`` accidentally went through a different path that
+happened to work.
+
+This file mirrors Mark's exact code (renamed only the parquet column
+generation to a deterministic synthetic dataset so the test is
+self-contained) and pins down all four filter idioms plus a handful of
+realistic follow-on operations a user would do after seeing the filter
+work.
+
+Once a real user pattern triggers a bug, it lives here permanently.
+"""
+
+import os
+import tempfile
+import unittest
+
+import numpy as np
+import pandas as pd
+
+import chdb.datastore as pd_chdb
+from datastore import DataStore
+
+from tests.test_utils import assert_datastore_equals_pandas
+
+
+class TestMarkSlackAmazonReviews(unittest.TestCase):
+    """Verbatim regression of the Slack-reported amazon-reviews journey."""
+
+    @classmethod
+    def setUpClass(cls):
+        np.random.seed(42)
+        n = 50_000
+        cls.df = pd.DataFrame(
+            {
+                'product_category': np.random.choice(
+                    [
+                        'Home',
+                        'Digital_Ebook_Purchase',
+                        'Apparel',
+                        'Health & Personal Care',
+                        'Books',
+                        'Kitchen',
+                        'Beauty',
+                        'Mobile_Apps',
+                        'Automotive',
+                        'Home Improvement',
+                        'Wireless',
+                        'Sports',
+                        'PC',
+                        'Digital_Video_Download',
+                    ],
+                    n,
+                ),
+                'star_rating': np.random.choice([1, 2, 3, 4, 5], n),
+                'verified_purchase': np.random.choice(
+                    [True, False], n, p=[0.7, 0.3]
+                ),
+            }
+        )
+        cls.temp_dir = tempfile.mkdtemp()
+        cls.parquet_path = os.path.join(cls.temp_dir, 'amazon_sample.parquet')
+        cls.df.to_parquet(cls.parquet_path)
+
+        # Mark's threshold scaled to the synthetic dataset (his was 50_000
+        # on a 5M-row dump; we shrink for test speed). Picks roughly half
+        # the categories so neither "empty result" nor "everything" hides
+        # the bug.
+        cls.threshold = 2500
+
+    @classmethod
+    def tearDownClass(cls):
+        import shutil
+
+        shutil.rmtree(cls.temp_dir)
+
+    # ------- pandas reference, computed once -------------------------------
+
+    def _pd_result(self):
+        return (
+            self.df[self.df['verified_purchase'] == True]
+            .groupby('product_category')['star_rating']
+            .agg(['mean', 'count'])
+            .sort_values('count', ascending=False)
+            .head(n=10)
+        )
+
+    def _ds_from_parquet(self):
+        """Mirror of ``chdb.datastore.read_parquet(...)``."""
+        return pd_chdb.read_parquet(self.parquet_path)
+
+    def _ds_result_from_parquet(self):
+        df_chdb = self._ds_from_parquet()
+        return (
+            df_chdb[df_chdb['verified_purchase'] == True]
+            .groupby('product_category')['star_rating']
+            .agg(['mean', 'count'])
+            .sort_values('count', ascending=False)
+            .head(n=10)
+        )
+
+    def _ds_result_from_dataframe(self):
+        """Same pipeline but reading from an in-memory DataFrame source.
+
+        Mark used ``read_parquet``; users who load via ``DataStore(df)``
+        hit the Python() table function path. The same dispatch bug
+        existed there too - this mirror covers both source types.
+        """
+        ds = DataStore(self.df)
+        return (
+            ds[ds['verified_purchase'] == True]
+            .groupby('product_category')['star_rating']
+            .agg(['mean', 'count'])
+            .sort_values('count', ascending=False)
+            .head(n=10)
+        )
+
+    # ------- the initial aggregate (the "So far so good" step) -------------
+
+    def test_initial_aggregate_parquet_matches_pandas(self):
+        assert_datastore_equals_pandas(
+            self._ds_result_from_parquet(),
+            self._pd_result(),
+            check_index=True,
+        )
+
+    def test_initial_aggregate_dataframe_matches_pandas(self):
+        assert_datastore_equals_pandas(
+            self._ds_result_from_dataframe(),
+            self._pd_result(),
+            check_index=True,
+        )
+
+    # ------- the four filter idioms Mark tried in order -------------------
+
+    def test_filter_with_bracket_mask_parquet(self):
+        """``result[result['count'] > N]`` - Pandonic boolean indexing."""
+        pd_filtered = self._pd_result()[self._pd_result()['count'] > self.threshold]
+        ds_result = self._ds_result_from_parquet()
+        ds_filtered = ds_result[ds_result['count'] > self.threshold]
+        assert_datastore_equals_pandas(
+            ds_filtered, pd_filtered, check_index=True
+        )
+
+    def test_filter_with_loc_parquet(self):
+        """``result.loc[result['count'] > N]`` - the documented pandas way."""
+        pd_result = self._pd_result()
+        pd_filtered = pd_result.loc[pd_result['count'] > self.threshold]
+        ds_result = self._ds_result_from_parquet()
+        ds_filtered = ds_result.loc[ds_result['count'] > self.threshold]
+        assert_datastore_equals_pandas(
+            ds_filtered, pd_filtered, check_index=True
+        )
+
+    def test_filter_with_query_parquet(self):
+        """``result.query('count > N')`` - the only one that accidentally
+        used to work, because it took a different code path that did not
+        share the broken layer dispatcher."""
+        pd_result = self._pd_result()
+        pd_filtered = pd_result.query(f'count > {self.threshold}')
+        ds_result = self._ds_result_from_parquet()
+        ds_filtered = ds_result.query(f'count > {self.threshold}')
+        assert_datastore_equals_pandas(
+            ds_filtered, pd_filtered, check_index=True
+        )
+
+    def test_filter_with_filter_method_parquet(self):
+        """``result.filter(result['count'] > N)`` - the call Mark tried
+        first. In pandas, ``DataFrame.filter`` only takes labels and would
+        reject a boolean mask; chdb-ds intentionally extends it to support
+        boolean masks, so we compare against pandas boolean indexing
+        (same semantics)."""
+        pd_result = self._pd_result()
+        pd_filtered = pd_result[pd_result['count'] > self.threshold]
+        ds_result = self._ds_result_from_parquet()
+        ds_filtered = ds_result.filter(ds_result['count'] > self.threshold)
+        assert_datastore_equals_pandas(
+            ds_filtered, pd_filtered, check_index=True
+        )
+
+    # ------- same four idioms on the DataFrame source path ----------------
+
+    def test_filter_with_bracket_mask_dataframe(self):
+        pd_filtered = self._pd_result()[self._pd_result()['count'] > self.threshold]
+        ds_result = self._ds_result_from_dataframe()
+        ds_filtered = ds_result[ds_result['count'] > self.threshold]
+        assert_datastore_equals_pandas(
+            ds_filtered, pd_filtered, check_index=True
+        )
+
+    def test_filter_with_loc_dataframe(self):
+        pd_result = self._pd_result()
+        pd_filtered = pd_result.loc[pd_result['count'] > self.threshold]
+        ds_result = self._ds_result_from_dataframe()
+        ds_filtered = ds_result.loc[ds_result['count'] > self.threshold]
+        assert_datastore_equals_pandas(
+            ds_filtered, pd_filtered, check_index=True
+        )
+
+    def test_filter_with_query_dataframe(self):
+        pd_result = self._pd_result()
+        pd_filtered = pd_result.query(f'count > {self.threshold}')
+        ds_result = self._ds_result_from_dataframe()
+        ds_filtered = ds_result.query(f'count > {self.threshold}')
+        assert_datastore_equals_pandas(
+            ds_filtered, pd_filtered, check_index=True
+        )
+
+    def test_filter_with_filter_method_dataframe(self):
+        pd_result = self._pd_result()
+        pd_filtered = pd_result[pd_result['count'] > self.threshold]
+        ds_result = self._ds_result_from_dataframe()
+        ds_filtered = ds_result.filter(ds_result['count'] > self.threshold)
+        assert_datastore_equals_pandas(
+            ds_filtered, pd_filtered, check_index=True
+        )
+
+    # ------- realistic things a user does AFTER the filter works ----------
+
+    def test_filter_then_select_aggregate_col(self):
+        """``result[mask]['count']`` - grab the count Series for further
+        analysis. This exercises the column projection through the temp
+        alias rewrite that was the trickiest part of the cross-layer
+        rewrite fix."""
+        pd_result = self._pd_result()
+        pd_series = pd_result[pd_result['count'] > self.threshold]['count']
+        ds_result = self._ds_result_from_parquet()
+        ds_series = ds_result[ds_result['count'] > self.threshold]['count']
+        np.testing.assert_array_equal(list(ds_series), list(pd_series))
+
+    def test_filter_then_sort_by_other_agg_col(self):
+        """Sort the filtered result by ``mean`` instead of ``count``."""
+        pd_result = self._pd_result()
+        pd_sorted = (
+            pd_result[pd_result['count'] > self.threshold]
+            .sort_values('mean', ascending=False)
+        )
+        ds_result = self._ds_result_from_parquet()
+        ds_sorted = (
+            ds_result[ds_result['count'] > self.threshold]
+            .sort_values('mean', ascending=False)
+        )
+        assert_datastore_equals_pandas(
+            ds_sorted, pd_sorted, check_index=True
+        )
+
+    def test_filter_then_head_smaller(self):
+        """Filter then take the top 3 of what remains."""
+        pd_result = self._pd_result()
+        pd_top = pd_result[pd_result['count'] > self.threshold].head(3)
+        ds_result = self._ds_result_from_parquet()
+        ds_top = ds_result[ds_result['count'] > self.threshold].head(3)
+        assert_datastore_equals_pandas(ds_top, pd_top, check_index=True)
+
+    def test_chained_post_filter_operations(self):
+        """A natural longer chain after the agg+filter step:
+        ``result[result['count'] > N].sort_values('mean', desc).head(3)['mean']``."""
+        pd_result = self._pd_result()
+        pd_series = (
+            pd_result[pd_result['count'] > self.threshold]
+            .sort_values('mean', ascending=False)
+            .head(3)['mean']
+        )
+        ds_result = self._ds_result_from_parquet()
+        ds_series = (
+            ds_result[ds_result['count'] > self.threshold]
+            .sort_values('mean', ascending=False)
+            .head(3)['mean']
+        )
+        np.testing.assert_allclose(
+            list(ds_series), list(pd_series), rtol=1e-5
+        )
+
+    # ------- a related dispatcher bug uncovered by hypothesis -----------
+
+    def test_head_before_agg_respects_limit(self):
+        """``df[mask][mask].head(1).groupby('cat').agg({'v': 'sum'})``
+        respects the ``head(1)`` and aggregates exactly that one row,
+        just like pandas. Hypothesis discovered the original bug (LIMIT
+        was folded into the same SQL layer as GROUP BY, limiting the
+        number of GROUPS instead of input rows). Fixed by splitting
+        ``LazyGroupByAgg`` into a new nested layer when it follows a
+        LIMIT/OFFSET in ``QueryPlanner._build_layers``.
+        """
+        import numpy as np
+
+        rng = np.random.default_rng(20260)
+        n = 400
+        df = pd.DataFrame(
+            {
+                'cat': rng.choice(['A', 'B', 'C', 'D'], n),
+                'v': rng.integers(0, 100, n),
+            }
+        )
+        pd_result = (
+            df[df['v'] > 0][df[df['v'] > 0]['v'] > 0]
+            .head(1)
+            .groupby('cat')
+            .agg({'v': 'sum'})
+        )
+
+        ds = DataStore(df)
+        ds_result = (
+            ds[ds['v'] > 0][ds[ds['v'] > 0]['v'] > 0]
+            .head(1)
+            .groupby('cat')
+            .agg({'v': 'sum'})
+        )
+        assert_datastore_equals_pandas(
+            ds_result, pd_result, check_index=True, check_row_order=False
+        )
+
+    # ------- the structural assertion: SQL really has the GROUP BY -------
+
+    def test_inner_subquery_keeps_group_by_after_post_agg_filter(self):
+        """The original bug: the inner subquery dropped GROUP BY entirely.
+        Snapshot the generated SQL and assert structural properties."""
+        from datastore.query_planner import QueryPlanner
+        from datastore.sql_executor import SQLExecutionEngine
+
+        ds_result = self._ds_result_from_parquet()
+        ds_filtered = ds_result[ds_result['count'] > self.threshold]
+
+        planner = QueryPlanner()
+        exec_plan = planner.plan_segments(
+            ds_filtered._lazy_ops, has_sql_source=True, schema=None
+        )
+        self.assertEqual(len(exec_plan.segments), 1)
+        seg = exec_plan.segments[0]
+        self.assertEqual(seg.segment_type, 'sql')
+
+        engine = SQLExecutionEngine(ds_filtered)
+        sql = engine.build_sql_from_plan(seg.plan, schema={}).sql
+
+        # The whole point of the bug: inner subquery must contain GROUP BY
+        # and the aggregate calls, otherwise the outer WHERE on the agg
+        # alias fails with UNKNOWN_IDENTIFIER.
+        self.assertIn('GROUP BY', sql)
+        self.assertIn('avg("star_rating")', sql)
+        self.assertIn('count("star_rating")', sql)
+        # And the outer filter is preserved.
+        self.assertIn(f'> {self.threshold}', sql)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/datastore/tests/journeys/test_property_chain_followups.py
+++ b/datastore/tests/journeys/test_property_chain_followups.py
@@ -1,0 +1,84 @@
+"""
+Verbatim journey regressions for falsifying examples surfaced by
+``tests/test_property_based_chains.py``.
+
+The cursor rule for property-based sweeps (see
+``.cursor/rules/chdb-ds.mdc`` rule #6) requires that every hypothesis
+falsifier becomes a permanent verbatim regression here, marked
+``@unittest.expectedFailure`` while the underlying bug is open. The
+property test then skips the exact shape (referencing this file by
+name) so the sweep stays green and the bug stays tracked.
+
+When the bug is fixed, flip the ``expectedFailure`` and drop the
+corresponding skip clause in the property test in the same commit.
+"""
+
+import unittest
+
+import numpy as np
+import pandas as pd
+
+from datastore import DataStore
+
+from tests.test_utils import assert_datastore_equals_pandas
+
+
+def _dataset():
+    """Same fixed schema/seed as
+    ``tests/test_property_based_chains.py::_dataset`` so the falsifying
+    examples reproduce verbatim."""
+    rng = np.random.default_rng(20260)
+    n = 400
+    return pd.DataFrame(
+        {
+            'cat': rng.choice(['A', 'B', 'C', 'D'], n),
+            'sub': rng.choice(['x', 'y', 'z'], n),
+            'v': rng.integers(0, 100, n),
+            'w': rng.uniform(0, 100, n).round(3),
+        }
+    )
+
+
+class TestEmptyGroupbyColumnDrift(unittest.TestCase):
+    """Chain ``filter(v>0) -> filter(v>99) -> sort(w desc) ->
+    groupby(cat).agg({'v':'sum'})`` produces an empty intermediate
+    after the second filter, then aggregates an empty input. Pandas
+    returns an empty DataFrame with just the aggregated column (``v``)
+    and an empty group-key index. DataStore's executor short-circuits
+    once an upstream segment returns zero rows and surfaces the
+    source-bound intermediate columns (``['sub', 'v', 'w']``) instead
+    of the agg's projected output.
+
+    Discovered by Hypothesis in CI (PR #578, commit 64f38b8). Marked
+    ``expectedFailure``; flip when the executor's empty-intermediate
+    handling projects to the agg's output columns regardless of
+    short-circuit.
+    """
+
+    @unittest.expectedFailure
+    def test_empty_filter_then_sort_then_agg_drops_non_agg_columns(self):
+        df = _dataset()
+
+        pd_result = (
+            df[df['v'] > 0][df[df['v'] > 0]['v'] > 99]
+            .sort_values('w', ascending=False)
+            .groupby('cat')
+            .agg({'v': 'sum'})
+        )
+
+        ds = DataStore(df)
+        ds_filt1 = ds[ds['v'] > 0]
+        ds_filt2 = ds_filt1[ds_filt1['v'] > 99]
+        ds_result = (
+            ds_filt2.sort_values('w', ascending=False)
+            .groupby('cat')
+            .agg({'v': 'sum'})
+        )
+
+        assert_datastore_equals_pandas(
+            ds_result, pd_result, check_index=True
+        )
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/datastore/tests/test_cartesian_result_followups.py
+++ b/datastore/tests/test_cartesian_result_followups.py
@@ -1,0 +1,186 @@
+"""
+Cartesian product test: every realistic ``result_builder`` x every
+realistic ``follow_up`` combination is mechanically generated and
+compared to pandas.
+
+Each individual chain is short, but together they cover the
+"result-as-input" combinatorial space that the per-feature unit tests
+do not exercise.
+
+Failure modes typically caught here:
+
+- dispatcher silently drops an op in a nested subquery (the Mark bug
+  class)
+- alias rename does not propagate across a wrapper layer
+- result of a builder is a Series/DataFrame mismatch
+- post-aggregation operations bind to source columns instead of
+  aggregation outputs
+
+A failure is named ``test_<builder>__then__<follow>`` so the offending
+combination is obvious from the test id.
+"""
+
+import unittest
+from itertools import product
+
+import numpy as np
+import pandas as pd
+import pytest
+
+from datastore import DataStore
+
+from tests.test_utils import assert_datastore_equals_pandas
+
+
+@pytest.fixture(scope='module')
+def fixture_df():
+    """A small but typed dataset shared across all parametrized cases."""
+    rng = np.random.default_rng(2026)
+    n = 500
+    return pd.DataFrame(
+        {
+            'cat': rng.choice(['A', 'B', 'C', 'D'], n),
+            'sub': rng.choice(['x', 'y', 'z'], n),
+            'v': rng.integers(1, 200, n),
+            'w': rng.uniform(0, 100, n),
+        }
+    )
+
+
+# ---------------------------------------------------------------------------
+# Result builders: each takes a DataFrame-like (works on both pandas and
+# DataStore) and returns a result that the user would treat as a new
+# DataFrame. Each tuple is ``(name, builder_fn, output_col, output_is_index)``
+# where ``output_col`` is the most-relevant column the follow-up can act on.
+# ---------------------------------------------------------------------------
+
+RESULT_BUILDERS = [
+    (
+        'groupby_agg_sum',
+        lambda df: df.groupby('cat').agg({'v': 'sum'}),
+        'v',
+    ),
+    (
+        'groupby_agg_mean',
+        lambda df: df.groupby('cat').agg({'w': 'mean'}),
+        'w',
+    ),
+    (
+        'groupby_agg_max',
+        lambda df: df.groupby('cat').agg({'v': 'max'}),
+        'v',
+    ),
+    (
+        'groupby_agg_sum_then_head',
+        lambda df: df.groupby('cat').agg({'v': 'sum'}).sort_values('v').head(3),
+        'v',
+    ),
+    (
+        'filter_then_head',
+        lambda df: df[df['v'] > 50].head(50),
+        'v',
+    ),
+    (
+        # ``w`` is uniform float, near-unique so tie-breaking does not
+        # leak between pandas and DataStore. Don't use ``v`` (integer)
+        # because tied ``v`` values surface a known stable-sort semantic
+        # difference that is out of scope for this Cartesian.
+        'sort_head',
+        lambda df: df.sort_values('w', ascending=False).head(20),
+        'w',
+    ),
+    (
+        'head_then_filter',
+        lambda df: df.head(100)[lambda x: x['v'] > 30],
+        'v',
+    ),
+    (
+        'filter_select',
+        lambda df: df[df['v'] > 50][['cat', 'v']],
+        'v',
+    ),
+]
+
+
+# ---------------------------------------------------------------------------
+# Follow-ups: each takes the builder's result and the relevant output
+# column name and produces a final result for comparison.
+# ---------------------------------------------------------------------------
+
+FOLLOW_UPS = [
+    (
+        'bool_mask_above_median',
+        lambda r, c: r[r[c] > r[c].median()],
+    ),
+    (
+        'loc_above_median',
+        lambda r, c: r.loc[r[c] > r[c].median()],
+    ),
+    (
+        'sort_descending_by_col',
+        lambda r, c: r.sort_values(c, ascending=False),
+    ),
+    (
+        'head_two',
+        lambda r, c: r.head(2),
+    ),
+    (
+        'select_only_col',
+        lambda r, c: r[[c]] if c in r.columns else r,
+    ),
+    (
+        'filter_then_head',
+        lambda r, c: r[r[c] > r[c].median()].head(2),
+    ),
+]
+
+
+# Some combinations are known to need additional work or have semantic
+# differences. Tag them as xfail / skip at collection time so the suite
+# stays green where it is supposed to.
+KNOWN_XFAIL = set()  # populated below as we discover them
+
+
+def _ids():
+    """Generate human-readable parameter ids."""
+    ids = []
+    for b in RESULT_BUILDERS:
+        for f in FOLLOW_UPS:
+            ids.append(f'{b[0]}__then__{f[0]}')
+    return ids
+
+
+_PARAMS = [
+    (b[0], b[1], b[2], f[0], f[1])
+    for b in RESULT_BUILDERS
+    for f in FOLLOW_UPS
+]
+
+
+@pytest.mark.parametrize(
+    'builder_name,builder_fn,output_col,follow_name,follow_fn',
+    _PARAMS,
+    ids=_ids(),
+)
+def test_builder_followup_matches_pandas(
+    builder_name, builder_fn, output_col, follow_name, follow_fn, fixture_df
+):
+    """Mirror the same code on pandas and DataStore; compare results."""
+    pd_result = follow_fn(builder_fn(fixture_df), output_col)
+
+    ds = DataStore(fixture_df)
+    ds_result = follow_fn(builder_fn(ds), output_col)
+
+    # Aggregation-style outputs often have set indexes; comparing rows by
+    # value+index is sufficient. Sort within column for stable comparison
+    # when the order isn't guaranteed by an explicit ORDER BY in the chain.
+    sorted_chain = (
+        'sort' in builder_name or 'head' in builder_name
+        or 'sort' in follow_name or 'head' in follow_name
+    )
+    assert_datastore_equals_pandas(
+        ds_result,
+        pd_result,
+        check_index=True,
+        check_row_order=sorted_chain,
+    )

--- a/datastore/tests/test_explain_method.py
+++ b/datastore/tests/test_explain_method.py
@@ -528,5 +528,56 @@ class TestExplainEngineLabelingForPushedOps(unittest.TestCase):
         self.assertEqual(non_pushable.execution_engine(), 'Pandas')
 
 
+class TestBuildExecutionSQLFirstSegment(unittest.TestCase):
+    """``_build_execution_sql`` (the backend for ``to_sql()`` and
+    ``explain()``'s SQL preview) returns the SQL the executor would
+    issue against the *original source* - i.e. the FIRST step of
+    ``_execute()``.
+
+    Regression for PR #577 Copilot comment: a previous implementation
+    used ``next(seg for seg in segments if seg.is_sql())`` which would
+    happily pick a LATER ``SQL-on-Python(__df__)`` segment when the
+    first segment was Pandas (cost-aware planner case for ORDER BY
+    without LIMIT). That returned a Python-table-function SQL whose
+    ``FROM`` clause does not match the original source the user sees in
+    the executor's first call.
+    """
+
+    def setUp(self):
+        import pandas as pd
+
+        self.temp_dir = tempfile.mkdtemp()
+        self.parquet_file = os.path.join(self.temp_dir, "data.parquet")
+        pd.DataFrame({"a": list(range(10)), "b": list(range(10))}).to_parquet(
+            self.parquet_file
+        )
+
+    def tearDown(self):
+        if os.path.exists(self.parquet_file):
+            os.unlink(self.parquet_file)
+        if os.path.exists(self.temp_dir):
+            os.rmdir(self.temp_dir)
+
+    def test_first_segment_sql_returns_source_bound_sql(self):
+        ds = DataStore.from_file(self.parquet_file)
+        sql = ds[ds["a"] > 5].to_sql()
+        self.assertIn("file(", sql)
+        self.assertNotIn("Python(", sql)
+        self.assertNotIn("__df__", sql)
+        self.assertIn('"a" > 5', sql)
+
+    def test_first_segment_pandas_returns_source_select(self):
+        """When the chain starts with a Pandas segment (e.g. ORDER BY
+        without LIMIT under the cost-aware planner), ``to_sql()`` must
+        return the initial ``SELECT * FROM <source>`` the executor
+        issues to materialize rows for Pandas - NOT a downstream
+        ``Python(__df__)`` SQL fragment."""
+        ds = DataStore.from_file(self.parquet_file)
+        sql = ds.sort_values("a").to_sql()
+        self.assertIn("file(", sql)
+        self.assertNotIn("Python(", sql)
+        self.assertNotIn("__df__", sql)
+
+
 if __name__ == '__main__':
     unittest.main()

--- a/datastore/tests/test_groupby_sql_pushdown.py
+++ b/datastore/tests/test_groupby_sql_pushdown.py
@@ -908,6 +908,92 @@ class TestDispatchByOpType(unittest.TestCase):
         # Post-agg condition is on the aggregation output
         self.assertIs(post[0], post_where.condition)
 
+    def test_mask_then_groupby_splits_into_nested_layers(self):
+        """Regression for PR #578 Copilot comment: ``mask(...).groupby(...).agg(...)``
+        used to put LazyMask and LazyGroupByAgg in the SAME layer, which
+        made the wrapper-layer CASE-WHEN temp-alias machinery
+        (``__tmp_<col>__``) collide with the aggregation's own SELECT
+        list - the outer ``SELECT __tmp_x__ AS x`` would reference
+        non-existent columns because the inner SELECT only emits
+        aggregations.
+
+        The planner now splits LazyGroupByAgg into a new nested layer
+        when the current layer already contains LazyWhere/LazyMask, so
+        the mask runs in the inner subquery and GROUP BY runs on the
+        masked output:
+        ``SELECT ... agg() FROM (SELECT CASE WHEN ... AS x) GROUP BY x``.
+        """
+        from datastore.query_planner import QueryPlanner
+        from datastore.lazy_ops import LazyMask, LazyGroupByAgg
+
+        df = pd.DataFrame({'g': [1, 1, 2, 2, 3], 'v': [10, 20, 30, 40, 50]})
+        ds = DataStore(df)
+        chain = ds.mask(ds['v'] < 30, 0).groupby('g').agg({'v': 'sum'})
+
+        planner = QueryPlanner()
+        exec_plan = planner.plan_segments(
+            chain._lazy_ops, has_sql_source=True, schema=None
+        )
+        sql_segments = [seg for seg in exec_plan.segments if seg.is_sql()]
+        self.assertEqual(len(sql_segments), 1)
+        layers = sql_segments[0].plan.layers
+        self.assertEqual(
+            len(layers), 2,
+            f'expected 2 layers (mask, then groupby), got {len(layers)}',
+        )
+        self.assertTrue(
+            any(isinstance(op, LazyMask) for op in layers[0]),
+            f'inner layer should hold the mask: {layers[0]}',
+        )
+        self.assertFalse(
+            any(isinstance(op, LazyGroupByAgg) for op in layers[0]),
+            f'inner layer should NOT hold the groupby: {layers[0]}',
+        )
+        self.assertTrue(
+            any(isinstance(op, LazyGroupByAgg) for op in layers[1]),
+            f'outer layer should hold the groupby: {layers[1]}',
+        )
+
+        # End-to-end correctness vs pandas
+        pd_result = df.mask(df['v'] < 30, 0).groupby('g').agg({'v': 'sum'})
+        ds_result = chain.to_df()
+        # Comparing as dicts is enough; index alignment differs for the
+        # ``0`` group (numeric vs auto-coerced) which is incidental here.
+        self.assertEqual(
+            dict(zip(ds_result.index.tolist(), ds_result['v'].tolist())),
+            dict(zip(pd_result.index.tolist(), pd_result['v'].tolist())),
+        )
+
+    def test_where_then_groupby_splits_into_nested_layers(self):
+        """Same as above but for ``where(...)`` (the boolean-mask twin
+        of ``mask(...)``)."""
+        from datastore.query_planner import QueryPlanner
+        from datastore.lazy_ops import LazyWhere, LazyGroupByAgg
+
+        df = pd.DataFrame({'g': [1, 1, 2, 2, 3], 'v': [10, 20, 30, 40, 50]})
+        ds = DataStore(df)
+        chain = ds.where(ds['v'] >= 30, 0).groupby('g').agg({'v': 'sum'})
+
+        planner = QueryPlanner()
+        exec_plan = planner.plan_segments(
+            chain._lazy_ops, has_sql_source=True, schema=None
+        )
+        sql_segments = [seg for seg in exec_plan.segments if seg.is_sql()]
+        self.assertEqual(len(sql_segments), 1)
+        layers = sql_segments[0].plan.layers
+        self.assertEqual(len(layers), 2)
+        self.assertTrue(any(isinstance(op, LazyWhere) for op in layers[0]))
+        self.assertTrue(
+            any(isinstance(op, LazyGroupByAgg) for op in layers[1])
+        )
+
+        pd_result = df.where(df['v'] >= 30, 0).groupby('g').agg({'v': 'sum'})
+        ds_result = chain.to_df()
+        self.assertEqual(
+            dict(zip(ds_result.index.tolist(), ds_result['v'].tolist())),
+            dict(zip(pd_result.index.tolist(), pd_result['v'].tolist())),
+        )
+
 
 class TestGroupBySQLPushdownPerformance(unittest.TestCase):
     """Test that SQL pushdown provides performance benefits."""

--- a/datastore/tests/test_groupby_sql_pushdown.py
+++ b/datastore/tests/test_groupby_sql_pushdown.py
@@ -811,7 +811,13 @@ class TestDispatchByOpType(unittest.TestCase):
         sql = result.sql
         self.assertIn('GROUP BY', sql)
         self.assertIn('sum("a")', sql)
-        self.assertIn('WHERE "a" > 5', sql)
+        # ``WHERE`` may be combined with the dropna ``IS NOT NULL`` filter
+        # for the group key when ``dropna=True`` (the pandas default), so
+        # allow either standalone or AND-combined forms.
+        self.assertTrue(
+            'WHERE "a" > 5' in sql or '"a" > 5 AND' in sql,
+            f'expected WHERE "a" > 5 clause in SQL: {sql}',
+        )
 
     def test_layer_without_groupby_agg_skips_group_by(self):
         """A layer with only WHERE/ORDER BY/LIMIT must not emit GROUP BY."""

--- a/datastore/tests/test_naming_conflict_fuzz.py
+++ b/datastore/tests/test_naming_conflict_fuzz.py
@@ -1,0 +1,236 @@
+"""
+Systematic enumeration of naming-conflict scenarios.
+
+Most chdb-ds bugs around aggregation alias handling boil down to a
+small set of name-collision shapes:
+
+- the agg's output alias equals a source column name
+- a source column is named after an agg function ('count', 'sum', ...)
+- a WHERE column equals the agg's output alias
+- a sort column equals the agg's output alias
+- chained aggregations re-aggregate a column with the same name
+
+This file enumerates each of these shapes and compares to pandas.
+
+Naming the parametrized test ids after the shape keeps failing tests
+self-documenting.
+"""
+
+import unittest
+from typing import Callable, List, Tuple
+
+import numpy as np
+import pandas as pd
+import pytest
+
+from datastore import DataStore
+
+from tests.test_utils import assert_datastore_equals_pandas
+
+
+# Each tuple is (shape_id, data_factory, op_chain_callable, post_compare_kwargs)
+# - data_factory takes no args and returns a pandas DataFrame
+# - op_chain_callable takes a DataFrame-like and returns the final result
+# - post_compare_kwargs forwards to assert_datastore_equals_pandas
+CONFLICT_PATTERNS: List[Tuple[str, Callable, Callable, dict]] = [
+    # ---- agg alias equals source column name -----------------------------
+    (
+        'agg_alias_equals_source_col_sum',
+        lambda: pd.DataFrame(
+            {'cat': ['A', 'B', 'A', 'B'] * 25, 'count': list(range(100))}
+        ),
+        lambda df: df.groupby('cat').agg({'count': 'sum'}),
+        dict(check_index=True),
+    ),
+    (
+        'agg_alias_equals_source_col_mean',
+        lambda: pd.DataFrame(
+            {'cat': ['A', 'B', 'A', 'B'] * 25, 'sum': list(range(100))}
+        ),
+        lambda df: df.groupby('cat').agg({'sum': 'mean'}),
+        dict(check_index=True),
+    ),
+    (
+        'agg_alias_equals_source_col_max',
+        lambda: pd.DataFrame(
+            {'cat': ['A', 'B'] * 50, 'amount': list(range(100))}
+        ),
+        lambda df: df.groupby('cat').agg({'amount': 'max'}),
+        dict(check_index=True),
+    ),
+
+    # ---- source col named like an agg function ----------------------------
+    (
+        'source_col_named_count_simple_agg',
+        lambda: pd.DataFrame(
+            {'cat': ['A', 'B'] * 50, 'count': list(range(100))}
+        ),
+        lambda df: df.groupby('cat').count(),
+        dict(check_index=True),
+    ),
+    (
+        'source_col_named_sum_simple_agg',
+        lambda: pd.DataFrame(
+            {'cat': ['A', 'B'] * 50, 'sum': list(range(100))}
+        ),
+        lambda df: df.groupby('cat').sum(),
+        dict(check_index=True),
+    ),
+
+    # ---- WHERE on source col then agg with same alias --------------------
+    (
+        'where_then_agg_alias_collision_sum',
+        lambda: pd.DataFrame(
+            {'cat': ['A', 'B'] * 100, 'amount': list(range(200))}
+        ),
+        lambda df: df[df['amount'] > 50].groupby('cat').agg({'amount': 'sum'}),
+        dict(check_index=True),
+    ),
+    (
+        'where_then_agg_alias_collision_count',
+        lambda: pd.DataFrame(
+            {'cat': ['A', 'B', 'C'] * 50, 'val': list(range(150))}
+        ),
+        lambda df: df[df['val'] > 30].groupby('cat').agg({'val': 'count'}),
+        dict(check_index=True),
+    ),
+
+    # ---- multiple agg funcs on same col (multi-index) -------------------
+    (
+        'multi_agg_same_col',
+        lambda: pd.DataFrame(
+            {'cat': ['A', 'B'] * 50, 'value': list(range(100))}
+        ),
+        lambda df: df.groupby('cat').agg({'value': ['mean', 'max']}),
+        dict(check_index=True),
+    ),
+
+    # ---- sort by aggregated column with conflict-named alias -----------
+    (
+        'sort_by_agg_alias_equal_source_col',
+        lambda: pd.DataFrame(
+            {'cat': ['A', 'B', 'C'] * 50, 'amount': list(range(150))}
+        ),
+        lambda df: (
+            df[df['amount'] > 20]
+            .groupby('cat')
+            .agg({'amount': 'sum'})
+            .sort_values('amount', ascending=False)
+        ),
+        dict(check_index=True),
+    ),
+
+    # ---- post-LIMIT WHERE on alias-conflicted col --------------------
+    (
+        'post_limit_filter_on_conflict_col',
+        lambda: pd.DataFrame(
+            {'cat': ['A', 'B', 'C', 'D'] * 50, 'value': list(range(200))}
+        ),
+        lambda df: (
+            df[df['value'] > 50]
+            .groupby('cat')
+            .agg({'value': 'sum'})
+            .sort_values('value', ascending=False)
+            .head(5)
+        ),
+        dict(check_index=True),
+    ),
+
+    # ---- ColumnExpr.agg(['count']) flat naming ------------------------
+    (
+        'columnexpr_single_col_agg_count',
+        lambda: pd.DataFrame(
+            {'cat': ['A', 'B', 'C'] * 30, 'rating': list(range(90))}
+        ),
+        lambda df: df.groupby('cat')['rating'].agg(['count']),
+        dict(check_index=True),
+    ),
+    (
+        'columnexpr_single_col_agg_mean_count',
+        lambda: pd.DataFrame(
+            {'cat': ['A', 'B', 'C'] * 30, 'rating': list(range(90))}
+        ),
+        lambda df: df.groupby('cat')['rating'].agg(['mean', 'count']),
+        dict(check_index=True),
+    ),
+
+    # ---- WHERE on cat with agg on cat as the only output ---------------
+    (
+        'where_on_groupkey_then_agg',
+        lambda: pd.DataFrame(
+            {'cat': list('ABCD') * 25, 'v': list(range(100))}
+        ),
+        lambda df: df[df['cat'] != 'D'].groupby('cat').agg({'v': 'sum'}),
+        dict(check_index=True),
+    ),
+
+    # ---- agg col name happens to be a SQL keyword-like word ------------
+    (
+        'agg_col_named_order',
+        lambda: pd.DataFrame(
+            {'cat': ['A', 'B'] * 50, 'order': list(range(100))}
+        ),
+        lambda df: df.groupby('cat').agg({'order': 'sum'}),
+        dict(check_index=True),
+    ),
+    (
+        'agg_col_named_limit',
+        lambda: pd.DataFrame(
+            {'cat': ['A', 'B'] * 50, 'limit': list(range(100))}
+        ),
+        lambda df: df.groupby('cat').agg({'limit': 'max'}),
+        dict(check_index=True),
+    ),
+
+    # ---- chained groupby on result with same column name --------------
+    (
+        'agg_then_groupby_again_same_col',
+        lambda: pd.DataFrame(
+            {
+                'cat': list('ABCD') * 25,
+                'sub': list('xy') * 50,
+                'value': list(range(100)),
+            }
+        ),
+        lambda df: (
+            df.groupby(['cat', 'sub'])
+            .agg({'value': 'sum'})
+            .reset_index()
+            .groupby('cat')
+            .agg({'value': 'max'})
+        ),
+        dict(check_index=True),
+    ),
+
+    # ---- source col name matches the aggregate alias used internally ---
+    (
+        'source_col_named_agg_v',
+        lambda: pd.DataFrame(
+            {'cat': ['A', 'B'] * 50, '__agg_v__': list(range(100))}
+        ),
+        lambda df: df.groupby('cat').agg({'__agg_v__': 'sum'}),
+        dict(check_index=True),
+    ),
+]
+
+
+@pytest.mark.parametrize(
+    'shape_id,data_factory,op_chain,compare_kwargs',
+    CONFLICT_PATTERNS,
+    ids=[p[0] for p in CONFLICT_PATTERNS],
+)
+def test_naming_conflict_matches_pandas(
+    shape_id, data_factory, op_chain, compare_kwargs
+):
+    """Each shape mirrors pandas; mismatch indicates an alias-handling bug."""
+    pd_df = data_factory()
+    pd_result = op_chain(pd_df)
+
+    ds = DataStore(pd_df)
+    ds_result = op_chain(ds)
+
+    # Aggregations without explicit sort have undefined row order.
+    compare_kwargs = dict(compare_kwargs)
+    compare_kwargs.setdefault('check_row_order', False)
+
+    assert_datastore_equals_pandas(ds_result, pd_result, **compare_kwargs)

--- a/datastore/tests/test_plan_invariants.py
+++ b/datastore/tests/test_plan_invariants.py
@@ -1,0 +1,372 @@
+"""
+Structural invariants on the QueryPlan / generated SQL pair.
+
+These tests do NOT execute the SQL. They build the plan, build the SQL,
+and assert structural properties that any internal change must preserve.
+A failure here means the planner and the SQL builder have drifted out of
+agreement - exactly the bug class that hid the layer-N GroupByAgg
+silent-drop bug for so long.
+
+Why this style: pure equality-with-pandas tests can pass on bad SQL by
+accident (e.g. an empty result on both sides). Invariants on the
+plan/SQL pair are independent of input data and tend to catch
+dispatcher / builder regressions immediately.
+
+Each invariant runs against a list of representative chains so a single
+broken invariant fires from multiple test ids and is easy to localise.
+"""
+
+import os
+import re
+import tempfile
+
+import numpy as np
+import pandas as pd
+import pytest
+
+from datastore import DataStore
+from datastore.lazy_ops import (
+    LazyGroupByAgg,
+    LazyMask,
+    LazyRelationalOp,
+    LazyWhere,
+)
+from datastore.query_planner import QueryPlanner
+from datastore.sql_executor import SQLExecutionEngine
+
+
+@pytest.fixture(scope='module')
+def parquet_source():
+    rng = np.random.default_rng(33)
+    n = 500
+    df = pd.DataFrame(
+        {
+            'cat': rng.choice(['A', 'B', 'C'], n),
+            'v': rng.integers(1, 100, n),
+            'w': rng.uniform(0, 100, n),
+        }
+    )
+    tmp = tempfile.mkdtemp()
+    path = os.path.join(tmp, 'src.parquet')
+    df.to_parquet(path)
+    yield path
+    import shutil
+
+    shutil.rmtree(tmp)
+
+
+def _plan_and_sql(ds_chain):
+    planner = QueryPlanner()
+    exec_plan = planner.plan_segments(
+        ds_chain._lazy_ops, has_sql_source=True, schema=None
+    )
+    seg = next(s for s in exec_plan.segments if s.is_sql() and s.plan)
+    plan = seg.plan
+    engine = SQLExecutionEngine(ds_chain)
+    sql = engine.build_sql_from_plan(plan, schema={}).sql
+    return plan, sql
+
+
+# ---------------------------------------------------------------------------
+# A representative selection of chain shapes used by every invariant test.
+# ---------------------------------------------------------------------------
+
+CHAINS_WITH_GROUPBY = [
+    ('simple_groupby_sum', lambda ds: ds.groupby('cat').agg({'v': 'sum'})),
+    (
+        'filter_then_groupby_sum',
+        lambda ds: ds[ds['v'] > 10].groupby('cat').agg({'v': 'sum'}),
+    ),
+    (
+        'groupby_sort_head',
+        lambda ds: ds.groupby('cat').agg({'v': 'sum'}).sort_values('v').head(2),
+    ),
+    (
+        'groupby_in_layer_n',
+        # head() before groupby pushes the agg into a non-zero layer
+        lambda ds: ds.head(50).groupby('cat').agg({'v': 'sum'}),
+    ),
+    (
+        'post_limit_filter_on_agg',
+        lambda ds: (
+            ds[ds['v'] > 10]
+            .groupby('cat')
+            .agg({'v': 'sum'})
+            .sort_values('v', ascending=False)
+            .head(3)[lambda r: r['v'] > 100]
+        ),
+    ),
+    (
+        'multi_agg_funcs',
+        lambda ds: ds.groupby('cat').agg({'v': ['sum', 'mean']}),
+    ),
+]
+
+CHAINS_WITHOUT_GROUPBY = [
+    ('pure_filter', lambda ds: ds[ds['v'] > 10]),
+    (
+        'filter_sort_head',
+        lambda ds: ds[ds['v'] > 10].sort_values('w').head(5),
+    ),
+    ('select_only', lambda ds: ds[['cat', 'v']]),
+    (
+        'limit_then_filter',
+        lambda ds: ds.head(50)[lambda r: r['v'] > 30],
+    ),
+]
+
+CHAINS_WITH_NESTED_LAYERS = [
+    (
+        'limit_then_where_creates_two_layers',
+        lambda ds: ds.head(50)[lambda r: r['v'] > 30],
+        2,
+    ),
+    (
+        'three_layer_chain',
+        lambda ds: (
+            ds[ds['v'] > 10]
+            .head(100)[lambda r: r['w'] > 30]
+            .head(10)[lambda r: r['v'] > 20]
+        ),
+        # WHERE -> LIMIT -> WHERE (new layer) -> LIMIT -> WHERE (new layer)
+        3,
+    ),
+]
+
+
+# ---------------------------------------------------------------------------
+# Invariant 1: groupby_agg in plan iff GROUP BY in SQL
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    'name,builder', CHAINS_WITH_GROUPBY, ids=[c[0] for c in CHAINS_WITH_GROUPBY]
+)
+def test_groupby_in_plan_implies_group_by_in_sql(name, builder, parquet_source):
+    ds = DataStore.from_file(parquet_source)
+    plan, sql = _plan_and_sql(builder(ds))
+    has_agg_in_layers = any(
+        isinstance(op, LazyGroupByAgg)
+        for layer in plan.layers
+        for op in layer
+    )
+    assert plan.groupby_agg is not None or has_agg_in_layers, (
+        f'[{name}] expected plan.groupby_agg or layer-level LazyGroupByAgg; got plan={plan}'
+    )
+    assert 'GROUP BY' in sql, (
+        f'[{name}] plan has GroupByAgg but SQL is missing GROUP BY:\n{sql}'
+    )
+
+
+@pytest.mark.parametrize(
+    'name,builder',
+    CHAINS_WITHOUT_GROUPBY,
+    ids=[c[0] for c in CHAINS_WITHOUT_GROUPBY],
+)
+def test_no_groupby_in_plan_implies_no_group_by_in_sql(
+    name, builder, parquet_source
+):
+    ds = DataStore.from_file(parquet_source)
+    plan, sql = _plan_and_sql(builder(ds))
+    has_agg_in_layers = any(
+        isinstance(op, LazyGroupByAgg)
+        for layer in plan.layers
+        for op in layer
+    )
+    assert plan.groupby_agg is None and not has_agg_in_layers, (
+        f'[{name}] expected no GroupByAgg; got plan={plan}'
+    )
+    assert 'GROUP BY' not in sql, (
+        f'[{name}] plan has no GroupByAgg but SQL contains GROUP BY:\n{sql}'
+    )
+
+
+# ---------------------------------------------------------------------------
+# Invariant 2: layer count maps to subquery count
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    'name,builder,expected_layers',
+    CHAINS_WITH_NESTED_LAYERS,
+    ids=[c[0] for c in CHAINS_WITH_NESTED_LAYERS],
+)
+def test_n_layers_implies_n_minus_1_subqueries(
+    name, builder, expected_layers, parquet_source
+):
+    ds = DataStore.from_file(parquet_source)
+    plan, sql = _plan_and_sql(builder(ds))
+    assert len(plan.layers) == expected_layers, (
+        f'[{name}] expected {expected_layers} layers, got {len(plan.layers)}: '
+        f'{plan.layers}'
+    )
+    n_subq = len(re.findall(r'__subq\d+__', sql))
+    # Each wrapper layer introduces exactly one __subqN__ alias; the
+    # first layer reads from the table source so it does not.
+    expected_subq = expected_layers - 1
+    assert n_subq == expected_subq, (
+        f'[{name}] expected {expected_subq} __subqN__ aliases, got {n_subq}.\nSQL:\n{sql}'
+    )
+
+
+# ---------------------------------------------------------------------------
+# Invariant 3: every alias rename has a presence in the SQL
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    'name,builder', CHAINS_WITH_GROUPBY, ids=[c[0] for c in CHAINS_WITH_GROUPBY]
+)
+def test_alias_renames_appear_in_sql(name, builder, parquet_source):
+    ds = DataStore.from_file(parquet_source)
+    plan, sql = _plan_and_sql(builder(ds))
+    if not plan.alias_renames:
+        pytest.skip(f'[{name}] plan introduced no aliases')
+    for temp_alias in plan.alias_renames.keys():
+        assert temp_alias in sql, (
+            f'[{name}] plan declared temp alias {temp_alias!r} but SQL '
+            f'does not reference it:\n{sql}'
+        )
+
+
+# ---------------------------------------------------------------------------
+# Invariant 4: WHERE op count is bounded by SQL WHERE clause count
+# ---------------------------------------------------------------------------
+
+
+_WHERE_PATTERN = re.compile(r'\bWHERE\b', re.IGNORECASE)
+
+
+@pytest.mark.parametrize(
+    'name,builder',
+    CHAINS_WITH_GROUPBY + CHAINS_WITHOUT_GROUPBY,
+    ids=[c[0] for c in CHAINS_WITH_GROUPBY + CHAINS_WITHOUT_GROUPBY],
+)
+def test_where_clauses_present_when_plan_has_where_ops(
+    name, builder, parquet_source
+):
+    ds = DataStore.from_file(parquet_source)
+    plan, sql = _plan_and_sql(builder(ds))
+    n_where_ops_in_layers = sum(
+        1
+        for layer in plan.layers
+        for op in layer
+        if isinstance(op, LazyRelationalOp) and op.op_type == 'WHERE'
+    )
+    if n_where_ops_in_layers == 0:
+        pytest.skip(f'[{name}] no WHERE in plan; nothing to assert')
+    n_where_in_sql = len(_WHERE_PATTERN.findall(sql))
+    assert n_where_in_sql >= 1, (
+        f'[{name}] plan has {n_where_ops_in_layers} WHERE ops but SQL has '
+        f'zero WHERE clauses:\n{sql}'
+    )
+
+
+# ---------------------------------------------------------------------------
+# Invariant 5: layer-0 wraps the actual source, never a __subq alias
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    'name,builder',
+    CHAINS_WITH_GROUPBY + CHAINS_WITHOUT_GROUPBY,
+    ids=[c[0] for c in CHAINS_WITH_GROUPBY + CHAINS_WITHOUT_GROUPBY],
+)
+def test_layer_zero_reads_from_real_source(name, builder, parquet_source):
+    """The innermost subquery must read from the actual source, not from
+    a synthetic __subqN__ alias. If it does not, we have a layer indexing
+    bug."""
+    ds = DataStore.from_file(parquet_source)
+    plan, sql = _plan_and_sql(builder(ds))
+    # The innermost FROM should reference the parquet path or table fn.
+    # We assert the parquet path is in the SQL (it must show up exactly
+    # once - the original table reference).
+    assert 'file(' in sql, (
+        f'[{name}] innermost SQL missing file() source reference:\n{sql}'
+    )
+
+
+# ---------------------------------------------------------------------------
+# Invariant 6: groupby_agg pointer matches a LazyGroupByAgg op in layers
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    'name,builder', CHAINS_WITH_GROUPBY, ids=[c[0] for c in CHAINS_WITH_GROUPBY]
+)
+def test_groupby_agg_pointer_aligns_with_layers(name, builder, parquet_source):
+    """``plan.groupby_agg`` should be either ``None`` or an actual op
+    inside ``plan.layers``; never a dangling reference."""
+    ds = DataStore.from_file(parquet_source)
+    plan, _sql = _plan_and_sql(builder(ds))
+    if plan.groupby_agg is None:
+        pytest.skip(f'[{name}] plan has no groupby_agg pointer')
+    layer_ops = [op for layer in plan.layers for op in layer]
+    matches = [
+        op
+        for op in layer_ops
+        if isinstance(op, LazyGroupByAgg)
+        and (
+            op is plan.groupby_agg
+            or (
+                op.groupby_cols == plan.groupby_agg.groupby_cols
+                and op.agg_dict == plan.groupby_agg.agg_dict
+                and op.agg_func == plan.groupby_agg.agg_func
+            )
+        )
+    ]
+    assert matches, (
+        f'[{name}] plan.groupby_agg has no corresponding LazyGroupByAgg in '
+        f'layers; pointer is dangling.'
+    )
+
+
+# ---------------------------------------------------------------------------
+# Invariant 7: where_ops convenience list matches LazyWhere/Mask in layers
+# ---------------------------------------------------------------------------
+
+
+def test_where_ops_pointer_alignment(parquet_source):
+    """``plan.where_ops`` should reflect exactly the LazyWhere/LazyMask
+    ops that live inside the layers."""
+    ds = DataStore.from_file(parquet_source)
+    # Build a chain that involves where() (pandas-style boolean wrapper)
+    ds_chain = ds.where(ds['v'] > 50, 0)
+    plan, _sql = _plan_and_sql(ds_chain)
+    layer_where_mask = [
+        op
+        for layer in plan.layers
+        for op in layer
+        if isinstance(op, (LazyWhere, LazyMask))
+    ]
+    assert len(plan.where_ops) == len(layer_where_mask), (
+        f'plan.where_ops length {len(plan.where_ops)} != '
+        f'LazyWhere/Mask count in layers {len(layer_where_mask)}; pointer is stale.'
+    )
+
+
+# ---------------------------------------------------------------------------
+# Invariant 8: SELECT never has a bare orphan __agg_*__ that isn't in renames
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    'name,builder', CHAINS_WITH_GROUPBY, ids=[c[0] for c in CHAINS_WITH_GROUPBY]
+)
+def test_temp_alias_in_sql_was_registered_in_plan(
+    name, builder, parquet_source
+):
+    """Every ``__agg_*__`` alias the SQL emits must also be in
+    ``plan.alias_renames`` so post-execution can rename it back. An
+    orphan SQL alias would leak the temp name to the user."""
+    ds = DataStore.from_file(parquet_source)
+    plan, sql = _plan_and_sql(builder(ds))
+    sql_aliases = set(re.findall(r'__agg_\w+__', sql))
+    if not sql_aliases:
+        pytest.skip(f'[{name}] no temp aliases emitted')
+    declared = set(plan.alias_renames.keys())
+    leaks = sql_aliases - declared
+    assert not leaks, (
+        f'[{name}] SQL emits temp aliases {leaks!r} that are not in '
+        f'plan.alias_renames {declared!r}; post-execution will not rename them.'
+    )

--- a/datastore/tests/test_property_based_chains.py
+++ b/datastore/tests/test_property_based_chains.py
@@ -1,0 +1,274 @@
+"""
+Property-based exploration: random op-chains must match pandas.
+
+Most existing tests are example-based - the author picked specific
+inputs that would surface a known issue. Property-based tests have
+hypothesis generate the inputs (here: operation chains of varying
+length on a fixed schema), shrink any failing case to a minimal
+reproducer, and re-run the same case forever via the example DB.
+
+The chain DSL stays narrow on purpose: filter / sort / head / select /
+agg. That covers the bug class that produced this whole branch
+(post-LIMIT / post-AGG / nested-layer dispatch).
+
+Settings are tuned so the test runs in a few seconds in CI:
+- ``max_examples=30`` per test
+- ``deadline=2000`` ms per example
+- chain depth bounded to 3..6 ops
+
+If hypothesis finds a regression, copy the printed Falsifying example
+into a verbatim regression test under
+``datastore/tests/journeys/`` and keep it.
+"""
+
+import unittest
+
+import numpy as np
+import pandas as pd
+import pytest
+from hypothesis import HealthCheck, given, settings, strategies as st
+
+from datastore import DataStore
+
+from tests.test_utils import assert_datastore_equals_pandas
+
+
+# ---------------------------------------------------------------------------
+# Fixed dataset: typed, contains a few nulls, large enough for filters
+# to leave non-empty results most of the time.
+# ---------------------------------------------------------------------------
+
+
+def _dataset():
+    rng = np.random.default_rng(20260)
+    n = 400
+    return pd.DataFrame(
+        {
+            'cat': rng.choice(['A', 'B', 'C', 'D'], n),
+            'sub': rng.choice(['x', 'y', 'z'], n),
+            'v': rng.integers(0, 100, n),
+            'w': rng.uniform(0, 100, n).round(3),
+        }
+    )
+
+
+_DF = _dataset()
+
+# Columns by kind (for op argument generation).
+INT_COL = 'v'
+FLOAT_COL = 'w'
+STR_COLS = ['cat', 'sub']
+NUMERIC_COLS = [INT_COL, FLOAT_COL]
+
+
+# ---------------------------------------------------------------------------
+# Op DSL: each op is a small dict describing what to do. Operations
+# are applied in order; ``apply_chain`` runs the same chain on a pandas
+# DataFrame or a DataStore (their APIs overlap enough that this works).
+# ---------------------------------------------------------------------------
+
+
+def _filter(col, thresh):
+    return {'op': 'filter', 'col': col, 'thresh': thresh}
+
+
+def _sort(col, ascending):
+    return {'op': 'sort', 'col': col, 'ascending': ascending}
+
+
+def _head(n):
+    return {'op': 'head', 'n': n}
+
+
+def _select(cols):
+    return {'op': 'select', 'cols': cols}
+
+
+def _agg(col, func):
+    return {'op': 'agg', 'col': col, 'func': func}
+
+
+def _apply_one(df, step):
+    op = step['op']
+    if op == 'filter':
+        col, thresh = step['col'], step['thresh']
+        return df[df[col] > thresh]
+    if op == 'sort':
+        return df.sort_values(step['col'], ascending=step['ascending'])
+    if op == 'head':
+        return df.head(step['n'])
+    if op == 'select':
+        return df[step['cols']]
+    if op == 'agg':
+        # After agg we cannot continue with non-agg ops on the same
+        # schema; we treat agg as a terminal step (the chain generator
+        # only puts it at the end).
+        return df.groupby('cat').agg({step['col']: step['func']})
+    raise ValueError(f'unknown op {op}')
+
+
+def apply_chain(df, chain):
+    out = df
+    for step in chain:
+        out = _apply_one(out, step)
+    return out
+
+
+# ---------------------------------------------------------------------------
+# Hypothesis strategies
+# ---------------------------------------------------------------------------
+
+
+# Thresholds: ints are 0..100 (matches the v range); floats are 0..100.
+int_threshold = st.integers(min_value=0, max_value=100)
+float_threshold = st.floats(min_value=0.0, max_value=100.0, allow_nan=False)
+head_n = st.integers(min_value=1, max_value=50)
+ascending = st.booleans()
+
+
+def _filter_strategy():
+    return st.one_of(
+        int_threshold.map(lambda t: _filter(INT_COL, t)),
+        float_threshold.map(lambda t: _filter(FLOAT_COL, t)),
+    )
+
+
+def _sort_strategy():
+    # Restrict to the float column (``w``): integer columns have ties
+    # which pandas and DataStore tie-break differently (stable vs
+    # source order). That semantic gap is out of scope here; the
+    # property test is for dispatcher / SQL correctness, not for sort
+    # stability.
+    return st.tuples(
+        st.just(FLOAT_COL), ascending
+    ).map(lambda t: _sort(t[0], t[1]))
+
+
+def _head_strategy():
+    return head_n.map(_head)
+
+
+def _select_strategy():
+    # Always include at least one numeric column so downstream ops
+    # have something to operate on.
+    return st.lists(
+        st.sampled_from(STR_COLS + NUMERIC_COLS), min_size=2, max_size=4, unique=True
+    ).filter(lambda cs: any(c in NUMERIC_COLS for c in cs)).map(_select)
+
+
+def _agg_strategy():
+    return st.tuples(
+        st.sampled_from(NUMERIC_COLS),
+        st.sampled_from(['sum', 'mean', 'max', 'min', 'count']),
+    ).map(lambda t: _agg(t[0], t[1]))
+
+
+# A non-terminal step (anything except agg).
+non_terminal_step = st.one_of(
+    _filter_strategy(),
+    _sort_strategy(),
+    _head_strategy(),
+    _select_strategy(),
+)
+
+
+@st.composite
+def op_chain(draw, min_steps=3, max_steps=6, terminal_agg_prob=0.5):
+    """Build a chain of 3..6 ops. Optionally terminate in an agg."""
+    n = draw(st.integers(min_value=min_steps, max_value=max_steps))
+    steps = [draw(non_terminal_step) for _ in range(n)]
+    if draw(st.floats(0.0, 1.0)) < terminal_agg_prob:
+        steps.append(draw(_agg_strategy()))
+    return steps
+
+
+# ---------------------------------------------------------------------------
+# Property: chain on DataStore matches the same chain on pandas
+# ---------------------------------------------------------------------------
+
+
+def _select_drops_agg_target(chain) -> bool:
+    """When a SELECT step removes the column an agg later targets, the
+    chain becomes invalid (KeyError on pandas, mismatched semantics on
+    DataStore). Skip such chains."""
+    for i, step in enumerate(chain):
+        if step['op'] != 'select':
+            continue
+        kept = set(step['cols'])
+        for later in chain[i + 1 :]:
+            if later['op'] in ('agg', 'sort', 'filter'):
+                needed = later.get('col')
+                if needed and needed not in kept:
+                    return True
+    return False
+
+
+def _chain_uses_dropped_col(chain) -> bool:
+    """Conservative pre-check: a sort/filter on a column that an earlier
+    SELECT dropped is invalid."""
+    return _select_drops_agg_target(chain)
+
+
+@given(chain=op_chain(min_steps=3, max_steps=6))
+@settings(
+    max_examples=30,
+    deadline=2000,
+    suppress_health_check=[
+        HealthCheck.function_scoped_fixture,
+        HealthCheck.filter_too_much,
+    ],
+)
+def test_random_chain_matches_pandas(chain):
+    """For any randomly generated chain, DataStore must match pandas.
+
+    Previous known-bug skip filters for head-before-agg and
+    sort/select-before-agg were dropped once the underlying planner
+    + SQL-builder bugs were fixed (see
+    ``journeys/test_mark_slack_amazon_reviews.py`` and
+    ``journeys/test_kaggle_style_exploration.py`` for the verbatim
+    regressions)."""
+    if _chain_uses_dropped_col(chain):
+        # Hypothesis will shrink past this and find more useful examples.
+        return
+
+    try:
+        pd_result = apply_chain(_DF, chain)
+    except (KeyError, ValueError, TypeError):
+        # An invalid combination from the perspective of pandas; skip it.
+        return
+    try:
+        ds_result = apply_chain(DataStore(_DF), chain)
+    except (KeyError, ValueError, TypeError):
+        # Match pandas' behaviour - both reject the chain; that's fine.
+        return
+
+    # Empty-result groupby is a known DataStore vs pandas divergence
+    # outside the scope of this dispatcher / SQL-correctness property
+    # test (pandas's empty groupby drops non-agg columns; DataStore's
+    # SQL path returns the input schema since GROUP BY runs over zero
+    # input rows). The verifiable bug surface this test guards is
+    # non-empty chains, so skip the empty cases rather than mask the
+    # column drift with looser assertions.
+    if (
+        isinstance(pd_result, pd.DataFrame)
+        and isinstance(ds_result, pd.DataFrame)
+        and len(pd_result) == 0
+        and len(ds_result) == 0
+    ):
+        return
+
+    # Sort-/head-stable comparisons are tricky with tie-breaking on
+    # integer cols; tolerate order differences via check_row_order=False
+    # whenever the chain doesn't end with a deterministic sort/head pair.
+    last_two = [s['op'] for s in chain[-2:]]
+    deterministic_tail = last_two and last_two[-1] in {'head', 'sort'} and (
+        last_two[-1] != 'head'
+        or (len(last_two) >= 2 and last_two[-2] == 'sort')
+    )
+    assert_datastore_equals_pandas(
+        ds_result,
+        pd_result,
+        check_index=True,
+        check_row_order=deterministic_tail,
+        check_nullable_dtype=False,
+    )

--- a/datastore/tests/test_property_based_chains.py
+++ b/datastore/tests/test_property_based_chains.py
@@ -245,16 +245,18 @@ def test_random_chain_matches_pandas(chain):
     # Empty-result groupby is a known DataStore vs pandas divergence
     # outside the scope of this dispatcher / SQL-correctness property
     # test (pandas's empty groupby drops non-agg columns; DataStore's
-    # SQL path returns the input schema since GROUP BY runs over zero
-    # input rows). The verifiable bug surface this test guards is
-    # non-empty chains, so skip the empty cases rather than mask the
-    # column drift with looser assertions.
-    if (
-        isinstance(pd_result, pd.DataFrame)
-        and isinstance(ds_result, pd.DataFrame)
-        and len(pd_result) == 0
-        and len(ds_result) == 0
-    ):
+    # SQL path returns the input schema since downstream segments
+    # short-circuit on the empty intermediate). Tracked verbatim in
+    # ``datastore/tests/journeys/test_property_chain_followups.py
+    # ::TestEmptyGroupbyColumnDrift``. ``len()`` works on both
+    # ``DataStore`` and ``pd.DataFrame``, so no isinstance dance needed.
+    def _is_empty(r):
+        try:
+            return len(r) == 0
+        except Exception:
+            return False
+
+    if _is_empty(pd_result) and _is_empty(ds_result):
         return
 
     # Sort-/head-stable comparisons are tricky with tie-breaking on

--- a/datastore/tests/test_sql_snapshot_assertions.py
+++ b/datastore/tests/test_sql_snapshot_assertions.py
@@ -1,0 +1,236 @@
+"""
+SQL snapshot tests: for each chain shape, assert that the SQL emitted by
+the planner+builder contains/excludes specific substrings.
+
+These tests are designed to catch "dispatcher failed silently but the
+SQL accidentally still ran" bugs that pure value-comparison tests miss.
+For example: if the planner declares ``plan.groupby_agg is not None``
+but the SQL does NOT contain ``GROUP BY``, that is a dispatch bug
+regardless of whether the result happened to be empty (so no value
+mismatch was detected).
+
+Snapshot strategy: don't snapshot the whole SQL string (that would
+break on any cosmetic change); only assert specific substrings that
+correspond to *structural* properties of the SQL.
+
+Add a new entry whenever a regression bug is fixed - the corresponding
+"must contain" / "must not contain" set is the simplest description of
+what the bug was.
+"""
+
+import os
+import tempfile
+
+import numpy as np
+import pandas as pd
+import pytest
+
+from datastore import DataStore
+from datastore.query_planner import QueryPlanner
+from datastore.sql_executor import SQLExecutionEngine
+
+
+@pytest.fixture(scope='module')
+def parquet_source():
+    """A persistent parquet file used by every test."""
+    rng = np.random.default_rng(2026)
+    n = 1000
+    df = pd.DataFrame(
+        {
+            'cat': rng.choice(['A', 'B', 'C', 'D'], n),
+            'sub': rng.choice(['x', 'y', 'z'], n),
+            'v': rng.integers(1, 200, n),
+            'w': rng.uniform(0, 100, n),
+        }
+    )
+    tmp = tempfile.mkdtemp()
+    path = os.path.join(tmp, 'src.parquet')
+    df.to_parquet(path)
+    yield path
+    import shutil
+
+    shutil.rmtree(tmp)
+
+
+def _build_sql(ds_chain) -> str:
+    """Run the planner+SQL builder and return the SQL string for the
+    first (single) SQL segment."""
+    planner = QueryPlanner()
+    exec_plan = planner.plan_segments(
+        ds_chain._lazy_ops, has_sql_source=True, schema=None
+    )
+    sql_segments = [s for s in exec_plan.segments if s.is_sql() and s.plan]
+    assert sql_segments, 'expected at least one SQL segment'
+    seg = sql_segments[0]
+    engine = SQLExecutionEngine(ds_chain)
+    return engine.build_sql_from_plan(seg.plan, schema={}).sql
+
+
+# ---------------------------------------------------------------------------
+# Shape table: (id, chain_builder, must_contain, must_not_contain)
+# Each chain_builder takes a DataStore and returns a chained DataStore.
+# ``must_contain`` is a list of substrings every generated SQL must include.
+# ``must_not_contain`` is a list of substrings the SQL must NOT include.
+# ---------------------------------------------------------------------------
+
+SHAPES = [
+    (
+        # The original Mark bug: GROUP BY must appear in inner subquery
+        # when the chain ends with a post-LIMIT WHERE on the agg column.
+        'mark_pattern_layer_n_groupby_kept',
+        lambda ds: (
+            ds[ds['cat'] == 'A']
+            .groupby('sub')
+            .agg({'v': 'sum'})
+            .sort_values('v', ascending=False)
+            .head(5)[lambda r: r['v'] > 0]
+        ),
+        ['GROUP BY', 'sum("v")', 'LIMIT 5', '__subq'],
+        [],
+    ),
+    (
+        'simple_groupby_emits_group_by',
+        lambda ds: ds.groupby('cat').agg({'v': 'sum'}),
+        ['GROUP BY', 'sum("v")'],
+        [],
+    ),
+    (
+        'filter_then_groupby_keeps_where_and_group_by',
+        lambda ds: ds[ds['v'] > 50].groupby('cat').agg({'v': 'sum'}),
+        ['WHERE', 'GROUP BY', '> 50'],
+        [],
+    ),
+    (
+        'no_groupby_pure_filter_does_not_emit_group_by',
+        lambda ds: ds[ds['v'] > 50],
+        ['WHERE', '> 50'],
+        ['GROUP BY'],
+    ),
+    (
+        'no_groupby_pure_sort_does_not_emit_group_by',
+        lambda ds: ds.sort_values('v', ascending=False).head(10),
+        ['ORDER BY', 'LIMIT 10'],
+        ['GROUP BY'],
+    ),
+    (
+        'limit_then_filter_creates_nested_subquery',
+        lambda ds: ds.head(50)[lambda r: r['v'] > 30],
+        ['LIMIT 50', '__subq', 'WHERE'],
+        ['GROUP BY'],
+    ),
+    (
+        'post_limit_filter_on_groupby_result_uses_temp_alias',
+        # post-LIMIT WHERE on the agg column ``v`` (which collides with
+        # source col ``v``) - SQL must use the ``__agg_v__`` temp alias
+        # in the outer WHERE.
+        lambda ds: (
+            ds[ds['v'] > 100]
+            .groupby('cat')
+            .agg({'v': 'sum'})
+            .sort_values('v', ascending=False)
+            .head(5)[lambda r: r['v'] > 1000]
+        ),
+        ['GROUP BY', '__agg_v__'],
+        [],
+    ),
+    (
+        'two_step_filter_keeps_both_where_clauses',
+        lambda ds: ds[ds['v'] > 50][ds['cat'] == 'A'],
+        ['"v" > 50', '"cat" = '],
+        [],
+    ),
+    (
+        'sort_then_head_keeps_order_by',
+        lambda ds: ds.sort_values('v').head(5),
+        ['ORDER BY "v"', 'LIMIT 5'],
+        [],
+    ),
+    (
+        'select_then_filter_only_selected_cols',
+        lambda ds: ds[['cat', 'v']][lambda r: r['v'] > 50],
+        ['WHERE', '"v" > 50'],
+        [],
+    ),
+    (
+        'multi_func_agg_emits_multiple_aggregates',
+        lambda ds: ds.groupby('cat').agg({'v': ['sum', 'mean']}),
+        ['sum("v")', 'avg("v")', 'GROUP BY'],
+        [],
+    ),
+    (
+        'single_column_agg_via_columnexpr',
+        lambda ds: ds.groupby('cat')['v'].agg(['count', 'mean']),
+        ['count', 'avg', 'GROUP BY'],
+        [],
+    ),
+    (
+        'limit_then_groupby_groupby_emitted',
+        # head(K) followed by groupby - GROUP BY should still emit;
+        # the previous nested SQL builder dropped this case.
+        lambda ds: ds.head(200).groupby('cat').agg({'v': 'sum'}),
+        ['GROUP BY', 'LIMIT 200', 'sum("v")'],
+        [],
+    ),
+    (
+        'filter_head_filter_groupby_layer_n_dispatch',
+        # GroupByAgg lands in a non-zero layer; the dispatcher must
+        # still emit GROUP BY in that wrapper.
+        lambda ds: (
+            ds[ds['v'] > 20]
+            .head(100)[lambda r: r['w'] > 30]
+            .groupby('cat')
+            .agg({'v': 'sum'})
+        ),
+        ['GROUP BY', 'sum("v")', '__subq'],
+        [],
+    ),
+    (
+        'filter_groupby_orderby_limit_no_post_filter',
+        # baseline: simple agg pipeline without nested wrapper layers
+        lambda ds: (
+            ds[ds['v'] > 30]
+            .groupby('cat')
+            .agg({'v': 'sum'})
+            .sort_values('v', ascending=False)
+            .head(3)
+        ),
+        ['GROUP BY', 'ORDER BY', 'LIMIT 3'],
+        ['__subq'],
+    ),
+    (
+        'pure_select_columns',
+        lambda ds: ds[['cat', 'v']],
+        ['SELECT', '"cat"', '"v"', 'FROM'],
+        ['GROUP BY', 'ORDER BY'],
+    ),
+    (
+        'distinct_pattern_keeps_distinct',
+        lambda ds: ds[['cat', 'sub']].drop_duplicates(),
+        ['DISTINCT'],
+        [],
+    ),
+]
+
+
+@pytest.mark.parametrize(
+    'shape_id,builder,must_contain,must_not_contain',
+    SHAPES,
+    ids=[s[0] for s in SHAPES],
+)
+def test_sql_structural_assertions(
+    shape_id, builder, must_contain, must_not_contain, parquet_source
+):
+    ds = DataStore.from_file(parquet_source)
+    ds_chain = builder(ds)
+    sql = _build_sql(ds_chain)
+
+    for needle in must_contain:
+        assert needle in sql, (
+            f'[{shape_id}] expected SQL to contain {needle!r}, '
+            f'got SQL:\n{sql}'
+        )
+    for needle in must_not_contain:
+        assert needle not in sql, (
+            f'[{shape_id}] expected SQL NOT to contain {needle!r}, '
+            f'got SQL:\n{sql}'
+        )

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -4,6 +4,7 @@
 # Testing
 pytest>=7.0.0
 pytest-cov>=4.0.0
+hypothesis>=6.0.0
 
 # Benchmarking
 duckdb>=1.3.0


### PR DESCRIPTION
## Summary

Stacked on top of #577. Fixes three SQL builder bugs the new user-path /
property-based test sweep uncovered, and flips the three `xfailed`
regression slots in `datastore/tests/journeys/` into permanent passing
guards.

### Bugs fixed

1. **`head(N).groupby().agg()` returns "first N groups" instead of
   "agg over first N rows"** (`query_planner._build_layers`).
   LIMIT was folded into the same SQL layer as GROUP BY. The planner
   now starts a new nested-subquery layer when `LazyGroupByAgg`
   follows LIMIT/OFFSET.

2. **`result[result['count'] > 0]` after `groupby().agg(...)` silently
   binds the WHERE to the source column of the same name**
   (`sql_executor._render_first_layer_sql`).
   The post-aggregation conditions were being appended to the
   pre-agg WHERE list "as a defensive fallback". They are now emitted
   as a real `HAVING` clause (composed with any existing
   `self.ds._having_condition`).

3. **`assign(x=...).groupby().agg(...)` on a Python() DataFrame source
   emits `SELECT *, expr AS x, agg(...) ... GROUP BY ...`** which
   ClickHouse rejects with `NOT_AN_AGGREGATE`
   (`sql_executor._build_sql_for_dataframe`, `_build_layer`).
   The single-layer DataFrame inline path was a parallel implementation
   that lacked the WHERE-by-position split, alias rewriting and
   `include_star=False` GROUP BY guard. Any plan containing
   `groupby_agg` / `where_ops` / multi-layer is now routed through the
   unified `_build_layered_sql`. `_build_layer` forces
   `include_star=False` whenever the layer has a `groupby_agg`.

### Supporting fixes in the unified pipeline

- `_build_layer`: append `col IS NOT NULL` for the `groupby_cols` when
  `dropna=True` (pandas default), so DataFrame source GROUP BY no
  longer leaks NULL groups - matches the legacy inline path.
- `_render_wrapper_layer_sql`: new `where_temp_alias_columns` parameter
  so the wrapper layer renames `__tmp_col__` back to user-visible
  names; postpone WHERE/ORDER BY/LIMIT/OFFSET to the outer rename
  layer so they bind to the masked values (LazyMask/LazyWhere
  semantic); suppress `ORDER BY _row_id` fallback when GROUP BY is
  present.
- Planner splits a pure-projection SELECT into a new layer when an
  in-layer WHERE references a column the projection would drop (e.g.
  `assign(x=...)[where x>0][['id']]`, as generated by ColumnExpr's
  per-column pruning).

### Test coverage added

- `datastore/tests/journeys/test_mark_slack_amazon_reviews.py`
  Verbatim mirror of the original Slack-reported pipeline (15 cases
  covering all 4 filter idioms x parquet/DataFrame sources, plus
  follow-on operations).
- `datastore/tests/journeys/test_agg_then_use_result.py`
  Cartesian `5 aggregations x 5 follow-ons` = 25 result-as-input
  user paths.
- `datastore/tests/journeys/test_kaggle_style_exploration.py`
  4 end-to-end Kaggle-style EDA chains (top products by region,
  customer order histogram, top active users, multi-stage revenue
  filter).
- `datastore/tests/test_cartesian_result_followups.py`
  Mechanically generated 8 builders x 6 follow-ups = 48 cases.
- `datastore/tests/test_naming_conflict_fuzz.py`
  17 alias-collision scenarios.
- `datastore/tests/test_sql_snapshot_assertions.py`
  17 structural SQL assertions (presence/absence of GROUP BY, WHERE,
  LIMIT, ORDER BY, `__subq` aliases).
- `datastore/tests/test_plan_invariants.py`
  44 plan-shape invariants over the layered pipeline.
- `datastore/tests/test_property_based_chains.py`
  Hypothesis-driven random op-chain fuzzer (filter / sort / head /
  select / agg). Now runs without skip filters for the two bugs that
  used to be tracked separately. Empty-result groupby cases (a
  pre-existing pandas-vs-DataStore column-set divergence) are
  explicitly short-circuited.
- `.cursor/rules/chdb-ds.mdc`: added "Multi-Step Mirror for Bug-Fix
  Tests" + "Property-Based Sweep for Compositional Bugs" sections.
- `requirements-dev.txt`: `hypothesis>=6.0.0`.

## Test plan

- [x] `pytest datastore/tests/` (excluding remote): **10473 passed,
  0 failed**, 17 skipped, 87 xfailed, 2 xpassed.
- [x] Hypothesis sweep with `max_examples=1000`: passes.
- [x] All 47 journey tests pass, including the 3 flipped xfails:
  - `test_head_before_agg_respects_limit`
  - `test_agg_output_name_shadows_source_column`
  - `test_top_three_revenue_dataframe_source_assign_before_groupby`
- [x] No new linter errors in the touched files.