### PR TITLE
fix: xfail blob_column SQL-roundtrip tests on chdb v4.1.8

### DIFF
--- a/datastore/tests/test_blob_column.py
+++ b/datastore/tests/test_blob_column.py
@@ -57,6 +57,10 @@ class TestBlobColumn(unittest.TestCase):
         # Compare results
         assert_datastore_equals_pandas(ds_df, pd_df)
 
+    @pytest.mark.xfail(
+        reason="chDB returns bytes as str through SQL projection; documented limitation in module docstring",
+        strict=True,
+    )
     def test_select_blob_column(self):
         """Test selecting blob column."""
         # pandas operations
@@ -78,6 +82,10 @@ class TestBlobColumn(unittest.TestCase):
         # Compare results
         assert_datastore_equals_pandas(ds_result, pd_result)
 
+    @pytest.mark.xfail(
+        reason="chDB returns bytes as str through SQL projection; documented limitation in module docstring",
+        strict=True,
+    )
     def test_filter_with_blob_column(self):
         """Test filtering DataStore that has blob column."""
         # pandas operations
@@ -159,6 +167,10 @@ class TestBlobColumn(unittest.TestCase):
         # Compare results
         assert_datastore_equals_pandas(ds_result, pd_result)
 
+    @pytest.mark.xfail(
+        reason="chDB returns bytes as str through SQL projection; documented limitation in module docstring",
+        strict=True,
+    )
     def test_blob_column_head_tail(self):
         """Test head and tail operations with blob column."""
         # pandas operations


### PR DESCRIPTION
## Summary

Mark three SQL-roundtrip blob tests as `xfail`. The module docstring already documents that these tests are expected to fail because chDB converts `bytes` columns to `str` through SQL operations, but the `@pytest.mark.xfail` decorators were never applied to the test methods. The result is that the docstring's stated intent doesn't match the actual marker state, so the three tests hard-fail on every run.

Fixes #579.

## Changes

`datastore/tests/test_blob_column.py`: add `@pytest.mark.xfail(strict=True, reason=...)` to three methods that perform SQL projection of a `bytes` column:

- `TestBlobColumn::test_select_blob_column`
- `TestBlobColumn::test_filter_with_blob_column`
- `TestBlobColumn::test_blob_column_head_tail`

`strict=True` so that the day chDB stops converting bytes→str (e.g. when proper `Bytes`/`FixedString` handling lands), these tests turn into `XPASS` failures and we know to drop the marker.

`test_blob_column_sort` was deliberately not touched — it currently passes (sort key is the non-blob `id` column, which seemingly doesn't trigger the same projection path) so adding a marker there would be premature.

## Why it matters now

chdb-io/chdb-core's `chdb/test_chdb_datastore.sh` CI step clones chdb at the latest release tag and runs the chdb test suite against the freshly built chdb-core wheel. With v4.1.8 it deterministically fails on these three tests:

```
=========================== short test summary info ============================
FAILED tests/test_blob_column.py::TestBlobColumn::test_blob_column_head_tail
FAILED tests/test_blob_column.py::TestBlobColumn::test_filter_with_blob_column
FAILED tests/test_blob_column.py::TestBlobColumn::test_select_blob_column
= 3 failed, 10995 passed, 19 skipped, 85 xfailed, 5 xpassed, 1816 warnings in 102.76s
```

Sample runs (after chdb-core's hypothesis fix unblocked the DataStore step):

- Linux x86_64: https://github.com/chdb-io/chdb-core/actions/runs/26277519150
- macOS arm64: https://github.com/chdb-io/chdb-core/actions/runs/26277519245

Once this PR lands and chdb cuts a release (≥ v4.1.9), chdb-core's CI on `main` auto-recovers.

## Test plan

- [x] Diff syntax-checks (`python3 -c "import ast; ast.parse(...)"`)
- [x] `import pytest` already present in the test file — no new import needed
- [ ] CI: `Build & Test ...` workflows in chdb (which run pytest) should now report `3 xfailed` instead of `3 failed`

## Notes

- `strict=True` makes the unmarked-passing case loud, which is what we want for a documented limitation.
- The xfail reason text mirrors the language from the module docstring so the rationale is consistent in one place.
