### PR TITLE
feat(datastore): mirror pandas iteration on LazyGroupBy / SeriesGroupBy

### DIFF
--- a/datastore/column_expr.py
+++ b/datastore/column_expr.py
@@ -3258,8 +3258,59 @@ class ColumnExpr:
         return len(self._execute())
 
     def __iter__(self):
-        """Iterate over executed values."""
+        """Iterate over values - SeriesGroupBy semantics when grouped, Series otherwise.
+
+        Mirrors :py:meth:`pandas.core.groupby.SeriesGroupBy.__iter__` when this
+        ColumnExpr is the direct result of ``ds.groupby(...)[col]`` (Expression
+        mode with a simple ``Field``): iteration yields ``(group_key, sub_series)``
+        pairs.
+
+        For all other forms - plain column expressions, computed expressions
+        like ``ds['a'] + ds['b']``, and crucially **aggregated results** like
+        ``ds.groupby('g')['v'].sum() * 2`` (which propagate ``_groupby_fields``
+        downstream but are no longer a SeriesGroupBy) - iteration falls back to
+        iterating over the values of the executed Series.
+
+        Example:
+            >>> # SeriesGroupBy form: yields (key, Series) per group
+            >>> for key, sub in ds.groupby('cat')['v']:
+            ...     print(key, sub.tolist())
+            ...
+            >>> # Plain column form: yields scalar values
+            >>> for v in ds['v']:
+            ...     print(v)
+            ...
+            >>> # Aggregated form: still yields scalar values (after agg+arith)
+            >>> for v in ds.groupby('cat')['v'].sum() * 2:
+            ...     print(v)
+        """
+        # Only a "pure" ds.groupby(...)[col] ColumnExpr is a SeriesGroupBy.
+        # Aggregation/method/op modes propagate _groupby_fields via _source for
+        # downstream pushdown bookkeeping, but their iter must keep yielding
+        # scalar values to match pandas Series semantics.
+        if self._groupby_fields and isinstance(self._expr, Field):
+            return self._iter_groupby_series()
         return iter(self._execute())
+
+    def _iter_groupby_series(self):
+        """Yield ``(key, sub_Series)`` pairs - SeriesGroupBy iteration via pandas.
+
+        Caller must have already verified ``isinstance(self._expr, Field)`` and
+        ``self._groupby_fields``.
+        """
+        df = self._datastore._get_df()
+        groupby_cols = [
+            gf.name if isinstance(gf, Field) else str(gf)
+            for gf in self._groupby_fields
+        ]
+        # Match LazyGroupBy._pandas_groupby() convention: single column -> scalar by,
+        # multi-column -> list, so scalar/tuple key semantics align between
+        # ``for k, g in gb:`` and ``for k, s in gb['col']:``.
+        by = groupby_cols[0] if len(groupby_cols) == 1 else groupby_cols
+        series_gb = df.groupby(
+            by, sort=self._groupby_sort, dropna=self._groupby_dropna
+        )[self._expr.name]
+        return iter(series_gb)
 
     def __getitem__(self, key):
         """

--- a/datastore/column_expr.py
+++ b/datastore/column_expr.py
@@ -3285,10 +3285,18 @@ class ColumnExpr:
             ...     print(v)
         """
         # Only a "pure" ds.groupby(...)[col] ColumnExpr is a SeriesGroupBy.
-        # Aggregation/method/op modes propagate _groupby_fields via _source for
-        # downstream pushdown bookkeeping, but their iter must keep yielding
-        # scalar values to match pandas Series semantics.
-        if self._groupby_fields and isinstance(self._expr, Field):
+        # Other modes propagate _groupby_fields for downstream pushdown
+        # bookkeeping (some, like ``transform``, even re-copy ``_expr=Field``
+        # onto an op-mode result), but their iter must keep yielding scalar
+        # values to match pandas Series semantics. So we require that NONE of
+        # the derived-mode entry fields are set.
+        if (
+            self._groupby_fields
+            and isinstance(self._expr, Field)
+            and self._source is None
+            and self._op_type is None
+            and self._agg_func_name is None
+        ):
             return self._iter_groupby_series()
         return iter(self._execute())
 

--- a/datastore/groupby.py
+++ b/datastore/groupby.py
@@ -99,17 +99,130 @@ class LazyGroupBy:
             >>> df.groupby('category').ngroups
             3
         """
-        # Get groupby column names
-        groupby_cols = []
+        return self._pandas_groupby().ngroups
+
+    def _groupby_col_names(self) -> List[str]:
+        """Resolve groupby Expression list to plain column-name strings."""
+        cols: List[str] = []
         for gf in self._groupby_fields:
             if isinstance(gf, Field):
-                groupby_cols.append(gf.name)
+                cols.append(gf.name)
             else:
-                groupby_cols.append(str(gf))
+                cols.append(str(gf))
+        return cols
 
-        # Execute the underlying datastore and get unique count
+    def _pandas_groupby(self):
+        """Materialize underlying DataStore and return a pandas GroupBy object.
+
+        Shared helper used by iteration, get_group(), groups, indices, ngroups,
+        len(), and ``in``. Respects ``sort``, ``dropna``, and ``selected_columns``
+        so behaviour matches pandas DataFrameGroupBy exactly.
+
+        Note: this triggers execution of the underlying DataStore. Each call
+        re-executes; callers in tight loops should hoist the result.
+        """
+        groupby_cols = self._groupby_col_names()
         df = self._datastore._get_df()
-        return df.groupby(groupby_cols, sort=self._sort, dropna=self._dropna).ngroups
+        # When grouping by a single column, pass the column name as a scalar to
+        # pandas (not a one-element list). This makes pandas yield scalar group
+        # keys (e.g. ``'A'``) instead of one-tuple keys (e.g. ``('A',)``),
+        # matching the dominant pandas convention ``df.groupby('col')`` and
+        # what users hit when chaining ``ds.groupby('col')`` from DataStore.
+        by = groupby_cols[0] if len(groupby_cols) == 1 else groupby_cols
+        pandas_gb = df.groupby(by, sort=self._sort, dropna=self._dropna)
+        if self._selected_columns is not None:
+            # Mirrors df.groupby(...)[ [cols] ] semantics: yielded sub-DataFrames
+            # only contain the selected columns, not the groupby key columns.
+            return pandas_gb[self._selected_columns]
+        return pandas_gb
+
+    def __iter__(self):
+        """Iterate over ``(group_key, sub_DataFrame)`` pairs - pandas semantics.
+
+        Mirrors :py:meth:`pandas.core.groupby.DataFrameGroupBy.__iter__`:
+
+        - Single-column groupby: yields ``(key, sub_df)`` where ``key`` is a scalar.
+        - Multi-column groupby:  yields ``((k1, k2, ...), sub_df)`` where the key
+          is a tuple of values matching the groupby columns.
+        - ``sub_df`` is a real ``pd.DataFrame`` containing the rows for that
+          group, preserving the original index of the source DataFrame.
+        - If ``selected_columns`` was set via ``gb[['c1', 'c2']]``, the yielded
+          sub-DataFrames only contain those columns.
+
+        Example:
+            >>> for (date, code), group in ds.groupby(['date', 'code']):
+            ...     print(date, code, len(group))
+        """
+        return iter(self._pandas_groupby())
+
+    def __len__(self) -> int:
+        """Return number of groups (matches pandas: ``len(gb) == gb.ngroups``)."""
+        return self.ngroups
+
+    def __contains__(self, key) -> bool:
+        """Return whether ``key`` is one of the group labels.
+
+        Matches pandas ``key in gb`` semantics: for multi-column groupby the
+        key should be a tuple of values matching the groupby columns.
+        """
+        return key in self._pandas_groupby().groups
+
+    @property
+    def groups(self) -> dict:
+        """Mapping from group label to the index labels in that group.
+
+        Mirrors :py:attr:`pandas.core.groupby.DataFrameGroupBy.groups`:
+        returns ``dict`` of ``{group_key: Index(...)}`` where each value is the
+        labels (not positions) of the rows in that group, using the original
+        DataFrame's index.
+
+        Example:
+            >>> ds.groupby('category').groups
+            {'A': Index([0, 2, 4]), 'B': Index([1, 3, 5])}
+        """
+        return self._pandas_groupby().groups
+
+    @property
+    def indices(self) -> dict:
+        """Mapping from group label to the positional locations in that group.
+
+        Mirrors :py:attr:`pandas.core.groupby.DataFrameGroupBy.indices`:
+        returns ``dict`` of ``{group_key: np.ndarray(positions)}`` where each
+        value gives integer row positions (0-based, after any reset) of the
+        rows in that group.
+
+        Example:
+            >>> ds.groupby('category').indices
+            {'A': array([0, 2, 4]), 'B': array([1, 3, 5])}
+        """
+        return self._pandas_groupby().indices
+
+    def get_group(self, name, obj=None) -> pd.DataFrame:
+        """Return the rows in the ``name`` group as a DataFrame.
+
+        Mirrors :py:meth:`pandas.core.groupby.DataFrameGroupBy.get_group`.
+
+        Args:
+            name: Group key. For single-column groupby this is a scalar matching
+                  the groupby column's value. For multi-column groupby it must
+                  be a tuple of values matching the groupby columns in order.
+            obj: Retained for pandas API compatibility (deprecated/removed in
+                 recent pandas versions); ignored here.
+
+        Returns:
+            pd.DataFrame: Sub-DataFrame for the requested group, preserving the
+            original index. If ``selected_columns`` was set via
+            ``gb[['c1', 'c2']]``, only those columns are included.
+
+        Raises:
+            KeyError: If ``name`` is not a valid group label.
+
+        Example:
+            >>> ds.groupby('category').get_group('A')
+            >>> ds.groupby(['date', 'code']).get_group(('2026-05-23', '000001'))
+        """
+        del obj  # unused, accepted for pandas API parity
+        return self._pandas_groupby().get_group(name)
 
     def __getitem__(self, key: Union[str, List[str]]) -> 'ColumnExpr':
         """
@@ -152,7 +265,16 @@ class LazyGroupBy:
             )
 
         else:
-            raise TypeError(f"Expected str or list, got {type(key).__name__}")
+            if isinstance(key, int):
+                raise TypeError(
+                    f"LazyGroupBy does not support integer indexing (got {key!r}). "
+                    "Use ``for key, group in groupby:`` to iterate over groups, "
+                    "or ``groupby.get_group(key)`` to access a specific group."
+                )
+            raise TypeError(
+                "LazyGroupBy column selection expects a str or list of str, "
+                f"got {type(key).__name__}"
+            )
 
     def __getattr__(self, name: str):
         """

--- a/datastore/tests/test_groupby_iteration.py
+++ b/datastore/tests/test_groupby_iteration.py
@@ -619,23 +619,13 @@ class TestSeriesGroupByIteration(unittest.TestCase):
 
         self.assertEqual(list(ds['v']), [10, 20, 30])
 
-    def test_series_groupby_iter_respects_dropna(self):
-        pdf = pd.DataFrame(
-            {'cat': ['A', None, 'B', np.nan], 'v': [1, 2, 3, 4]}
-        )
-        ds = DataStore(pdf.copy())
-
-        pd_items = list(pdf.groupby('cat', dropna=False)['v'])
-        ds_items = list(ds.groupby('cat', dropna=False)['v'])
-
-        self.assertEqual(len(ds_items), len(pd_items))
-        for (pk, ps), (dk, ds_s) in zip(pd_items, ds_items):
-            # NaN keys aren't equal even to themselves, so compare via isna
-            if pd.isna(pk):
-                self.assertTrue(pd.isna(dk))
-            else:
-                self.assertEqual(dk, pk)
-            self.assertEqual(ds_s.tolist(), ps.tolist())
+    # NB: ``dropna`` behaviour for ``gb[col]`` iteration is intentionally not
+    # tested directly - both DataFrameGroupBy and SeriesGroupBy share the
+    # same ``_pandas_groupby()`` helper, so the dropna semantics is already
+    # covered by ``test_iter_dropna_false_includes_na_group`` above. A
+    # standalone SeriesGroupBy variant additionally trips a pandas 2.x
+    # internal bug (``ValueError: Categorical categories cannot be null``
+    # via ``__length_hint__ -> __len__ -> .groups``) that is fixed in 3.x.
 
     def test_iter_after_aggregation_yields_scalar_values_not_subseries(self):
         """Aggregated ColumnExprs propagate _groupby_fields downstream (for

--- a/datastore/tests/test_groupby_iteration.py
+++ b/datastore/tests/test_groupby_iteration.py
@@ -30,6 +30,21 @@ import pandas as pd
 from datastore import DataStore
 
 
+# pandas 2.x has version-specific behaviour around NaN groupby keys that
+# DataStore inherits because ``LazyGroupBy`` materializes through a real
+# pandas ``DataFrameGroupBy`` (see ``LazyGroupBy._pandas_groupby``). These
+# tests verify the chdb-ds side is correct on pandas 3.x where the NaN
+# semantics are well-defined; on pandas 2.x they would assert pandas's own
+# bugs (e.g. ``Categorical categories cannot be null`` from
+# ``groupby(NaN-col, dropna=False).groups``) rather than chdb-ds behaviour.
+_PANDAS_MAJOR = int(pd.__version__.split('.', 1)[0])
+_NAN_KEY_REQUIRES_PANDAS_3 = unittest.skipIf(
+    _PANDAS_MAJOR < 3,
+    "pandas 2.x has version-specific bugs with NaN groupby keys; "
+    "DataStore mirrors whatever pandas does. Coverage runs on pandas 3.x.",
+)
+
+
 class TestGroupByIterationSingleColumn(unittest.TestCase):
     """``for key, group in ds.groupby(col):`` mirrors pandas exactly."""
 
@@ -515,20 +530,56 @@ class TestGroupByPandasCompatibilityEdges(unittest.TestCase):
 
         pd.testing.assert_frame_equal(ds_group, pd_group)
 
-    # ----- dropna=False + NaN as lookup key -----
+    # ----- dropna=False + NaN as lookup key (pandas 3.x only) -----
 
-    # NB: NaN-key behaviour with ``dropna=False`` is intentionally only
-    # covered via iteration (see ``test_iter_dropna_false_includes_na_group``)
-    # because both pandas-side APIs diverge across supported versions:
-    # - ``get_group(np.nan)``: pandas 2.x raises KeyError, pandas 3.x works
-    # - ``.groups`` on a column with None/NaN: pandas 2.x raises
-    #   ``ValueError: Categorical categories cannot be null`` (fixed in 3.x)
+    @_NAN_KEY_REQUIRES_PANDAS_3
+    def test_get_group_with_nan_key_when_dropna_false(self):
+        pdf = pd.DataFrame(
+            {'cat': ['A', None, 'B', np.nan], 'v': [1, 2, 3, 4]}
+        )
+        ds = DataStore(pdf.copy())
 
-    # NB: ``get_group(('x', np.nan))`` for multi-column dropna=False groupby
-    # is intentionally not tested - pandas 2.x raises KeyError on NaN-bearing
-    # tuple keys (NaN != NaN in hash lookup) while pandas 3.x supports it,
-    # so any single assertion would diverge between supported pandas versions.
-    # Single-column NaN-key behaviour is covered by the two tests above.
+        pd_group = pdf.groupby('cat', dropna=False).get_group(np.nan)
+        ds_group = ds.groupby('cat', dropna=False).get_group(np.nan)
+
+        pd.testing.assert_frame_equal(ds_group, pd_group)
+
+    @_NAN_KEY_REQUIRES_PANDAS_3
+    def test_groups_includes_nan_key_when_dropna_false(self):
+        pdf = pd.DataFrame(
+            {'cat': ['A', None, 'B', np.nan], 'v': [1, 2, 3, 4]}
+        )
+        ds = DataStore(pdf.copy())
+
+        pd_groups = pdf.groupby('cat', dropna=False).groups
+        ds_groups = ds.groupby('cat', dropna=False).groups
+
+        self.assertEqual(len(ds_groups), len(pd_groups))
+        pd_nan_keys = [k for k in pd_groups if pd.isna(k)]
+        ds_nan_keys = [k for k in ds_groups if pd.isna(k)]
+        self.assertEqual(len(pd_nan_keys), 1)
+        self.assertEqual(len(ds_nan_keys), 1)
+        self.assertEqual(
+            list(ds_groups[ds_nan_keys[0]]),
+            list(pd_groups[pd_nan_keys[0]]),
+        )
+
+    @_NAN_KEY_REQUIRES_PANDAS_3
+    def test_get_group_multi_column_tuple_with_nan_when_dropna_false(self):
+        pdf = pd.DataFrame(
+            {
+                'a': ['x', 'x', 'y'],
+                'b': [1, np.nan, 1],
+                'v': [10, 20, 30],
+            }
+        )
+        ds = DataStore(pdf.copy())
+
+        target = ('x', np.nan)
+        pd_group = pdf.groupby(['a', 'b'], dropna=False).get_group(target)
+        ds_group = ds.groupby(['a', 'b'], dropna=False).get_group(target)
+
+        pd.testing.assert_frame_equal(ds_group, pd_group)
 
     # ----- degenerate inputs: empty / single-row / all-same -----
 
@@ -619,13 +670,23 @@ class TestSeriesGroupByIteration(unittest.TestCase):
 
         self.assertEqual(list(ds['v']), [10, 20, 30])
 
-    # NB: ``dropna`` behaviour for ``gb[col]`` iteration is intentionally not
-    # tested directly - both DataFrameGroupBy and SeriesGroupBy share the
-    # same ``_pandas_groupby()`` helper, so the dropna semantics is already
-    # covered by ``test_iter_dropna_false_includes_na_group`` above. A
-    # standalone SeriesGroupBy variant additionally trips a pandas 2.x
-    # internal bug (``ValueError: Categorical categories cannot be null``
-    # via ``__length_hint__ -> __len__ -> .groups``) that is fixed in 3.x.
+    @_NAN_KEY_REQUIRES_PANDAS_3
+    def test_series_groupby_iter_respects_dropna(self):
+        pdf = pd.DataFrame(
+            {'cat': ['A', None, 'B', np.nan], 'v': [1, 2, 3, 4]}
+        )
+        ds = DataStore(pdf.copy())
+
+        pd_items = list(pdf.groupby('cat', dropna=False)['v'])
+        ds_items = list(ds.groupby('cat', dropna=False)['v'])
+
+        self.assertEqual(len(ds_items), len(pd_items))
+        for (pk, ps), (dk, ds_s) in zip(pd_items, ds_items):
+            if pd.isna(pk):
+                self.assertTrue(pd.isna(dk))
+            else:
+                self.assertEqual(dk, pk)
+            self.assertEqual(ds_s.tolist(), ps.tolist())
 
     def test_iter_after_aggregation_yields_scalar_values_not_subseries(self):
         """Aggregated ColumnExprs propagate _groupby_fields downstream (for

--- a/datastore/tests/test_groupby_iteration.py
+++ b/datastore/tests/test_groupby_iteration.py
@@ -686,6 +686,27 @@ class TestSeriesGroupByIteration(unittest.TestCase):
 
         self.assertEqual(list(ds_result), list(pd_result))
 
+    def test_iter_after_groupby_transform_yields_scalar_values(self):
+        """``gb['col'].transform(...)`` returns an op-mode ColumnExpr that
+        manually re-copies ``_expr=Field`` and ``_groupby_fields`` from its
+        source. The judgement that selects SeriesGroupBy iteration must look
+        at the derived-mode entry fields (``_source``, ``_op_type``,
+        ``_agg_func_name``) and skip SeriesGroupBy iteration here.
+
+        Regression for the CI failure of ``test_groupby_transform`` -
+        previously this fell into the SeriesGroupBy branch and yielded
+        ``[('bar', Series), ('foo', Series)]`` instead of transform values.
+        """
+        pdf = pd.DataFrame(
+            {'A': ['foo', 'foo', 'bar', 'bar'], 'B': [1, 2, 3, 4]}
+        )
+        ds = DataStore(pdf.copy())
+
+        pd_transform = pdf.groupby('A')['B'].transform('sum')
+        ds_transform = ds.groupby('A')['B'].transform('sum')
+
+        self.assertEqual(list(ds_transform), pd_transform.tolist())
+
 
 class TestGroupByGetItemErrorPaths(unittest.TestCase):
     """``gb[<illegal>]`` raises TypeError with a clear, type-specific message.

--- a/datastore/tests/test_groupby_iteration.py
+++ b/datastore/tests/test_groupby_iteration.py
@@ -517,16 +517,11 @@ class TestGroupByPandasCompatibilityEdges(unittest.TestCase):
 
     # ----- dropna=False + NaN as lookup key -----
 
-    def test_get_group_with_nan_key_when_dropna_false(self):
-        pdf = pd.DataFrame(
-            {'cat': ['A', None, 'B', np.nan], 'v': [1, 2, 3, 4]}
-        )
-        ds = DataStore(pdf.copy())
-
-        pd_group = pdf.groupby('cat', dropna=False).get_group(np.nan)
-        ds_group = ds.groupby('cat', dropna=False).get_group(np.nan)
-
-        pd.testing.assert_frame_equal(ds_group, pd_group)
+    # NB: ``get_group(np.nan)`` is intentionally not tested - pandas 2.x
+    # raises KeyError on NaN lookup (NaN != NaN in hash table) while
+    # pandas 3.x supports it, so any single assertion would diverge between
+    # supported pandas versions. NaN-group presence is still covered via
+    # ``.groups`` and ``iter`` (both version-stable APIs).
 
     def test_groups_includes_nan_key_when_dropna_false(self):
         pdf = pd.DataFrame(

--- a/datastore/tests/test_groupby_iteration.py
+++ b/datastore/tests/test_groupby_iteration.py
@@ -1,0 +1,738 @@
+"""
+Tests for pandas-style iteration over LazyGroupBy.
+
+These tests verify that ``LazyGroupBy`` mirrors the iteration / lookup parts
+of the pandas ``DataFrameGroupBy`` API:
+
+- ``for key, group in gb:``                - iteration over (key, sub_df) pairs
+- ``gb.get_group(key)``                    - direct access to one group
+- ``gb.groups``                            - label-based index of each group
+- ``gb.indices``                           - positional index of each group
+- ``len(gb)`` / ``key in gb``              - count & membership
+
+Each test follows the Mirror Code Pattern (CLAUDE.md): the pandas and
+DataStore expressions are written verbatim side-by-side so a reader can spot
+divergences instantly.
+
+Regression motivation: a user reported that
+``for (date, code), group in ds.groupby(['date', 'code']):`` raised
+``TypeError: Expected str or list, got int``. The root cause was that
+``LazyGroupBy`` had no ``__iter__``, so Python's iter protocol fell back to
+``__getitem__(0)`` which rejected ``int``. The misleading error message
+disguised a missing-feature problem as a wrong-arg-type problem.
+"""
+
+import unittest
+
+import numpy as np
+import pandas as pd
+
+from datastore import DataStore
+
+
+class TestGroupByIterationSingleColumn(unittest.TestCase):
+    """``for key, group in ds.groupby(col):`` mirrors pandas exactly."""
+
+    def setUp(self):
+        self.pdf = pd.DataFrame(
+            {
+                'category': ['A', 'B', 'A', 'B', 'A', 'C'],
+                'value': [10, 20, 30, 40, 50, 60],
+                'score': [1.0, 2.0, 3.0, 4.0, 5.0, 6.0],
+            }
+        )
+        self.ds = DataStore(self.pdf.copy())
+
+    def test_iter_yields_scalar_key_and_sub_dataframe(self):
+        pd_groupby = self.pdf.groupby('category')
+        ds_groupby = self.ds.groupby('category')
+
+        pd_items = list(pd_groupby)
+        ds_items = list(ds_groupby)
+
+        self.assertEqual(len(ds_items), len(pd_items))
+
+        for (pd_key, pd_group), (ds_key, ds_group) in zip(pd_items, ds_items):
+            self.assertEqual(ds_key, pd_key)
+            self.assertIsInstance(ds_group, pd.DataFrame)
+            pd.testing.assert_frame_equal(ds_group, pd_group)
+
+    def test_iter_preserves_source_index_within_each_group(self):
+        custom_index = [100, 200, 300, 400, 500, 600]
+        pdf = self.pdf.copy()
+        pdf.index = custom_index
+        ds = DataStore(pdf.copy())
+
+        pd_items = list(pdf.groupby('category'))
+        ds_items = list(ds.groupby('category'))
+
+        for (pd_key, pd_group), (ds_key, ds_group) in zip(pd_items, ds_items):
+            self.assertEqual(ds_key, pd_key)
+            self.assertEqual(list(ds_group.index), list(pd_group.index))
+            pd.testing.assert_frame_equal(ds_group, pd_group)
+
+    def test_iter_total_rows_equal_source(self):
+        ds_total = sum(len(g) for _, g in self.ds.groupby('category'))
+        self.assertEqual(ds_total, len(self.pdf))
+
+    def test_iter_sort_false_uses_first_occurrence_order(self):
+        pd_keys = [k for k, _ in self.pdf.groupby('category', sort=False)]
+        ds_keys = [k for k, _ in self.ds.groupby('category', sort=False)]
+
+        self.assertEqual(ds_keys, pd_keys)
+        self.assertEqual(ds_keys, ['A', 'B', 'C'])
+
+    def test_iter_sort_true_default_uses_sorted_key_order(self):
+        pd_keys = [k for k, _ in self.pdf.groupby('category')]
+        ds_keys = [k for k, _ in self.ds.groupby('category')]
+
+        self.assertEqual(ds_keys, sorted(pd_keys))
+        self.assertEqual(ds_keys, ['A', 'B', 'C'])
+
+
+class TestGroupByIterationMultiColumn(unittest.TestCase):
+    """Verbatim mirror of the user-reported case (`for (date, code), group in ...`)."""
+
+    def setUp(self):
+        self.pdf = pd.DataFrame(
+            {
+                'date': [
+                    '2026-05-22',
+                    '2026-05-22',
+                    '2026-05-23',
+                    '2026-05-23',
+                    '2026-05-23',
+                ],
+                'code': ['000001', '000002', '000001', '000001', '000002'],
+                'price': [10.0, 20.0, 10.5, 11.0, 21.0],
+                'volume': [100, 200, 150, 400, 250],
+            }
+        )
+        self.ds = DataStore(self.pdf.copy())
+
+    def test_iter_yields_tuple_key_and_sub_dataframe(self):
+        pd_items = list(self.pdf.groupby(['date', 'code']))
+        ds_items = list(self.ds.groupby(['date', 'code']))
+
+        self.assertEqual(len(ds_items), len(pd_items))
+
+        for (pd_key, pd_group), (ds_key, ds_group) in zip(pd_items, ds_items):
+            self.assertIsInstance(ds_key, tuple)
+            self.assertEqual(len(ds_key), 2)
+            self.assertEqual(ds_key, pd_key)
+            self.assertIsInstance(ds_group, pd.DataFrame)
+            pd.testing.assert_frame_equal(ds_group, pd_group)
+
+    def test_iter_unpacking_matches_user_screenshot_pattern(self):
+        """Exact mirror of `for (date, code), group in ds.groupby(['date', 'code']):`."""
+        pd_groupby = self.pdf.groupby(['date', 'code'])
+        ds_groupby = self.ds.groupby(['date', 'code'])
+
+        pd_collected = []
+        for (date, code), group in pd_groupby:
+            pd_collected.append((date, code, len(group), list(group['price'])))
+
+        ds_collected = []
+        for (date, code), group in ds_groupby:
+            ds_collected.append((date, code, len(group), list(group['price'])))
+
+        self.assertEqual(ds_collected, pd_collected)
+
+    def test_iter_does_not_drop_or_duplicate_rows(self):
+        ds_concat = pd.concat(
+            [g for _, g in self.ds.groupby(['date', 'code'])], axis=0
+        )
+        ds_concat_sorted = ds_concat.sort_index()
+        pd.testing.assert_frame_equal(ds_concat_sorted, self.pdf)
+
+
+class TestGroupByIterationDropna(unittest.TestCase):
+    """``dropna`` parameter is honoured by iteration just like pandas."""
+
+    def setUp(self):
+        self.pdf = pd.DataFrame(
+            {
+                'category': ['A', 'B', None, 'A', np.nan, 'B'],
+                'value': [10, 20, 30, 40, 50, 60],
+            }
+        )
+        self.ds = DataStore(self.pdf.copy())
+
+    def test_iter_dropna_true_default_excludes_na_group(self):
+        pd_keys = [k for k, _ in self.pdf.groupby('category')]
+        ds_keys = [k for k, _ in self.ds.groupby('category')]
+
+        self.assertEqual(ds_keys, pd_keys)
+        self.assertNotIn(np.nan, ds_keys)
+        self.assertNotIn(None, ds_keys)
+
+    def test_iter_dropna_false_includes_na_group(self):
+        pd_keys = [k for k, _ in self.pdf.groupby('category', dropna=False)]
+        ds_keys = [k for k, _ in self.ds.groupby('category', dropna=False)]
+
+        self.assertEqual(len(ds_keys), len(pd_keys))
+        ds_has_na = any(pd.isna(k) for k in ds_keys)
+        pd_has_na = any(pd.isna(k) for k in pd_keys)
+        self.assertTrue(ds_has_na)
+        self.assertEqual(ds_has_na, pd_has_na)
+
+
+class TestGroupByIterationWithColumnSelection(unittest.TestCase):
+    """``gb[['c1','c2']]`` then iterate yields sub-DataFrames with only those columns."""
+
+    def setUp(self):
+        self.pdf = pd.DataFrame(
+            {
+                'category': ['A', 'B', 'A', 'B'],
+                'v1': [1, 2, 3, 4],
+                'v2': [10.0, 20.0, 30.0, 40.0],
+                'v3': ['x', 'y', 'z', 'w'],
+            }
+        )
+        self.ds = DataStore(self.pdf.copy())
+
+    def test_iter_after_multi_column_selection_restricts_columns(self):
+        pd_items = list(self.pdf.groupby('category')[['v1', 'v2']])
+        ds_items = list(self.ds.groupby('category')[['v1', 'v2']])
+
+        self.assertEqual(len(ds_items), len(pd_items))
+
+        for (pd_key, pd_group), (ds_key, ds_group) in zip(pd_items, ds_items):
+            self.assertEqual(ds_key, pd_key)
+            self.assertEqual(list(ds_group.columns), ['v1', 'v2'])
+            pd.testing.assert_frame_equal(ds_group, pd_group)
+
+
+class TestGroupByGetGroup(unittest.TestCase):
+    """``gb.get_group(key)`` mirrors pandas exactly."""
+
+    def setUp(self):
+        self.pdf = pd.DataFrame(
+            {
+                'date': ['2026-05-22', '2026-05-22', '2026-05-23', '2026-05-23'],
+                'code': ['000001', '000002', '000001', '000001'],
+                'price': [10.0, 20.0, 10.5, 11.0],
+                'volume': [100, 200, 150, 400],
+            }
+        )
+        self.ds = DataStore(self.pdf.copy())
+
+    def test_get_group_single_column_returns_subframe(self):
+        pdf = pd.DataFrame(
+            {
+                'category': ['A', 'B', 'A', 'B', 'A'],
+                'value': [1, 2, 3, 4, 5],
+            }
+        )
+        ds = DataStore(pdf.copy())
+
+        pd_group = pdf.groupby('category').get_group('A')
+        ds_group = ds.groupby('category').get_group('A')
+
+        self.assertIsInstance(ds_group, pd.DataFrame)
+        pd.testing.assert_frame_equal(ds_group, pd_group)
+
+    def test_get_group_multi_column_tuple_key(self):
+        pd_group = self.pdf.groupby(['date', 'code']).get_group(
+            ('2026-05-23', '000001')
+        )
+        ds_group = self.ds.groupby(['date', 'code']).get_group(
+            ('2026-05-23', '000001')
+        )
+
+        self.assertEqual(len(ds_group), 2)
+        pd.testing.assert_frame_equal(ds_group, pd_group)
+
+    def test_get_group_with_column_selection_restricts_columns(self):
+        pd_group = self.pdf.groupby('date')[['code', 'price']].get_group(
+            '2026-05-23'
+        )
+        ds_group = self.ds.groupby('date')[['code', 'price']].get_group(
+            '2026-05-23'
+        )
+
+        self.assertEqual(list(ds_group.columns), ['code', 'price'])
+        pd.testing.assert_frame_equal(ds_group, pd_group)
+
+    def test_get_group_missing_key_raises_keyerror(self):
+        with self.assertRaises(KeyError):
+            self.ds.groupby('date').get_group('1999-01-01')
+
+    def test_get_group_accepts_legacy_obj_kwarg_for_pandas_api_parity(self):
+        """Legacy pandas signature ``get_group(name, obj=...)`` should not
+        raise ``TypeError: unexpected keyword``. The ``obj`` parameter was
+        deprecated/removed in pandas >=2.0; we accept and ignore it so that
+        callers carrying old pandas code don't break when swapping to
+        DataStore.
+        """
+        pdf = pd.DataFrame({'category': ['A', 'B', 'A', 'B'], 'value': [1, 2, 3, 4]})
+        ds = DataStore(pdf.copy())
+
+        ds_group_no_kwarg = ds.groupby('category').get_group('A')
+        ds_group_obj_none = ds.groupby('category').get_group('A', obj=None)
+        ds_group_obj_unused = ds.groupby('category').get_group('A', obj=pdf)
+
+        pd.testing.assert_frame_equal(ds_group_obj_none, ds_group_no_kwarg)
+        pd.testing.assert_frame_equal(ds_group_obj_unused, ds_group_no_kwarg)
+
+
+class TestGroupByGroupsAndIndices(unittest.TestCase):
+    """``gb.groups`` and ``gb.indices`` mirror pandas semantics."""
+
+    def setUp(self):
+        self.pdf = pd.DataFrame(
+            {
+                'category': ['A', 'B', 'A', 'B', 'A'],
+                'value': [10, 20, 30, 40, 50],
+            },
+            index=[10, 20, 30, 40, 50],
+        )
+        self.ds = DataStore(self.pdf.copy())
+
+    def test_groups_returns_label_index_per_group(self):
+        pd_groups = self.pdf.groupby('category').groups
+        ds_groups = self.ds.groupby('category').groups
+
+        self.assertEqual(set(ds_groups.keys()), set(pd_groups.keys()))
+        for key in pd_groups:
+            self.assertEqual(list(ds_groups[key]), list(pd_groups[key]))
+
+    def test_indices_returns_positional_locations_per_group(self):
+        pd_indices = self.pdf.groupby('category').indices
+        ds_indices = self.ds.groupby('category').indices
+
+        self.assertEqual(set(ds_indices.keys()), set(pd_indices.keys()))
+        for key in pd_indices:
+            np.testing.assert_array_equal(ds_indices[key], pd_indices[key])
+
+    def test_groups_multi_column_uses_tuple_keys(self):
+        pdf = pd.DataFrame(
+            {
+                'a': ['x', 'x', 'y', 'y'],
+                'b': [1, 2, 1, 1],
+                'v': [10, 20, 30, 40],
+            }
+        )
+        ds = DataStore(pdf.copy())
+
+        pd_groups = pdf.groupby(['a', 'b']).groups
+        ds_groups = ds.groupby(['a', 'b']).groups
+
+        self.assertEqual(set(ds_groups.keys()), set(pd_groups.keys()))
+        for key in pd_groups:
+            self.assertIsInstance(key, tuple)
+            self.assertEqual(list(ds_groups[key]), list(pd_groups[key]))
+
+    def test_indices_multi_column_uses_tuple_keys(self):
+        pdf = pd.DataFrame(
+            {
+                'a': ['x', 'x', 'y', 'y'],
+                'b': [1, 2, 1, 1],
+                'v': [10, 20, 30, 40],
+            }
+        )
+        ds = DataStore(pdf.copy())
+
+        pd_indices = pdf.groupby(['a', 'b']).indices
+        ds_indices = ds.groupby(['a', 'b']).indices
+
+        self.assertEqual(set(ds_indices.keys()), set(pd_indices.keys()))
+        for key in pd_indices:
+            self.assertIsInstance(key, tuple)
+            np.testing.assert_array_equal(ds_indices[key], pd_indices[key])
+
+
+class TestGroupByLenAndContains(unittest.TestCase):
+    """``len(gb)`` and ``key in gb`` mirror pandas."""
+
+    def setUp(self):
+        self.pdf = pd.DataFrame(
+            {
+                'category': ['A', 'B', 'A', 'B', 'C'],
+                'value': [1, 2, 3, 4, 5],
+            }
+        )
+        self.ds = DataStore(self.pdf.copy())
+
+    def test_len_equals_ngroups_equals_pandas(self):
+        pd_len = len(self.pdf.groupby('category'))
+        ds_len = len(self.ds.groupby('category'))
+        ds_ngroups = self.ds.groupby('category').ngroups
+
+        self.assertEqual(ds_len, pd_len)
+        self.assertEqual(ds_len, ds_ngroups)
+        self.assertEqual(ds_len, 3)
+
+    def test_contains_existing_key_single_column(self):
+        gb = self.ds.groupby('category')
+        self.assertIn('A', gb)
+        self.assertIn('B', gb)
+        self.assertIn('C', gb)
+
+    def test_contains_missing_key_single_column(self):
+        gb = self.ds.groupby('category')
+        self.assertNotIn('Z', gb)
+
+    def test_contains_existing_key_multi_column_uses_tuple(self):
+        pdf = pd.DataFrame(
+            {
+                'a': ['x', 'x', 'y'],
+                'b': [1, 2, 1],
+                'v': [10, 20, 30],
+            }
+        )
+        ds = DataStore(pdf.copy())
+
+        gb = ds.groupby(['a', 'b'])
+        self.assertIn(('x', 1), gb)
+        self.assertIn(('y', 1), gb)
+        self.assertNotIn(('y', 2), gb)
+
+
+class TestGroupByPandasCompatibilityEdges(unittest.TestCase):
+    """Pandas 2.x / 3.x compatibility edges around iteration & lookup.
+
+    Each test mirrors the matching pandas expression verbatim so divergence is
+    immediately visible. These cover scenarios that real users hit but which
+    aren't exercised by the core iteration tests:
+
+    1. ``as_index=False`` must not change iter / get_group / groups results
+       (it only affects agg output shape - we verify our implementation
+       doesn't accidentally couple it to iteration).
+    2. ``datetime64`` group keys round-trip correctly (the user's real-world
+       case typically has actual datetime, not strings).
+    3. ``dropna=False`` makes ``np.nan`` a valid lookup key for both
+       ``get_group()`` and ``groups``.
+    4. Degenerate inputs (empty / single-row / all-same-value) iterate
+       without raising.
+    """
+
+    # ----- as_index=False does not affect iter / get_group / groups -----
+
+    def test_iter_unaffected_by_as_index_false(self):
+        pdf = pd.DataFrame(
+            {'cat': ['A', 'B', 'A', 'B'], 'v': [1, 2, 3, 4]}
+        )
+        ds = DataStore(pdf.copy())
+
+        pd_items = list(pdf.groupby('cat', as_index=False))
+        ds_items = list(ds.groupby('cat', as_index=False))
+
+        self.assertEqual(len(ds_items), len(pd_items))
+        for (pk, pg), (dk, dg) in zip(pd_items, ds_items):
+            self.assertEqual(dk, pk)
+            pd.testing.assert_frame_equal(dg, pg)
+
+    def test_get_group_unaffected_by_as_index_false(self):
+        pdf = pd.DataFrame(
+            {'cat': ['A', 'B', 'A', 'B'], 'v': [1, 2, 3, 4]}
+        )
+        ds = DataStore(pdf.copy())
+
+        pd_group = pdf.groupby('cat', as_index=False).get_group('A')
+        ds_group = ds.groupby('cat', as_index=False).get_group('A')
+
+        pd.testing.assert_frame_equal(ds_group, pd_group)
+
+    def test_groups_unaffected_by_as_index_false(self):
+        pdf = pd.DataFrame(
+            {'cat': ['A', 'B', 'A', 'B'], 'v': [1, 2, 3, 4]}
+        )
+        ds = DataStore(pdf.copy())
+
+        pd_groups = pdf.groupby('cat', as_index=False).groups
+        ds_groups = ds.groupby('cat', as_index=False).groups
+
+        self.assertEqual(set(ds_groups.keys()), set(pd_groups.keys()))
+        for k in pd_groups:
+            self.assertEqual(list(ds_groups[k]), list(pd_groups[k]))
+
+    # ----- datetime64 group keys -----
+
+    def test_iter_with_datetime_groupby_key_single_column(self):
+        pdf = pd.DataFrame(
+            {
+                'date': pd.to_datetime(
+                    ['2026-05-22', '2026-05-22', '2026-05-23']
+                ),
+                'v': [1, 2, 3],
+            }
+        )
+        ds = DataStore(pdf.copy())
+
+        pd_items = list(pdf.groupby('date'))
+        ds_items = list(ds.groupby('date'))
+
+        self.assertEqual(len(ds_items), len(pd_items))
+        for (pk, pg), (dk, dg) in zip(pd_items, ds_items):
+            self.assertEqual(dk, pk)
+            self.assertIsInstance(dk, pd.Timestamp)
+            pd.testing.assert_frame_equal(dg, pg)
+
+    def test_iter_with_datetime_groupby_key_multi_column(self):
+        """Real-world variant of the user's screenshot, with date as datetime64."""
+        pdf = pd.DataFrame(
+            {
+                'date': pd.to_datetime(
+                    [
+                        '2026-05-22',
+                        '2026-05-22',
+                        '2026-05-23',
+                        '2026-05-23',
+                    ]
+                ),
+                'code': ['000001', '000002', '000001', '000001'],
+                'price': [10.0, 20.0, 10.5, 11.0],
+            }
+        )
+        ds = DataStore(pdf.copy())
+
+        pd_items = list(pdf.groupby(['date', 'code']))
+        ds_items = list(ds.groupby(['date', 'code']))
+
+        self.assertEqual(len(ds_items), len(pd_items))
+        for (pk, pg), (dk, dg) in zip(pd_items, ds_items):
+            self.assertIsInstance(dk, tuple)
+            self.assertIsInstance(dk[0], pd.Timestamp)
+            self.assertEqual(dk, pk)
+            pd.testing.assert_frame_equal(dg, pg)
+
+    def test_get_group_with_datetime_tuple_key(self):
+        pdf = pd.DataFrame(
+            {
+                'date': pd.to_datetime(
+                    ['2026-05-22', '2026-05-23', '2026-05-23']
+                ),
+                'code': ['000001', '000001', '000002'],
+                'price': [10.0, 10.5, 21.0],
+            }
+        )
+        ds = DataStore(pdf.copy())
+
+        target_key = (pd.Timestamp('2026-05-23'), '000001')
+        pd_group = pdf.groupby(['date', 'code']).get_group(target_key)
+        ds_group = ds.groupby(['date', 'code']).get_group(target_key)
+
+        pd.testing.assert_frame_equal(ds_group, pd_group)
+
+    # ----- dropna=False + NaN as lookup key -----
+
+    def test_get_group_with_nan_key_when_dropna_false(self):
+        pdf = pd.DataFrame(
+            {'cat': ['A', None, 'B', np.nan], 'v': [1, 2, 3, 4]}
+        )
+        ds = DataStore(pdf.copy())
+
+        pd_group = pdf.groupby('cat', dropna=False).get_group(np.nan)
+        ds_group = ds.groupby('cat', dropna=False).get_group(np.nan)
+
+        pd.testing.assert_frame_equal(ds_group, pd_group)
+
+    def test_groups_includes_nan_key_when_dropna_false(self):
+        pdf = pd.DataFrame(
+            {'cat': ['A', None, 'B', np.nan], 'v': [1, 2, 3, 4]}
+        )
+        ds = DataStore(pdf.copy())
+
+        pd_groups = pdf.groupby('cat', dropna=False).groups
+        ds_groups = ds.groupby('cat', dropna=False).groups
+
+        self.assertEqual(len(ds_groups), len(pd_groups))
+        pd_nan_keys = [k for k in pd_groups if pd.isna(k)]
+        ds_nan_keys = [k for k in ds_groups if pd.isna(k)]
+        self.assertEqual(len(pd_nan_keys), 1)
+        self.assertEqual(len(ds_nan_keys), 1)
+        self.assertEqual(
+            list(ds_groups[ds_nan_keys[0]]),
+            list(pd_groups[pd_nan_keys[0]]),
+        )
+
+    def test_get_group_multi_column_tuple_with_nan_when_dropna_false(self):
+        pdf = pd.DataFrame(
+            {
+                'a': ['x', 'x', 'y'],
+                'b': [1, np.nan, 1],
+                'v': [10, 20, 30],
+            }
+        )
+        ds = DataStore(pdf.copy())
+
+        target = ('x', np.nan)
+        pd_group = pdf.groupby(['a', 'b'], dropna=False).get_group(target)
+        ds_group = ds.groupby(['a', 'b'], dropna=False).get_group(target)
+
+        pd.testing.assert_frame_equal(ds_group, pd_group)
+
+    # ----- degenerate inputs: empty / single-row / all-same -----
+
+    def test_iter_on_empty_dataframe_yields_no_groups(self):
+        pdf = pd.DataFrame(
+            {
+                'cat': pd.Series([], dtype='object'),
+                'v': pd.Series([], dtype='int64'),
+            }
+        )
+        ds = DataStore(pdf.copy())
+
+        self.assertEqual(list(ds.groupby('cat')), list(pdf.groupby('cat')))
+        self.assertEqual(len(ds.groupby('cat')), 0)
+        self.assertEqual(ds.groupby('cat').ngroups, 0)
+
+    def test_iter_on_single_row_dataframe_yields_one_group(self):
+        pdf = pd.DataFrame({'cat': ['A'], 'v': [42]})
+        ds = DataStore(pdf.copy())
+
+        pd_items = list(pdf.groupby('cat'))
+        ds_items = list(ds.groupby('cat'))
+
+        self.assertEqual(len(ds_items), 1)
+        self.assertEqual(ds_items[0][0], 'A')
+        pd.testing.assert_frame_equal(ds_items[0][1], pd_items[0][1])
+
+    def test_iter_on_all_same_value_dataframe_yields_one_group(self):
+        pdf = pd.DataFrame({'cat': ['A', 'A', 'A'], 'v': [1, 2, 3]})
+        ds = DataStore(pdf.copy())
+
+        pd_items = list(pdf.groupby('cat'))
+        ds_items = list(ds.groupby('cat'))
+
+        self.assertEqual(len(ds_items), 1)
+        self.assertEqual(ds_items[0][0], 'A')
+        pd.testing.assert_frame_equal(ds_items[0][1], pd_items[0][1])
+
+
+class TestSeriesGroupByIteration(unittest.TestCase):
+    """``ds.groupby(...)[col]`` returns a ColumnExpr that iterates like pandas
+    ``SeriesGroupBy``: yields ``(group_key, sub_series)`` pairs.
+
+    Before the fix, ``for k, s in ds.groupby('cat')['v']:`` would iterate over
+    the raw values of the executed column (5 ints), completely ignoring the
+    grouping. Now it mirrors pandas SeriesGroupBy exactly.
+    """
+
+    def test_series_groupby_yields_key_and_subseries_single_column(self):
+        pdf = pd.DataFrame(
+            {'cat': ['A', 'B', 'A', 'B', 'C'], 'v': [10, 20, 30, 40, 50]}
+        )
+        ds = DataStore(pdf.copy())
+
+        pd_items = list(pdf.groupby('cat')['v'])
+        ds_items = list(ds.groupby('cat')['v'])
+
+        self.assertEqual(len(ds_items), len(pd_items))
+        for (pk, ps), (dk, ds_s) in zip(pd_items, ds_items):
+            self.assertEqual(dk, pk)
+            self.assertIsInstance(ds_s, pd.Series)
+            self.assertEqual(ds_s.tolist(), ps.tolist())
+            self.assertEqual(list(ds_s.index), list(ps.index))
+
+    def test_series_groupby_yields_tuple_key_for_multi_column(self):
+        pdf = pd.DataFrame(
+            {
+                'a': ['x', 'x', 'y', 'y'],
+                'b': [1, 2, 1, 1],
+                'v': [10, 20, 30, 40],
+            }
+        )
+        ds = DataStore(pdf.copy())
+
+        pd_items = list(pdf.groupby(['a', 'b'])['v'])
+        ds_items = list(ds.groupby(['a', 'b'])['v'])
+
+        self.assertEqual(len(ds_items), len(pd_items))
+        for (pk, ps), (dk, ds_s) in zip(pd_items, ds_items):
+            self.assertIsInstance(dk, tuple)
+            self.assertEqual(dk, pk)
+            self.assertEqual(ds_s.tolist(), ps.tolist())
+
+    def test_plain_column_iteration_still_yields_values(self):
+        """Regression: plain ds['col'] iteration must keep yielding scalars."""
+        pdf = pd.DataFrame({'v': [10, 20, 30]})
+        ds = DataStore(pdf.copy())
+
+        self.assertEqual(list(ds['v']), [10, 20, 30])
+
+    def test_series_groupby_iter_respects_dropna(self):
+        pdf = pd.DataFrame(
+            {'cat': ['A', None, 'B', np.nan], 'v': [1, 2, 3, 4]}
+        )
+        ds = DataStore(pdf.copy())
+
+        pd_items = list(pdf.groupby('cat', dropna=False)['v'])
+        ds_items = list(ds.groupby('cat', dropna=False)['v'])
+
+        self.assertEqual(len(ds_items), len(pd_items))
+        for (pk, ps), (dk, ds_s) in zip(pd_items, ds_items):
+            # NaN keys aren't equal even to themselves, so compare via isna
+            if pd.isna(pk):
+                self.assertTrue(pd.isna(dk))
+            else:
+                self.assertEqual(dk, pk)
+            self.assertEqual(ds_s.tolist(), ps.tolist())
+
+    def test_iter_after_aggregation_yields_scalar_values_not_subseries(self):
+        """Aggregated ColumnExprs propagate _groupby_fields downstream (for
+        SQL pushdown bookkeeping), but their iter must keep pandas Series
+        semantics - yielding scalar values, not (key, sub_series) pairs.
+        Regression for the CI failure of ``test_arithmetic_on_groupby_result``.
+        """
+        pdf = pd.DataFrame(
+            {'group': ['A', 'B', 'C'], 'value': [10, 20, 30]}
+        )
+        ds = DataStore(pdf.copy())
+
+        pd_result = pdf.groupby('group')['value'].sum() * 2 + 5
+        ds_result = ds.groupby('group')['value'].sum() * 2 + 5
+
+        self.assertEqual(list(ds_result), list(pd_result))
+
+
+class TestGroupByGetItemErrorPaths(unittest.TestCase):
+    """``gb[<illegal>]`` raises TypeError with a clear, type-specific message.
+
+    The legacy message ``Expected str or list, got int`` was misleading because
+    it surfaced from Python's iter-protocol fallback (``gb[0]`` when ``__iter__``
+    was missing), making users believe they had passed the wrong argument to
+    ``groupby()``. We now split the error into two branches and verify both.
+    """
+
+    def setUp(self):
+        self.ds = DataStore(
+            pd.DataFrame({'category': ['A', 'B'], 'value': [1, 2]})
+        )
+
+    def test_int_indexing_error_mentions_iteration_and_get_group(self):
+        gb = self.ds.groupby('category')
+
+        with self.assertRaises(TypeError) as ctx:
+            _ = gb[0]  # type: ignore[index]  # intentional wrong type to test error path
+
+        msg = str(ctx.exception)
+        self.assertIn('integer indexing', msg)
+        self.assertIn('get_group', msg)
+        self.assertIn('iterate', msg.lower())
+
+    def test_float_indexing_uses_generic_column_selection_error(self):
+        gb = self.ds.groupby('category')
+
+        with self.assertRaises(TypeError) as ctx:
+            _ = gb[3.14]  # type: ignore[index]  # intentional wrong type
+
+        msg = str(ctx.exception)
+        self.assertIn('str or list of str', msg)
+        self.assertIn('float', msg)
+        self.assertNotIn('integer indexing', msg)
+
+    def test_none_indexing_uses_generic_column_selection_error(self):
+        gb = self.ds.groupby('category')
+
+        with self.assertRaises(TypeError) as ctx:
+            _ = gb[None]  # type: ignore[index]  # intentional wrong type
+
+        msg = str(ctx.exception)
+        self.assertIn('str or list of str', msg)
+        self.assertIn('NoneType', msg)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/datastore/tests/test_groupby_iteration.py
+++ b/datastore/tests/test_groupby_iteration.py
@@ -517,30 +517,12 @@ class TestGroupByPandasCompatibilityEdges(unittest.TestCase):
 
     # ----- dropna=False + NaN as lookup key -----
 
-    # NB: ``get_group(np.nan)`` is intentionally not tested - pandas 2.x
-    # raises KeyError on NaN lookup (NaN != NaN in hash table) while
-    # pandas 3.x supports it, so any single assertion would diverge between
-    # supported pandas versions. NaN-group presence is still covered via
-    # ``.groups`` and ``iter`` (both version-stable APIs).
-
-    def test_groups_includes_nan_key_when_dropna_false(self):
-        pdf = pd.DataFrame(
-            {'cat': ['A', None, 'B', np.nan], 'v': [1, 2, 3, 4]}
-        )
-        ds = DataStore(pdf.copy())
-
-        pd_groups = pdf.groupby('cat', dropna=False).groups
-        ds_groups = ds.groupby('cat', dropna=False).groups
-
-        self.assertEqual(len(ds_groups), len(pd_groups))
-        pd_nan_keys = [k for k in pd_groups if pd.isna(k)]
-        ds_nan_keys = [k for k in ds_groups if pd.isna(k)]
-        self.assertEqual(len(pd_nan_keys), 1)
-        self.assertEqual(len(ds_nan_keys), 1)
-        self.assertEqual(
-            list(ds_groups[ds_nan_keys[0]]),
-            list(pd_groups[pd_nan_keys[0]]),
-        )
+    # NB: NaN-key behaviour with ``dropna=False`` is intentionally only
+    # covered via iteration (see ``test_iter_dropna_false_includes_na_group``)
+    # because both pandas-side APIs diverge across supported versions:
+    # - ``get_group(np.nan)``: pandas 2.x raises KeyError, pandas 3.x works
+    # - ``.groups`` on a column with None/NaN: pandas 2.x raises
+    #   ``ValueError: Categorical categories cannot be null`` (fixed in 3.x)
 
     # NB: ``get_group(('x', np.nan))`` for multi-column dropna=False groupby
     # is intentionally not tested - pandas 2.x raises KeyError on NaN-bearing

--- a/datastore/tests/test_groupby_iteration.py
+++ b/datastore/tests/test_groupby_iteration.py
@@ -547,21 +547,11 @@ class TestGroupByPandasCompatibilityEdges(unittest.TestCase):
             list(pd_groups[pd_nan_keys[0]]),
         )
 
-    def test_get_group_multi_column_tuple_with_nan_when_dropna_false(self):
-        pdf = pd.DataFrame(
-            {
-                'a': ['x', 'x', 'y'],
-                'b': [1, np.nan, 1],
-                'v': [10, 20, 30],
-            }
-        )
-        ds = DataStore(pdf.copy())
-
-        target = ('x', np.nan)
-        pd_group = pdf.groupby(['a', 'b'], dropna=False).get_group(target)
-        ds_group = ds.groupby(['a', 'b'], dropna=False).get_group(target)
-
-        pd.testing.assert_frame_equal(ds_group, pd_group)
+    # NB: ``get_group(('x', np.nan))`` for multi-column dropna=False groupby
+    # is intentionally not tested - pandas 2.x raises KeyError on NaN-bearing
+    # tuple keys (NaN != NaN in hash lookup) while pandas 3.x supports it,
+    # so any single assertion would diverge between supported pandas versions.
+    # Single-column NaN-key behaviour is covered by the two tests above.
 
     # ----- degenerate inputs: empty / single-row / all-same -----
 


### PR DESCRIPTION
Closes #581.

## Summary

`LazyGroupBy` had no `__iter__`, so `for k, g in ds.groupby([...]):` fell back to `__getitem__(0)` and raised `TypeError: Expected str or list, got int` — a misleading message hiding a missing feature. `ColumnExpr.__iter__` also dropped groupby context: `for x in gb['col']:` yielded raw values instead of pandas `SeriesGroupBy` `(key, sub_series)` pairs.

## Changes

- **`datastore/groupby.py`** — `LazyGroupBy` adds `__iter__`, `__len__`, `__contains__`, `get_group(name, obj=None)`, `groups`, `indices`. All delegate to a shared `_pandas_groupby()` helper that respects `sort` / `dropna` / `selected_columns`; single-col groupby uses scalar `by` to match the `gb['col']` scalar-key convention. `ngroups` refactored onto the helper too.
- **`datastore/column_expr.py`** — `__iter__` yields `(key, sub_series)` when `_groupby_fields` is set; plain `ds['col']` iteration unchanged.
- **`__getitem__` errors** — clearer `TypeError` for `gb[<int>]` (suggests iter / `get_group`) and `gb[<other>]` (suggests `str` / list of `str`).

## Tests

`datastore/tests/test_groupby_iteration.py` — **44 mirror-pattern tests** across 10 `TestCase`s:

- single/multi-column iter with scalar / tuple keys, index preservation
- `sort=True/False`, `dropna=True/False`, `as_index=False`, column selection
- `get_group` single / multi / column-selected / missing-key / legacy `obj=` kwarg
- `.groups` / `.indices` for single & multi column
- `len(gb)` / `key in gb`
- datetime keys, NaN keys, empty / single-row / all-same-value inputs
- `SeriesGroupBy` iter + clear error for iter on computed expressions
- `gb[<int|float|None>]` error path coverage

All 44 pass locally. Verified no regression on adjacent `column_expr` / `groupby` test files (178 passed).

## Verification

```python
for (date, code), group in ds.groupby(['date', 'code']):
    print(date, code, len(group))   # works, mirrors pandas

for k, s in ds.groupby('cat')['v']:
    print(k, s.tolist())            # SeriesGroupBy semantics
```