### PR TITLE
Mirror DataStore output_format + UDF surfaces from chdb-core

### DIFF
--- a/chdb/__init__.py
+++ b/chdb/__init__.py
@@ -33,8 +33,10 @@ class ChdbError(Exception):
 
 
 _arrow_format = set({"arrowtable"})
+_df_format = set({"dataframe", "datastore"})
 _process_result_format_funs = {
     "arrowtable": lambda x: to_arrowTable(x),
+    "datastore": lambda x: to_datastore(x),
 }
 
 g_udf_path = ""
@@ -116,6 +118,22 @@ def to_arrowTable(res):
     return pa.RecordBatchFileReader(memview.view()).read_all()
 
 
+def to_datastore(df):
+    """Wrap a pandas DataFrame in a chdb DataStore.
+
+    Requires the ``chdb`` pip package (providing the DataStore API) to be
+    installed alongside ``chdb-core``.
+    """
+    try:
+        from chdb.datastore import DataStore
+    except ImportError as e:
+        raise ImportError(
+            'DataStore output format requires the chdb package. '
+            'Install it via "pip install chdb".'
+        ) from e
+    return DataStore(df)
+
+
 g_conn_lock = threading.Lock()
 
 from .progress_display import (  # noqa: E402
@@ -183,9 +201,9 @@ def query(sql, output_format="CSV", path="", udf_path="", params=None, options=N
                 conn.set_progress_callback(progress_callback)
 
         try:
-            if lower_output_format == "dataframe":
+            if lower_output_format in _df_format:
                 res = conn.query_df(sql, params=params)
-                return res
+                return result_func(res)
 
             res = conn.query(sql, output_format, params=params)
 
@@ -203,8 +221,23 @@ sql = query
 
 PyReader = _chdb.PyReader
 
+# UDF module-level surfaces. Mirrored from chdb-core but guarded with hasattr
+# so chdb-ds keeps working against chdb-core releases that pre-date the
+# `promote create_function to module-level API` refactor (e.g. 26.3.0).
+_udf_exports = []
+for _name in ("create_function", "drop_function", "NullHandling", "ExceptionHandling"):
+    if hasattr(_chdb, _name):
+        globals()[_name] = getattr(_chdb, _name)
+        _udf_exports.append(_name)
+
 from . import dbapi, session, udf, utils  # noqa: E402
 from .state import connect  # noqa: E402
+
+try:
+    from .udf import func  # noqa: E402
+    _udf_exports.append("func")
+except ImportError:
+    pass
 
 __all__ = [
     "_chdb",
@@ -215,9 +248,10 @@ __all__ = [
     "chdb_version",
     "engine_version",
     "to_arrowTable",
+    "to_datastore",
     "dbapi",
     "session",
     "udf",
     "utils",
     "connect",
-]
+] + _udf_exports

--- a/chdb/__init__.py
+++ b/chdb/__init__.py
@@ -127,15 +127,6 @@ def to_datastore(df):
     try:
         from chdb.datastore import DataStore
     except ImportError as e:
-        # `from chdb.datastore import DataStore` pulls in the top-level
-        # `datastore` package through the chdb.datastore shim, so a missing
-        # API package surfaces as one of chdb.datastore / chdb / datastore.
-        # Translate those into the "install chdb" hint, but re-raise unrelated
-        # import failures (e.g. a broken transitive import *inside* the
-        # datastore package, such as a missing pandas) with their original
-        # traceback so real bugs stay debuggable.
-        if e.name not in ("chdb.datastore", "chdb", "datastore"):
-            raise
         raise ImportError(
             'DataStore output format requires the chdb package. '
             'Install it via "pip install chdb".'
@@ -245,14 +236,8 @@ from .state import connect  # noqa: E402
 try:
     from .udf import func  # noqa: E402
     _udf_exports.append("func")
-except ImportError as e:
-    # `func` is mirrored from chdb-core and may be absent on engine builds
-    # that predate the module-level UDF API; in that case the missing name /
-    # submodule surfaces as e.name == "chdb.udf"(.func). Re-raise anything
-    # else (e.g. a missing dependency *inside* the udf module) so a real
-    # import failure doesn't silently drop chdb.func.
-    if e.name not in ("chdb.udf", "chdb.udf.func"):
-        raise
+except ImportError:
+    pass
 
 __all__ = [
     "_chdb",

--- a/chdb/__init__.py
+++ b/chdb/__init__.py
@@ -127,6 +127,12 @@ def to_datastore(df):
     try:
         from chdb.datastore import DataStore
     except ImportError as e:
+        # Only translate a genuinely-missing datastore module into the
+        # "install chdb" hint. Re-raise unrelated import failures (e.g. a
+        # broken transitive import *inside* the datastore package) with their
+        # original traceback so real bugs stay debuggable.
+        if e.name not in ("chdb.datastore", "chdb"):
+            raise
         raise ImportError(
             'DataStore output format requires the chdb package. '
             'Install it via "pip install chdb".'

--- a/chdb/__init__.py
+++ b/chdb/__init__.py
@@ -245,8 +245,14 @@ from .state import connect  # noqa: E402
 try:
     from .udf import func  # noqa: E402
     _udf_exports.append("func")
-except ImportError:
-    pass
+except ImportError as e:
+    # `func` is mirrored from chdb-core and may be absent on engine builds
+    # that predate the module-level UDF API; in that case the missing name /
+    # submodule surfaces as e.name == "chdb.udf"(.func). Re-raise anything
+    # else (e.g. a missing dependency *inside* the udf module) so a real
+    # import failure doesn't silently drop chdb.func.
+    if e.name not in ("chdb.udf", "chdb.udf.func"):
+        raise
 
 __all__ = [
     "_chdb",

--- a/chdb/__init__.py
+++ b/chdb/__init__.py
@@ -127,11 +127,14 @@ def to_datastore(df):
     try:
         from chdb.datastore import DataStore
     except ImportError as e:
-        # Only translate a genuinely-missing datastore module into the
-        # "install chdb" hint. Re-raise unrelated import failures (e.g. a
-        # broken transitive import *inside* the datastore package) with their
-        # original traceback so real bugs stay debuggable.
-        if e.name not in ("chdb.datastore", "chdb"):
+        # `from chdb.datastore import DataStore` pulls in the top-level
+        # `datastore` package through the chdb.datastore shim, so a missing
+        # API package surfaces as one of chdb.datastore / chdb / datastore.
+        # Translate those into the "install chdb" hint, but re-raise unrelated
+        # import failures (e.g. a broken transitive import *inside* the
+        # datastore package, such as a missing pandas) with their original
+        # traceback so real bugs stay debuggable.
+        if e.name not in ("chdb.datastore", "chdb", "datastore"):
             raise
         raise ImportError(
             'DataStore output format requires the chdb package. '

--- a/datastore/tests/test_query_output_format_datastore.py
+++ b/datastore/tests/test_query_output_format_datastore.py
@@ -1,0 +1,52 @@
+"""
+Test that ``chdb.query(..., output_format="DataStore")`` dispatches to the
+DataFrame -> DataStore wrapper and is case-insensitive.
+
+Covers the output_format dispatch added in chdb/__init__.py so that
+``chdb.query(SQL, output_format="DataStore")`` returns a
+``chdb.datastore.DataStore`` (mirrored from chdb-core). The existing suite
+exercises ``output_format="DataFrame"`` extensively but never the DataStore
+variant, so this guards the dispatch table and the DataFrame->DataStore wrap.
+"""
+
+import unittest
+import chdb
+from datastore import DataStore
+from tests.test_utils import assert_datastore_equals_pandas
+
+
+class TestQueryOutputFormatDataStore(unittest.TestCase):
+    """chdb.query(..., output_format="DataStore") returns a DataStore."""
+
+    # Two columns of differing type so a wrong dispatch / wrap surfaces clearly.
+    SQL = "SELECT number AS n, toString(number) AS s FROM numbers(5)"
+
+    def test_query_output_format_datastore_returns_datastore(self):
+        """output_format="DataStore" returns a DataStore holding the query data."""
+        # pandas reference via the DataFrame output format
+        pd_result = chdb.query(self.SQL, output_format="DataFrame")
+
+        # DataStore output format (mirror of the DataFrame query)
+        ds_result = chdb.query(self.SQL, output_format="DataStore")
+
+        self.assertIsInstance(ds_result, DataStore)
+        assert_datastore_equals_pandas(ds_result, pd_result)
+
+    def test_query_output_format_datastore_is_case_insensitive(self):
+        """Every casing of "DataStore" returns an equivalent DataStore."""
+        pd_result = chdb.query(self.SQL, output_format="DataFrame")
+
+        for fmt in ("datastore", "DATASTORE", "DataStore", "dataStore"):
+            ds_result = chdb.query(self.SQL, output_format=fmt)
+            self.assertIsInstance(
+                ds_result,
+                DataStore,
+                msg=f"output_format={fmt!r} did not return a DataStore",
+            )
+            assert_datastore_equals_pandas(
+                ds_result, pd_result, msg=f"output_format={fmt!r}"
+            )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Closes #583
Companion to chdb-io/chdb-core#68

## Summary
- \`chdb.query(SQL, output_format="DataStore")\` (case-insensitive) returns \`chdb.datastore.DataStore\`
- Top-level UDF symbols (\`create_function\`, \`drop_function\`, \`NullHandling\`, \`ExceptionHandling\`, \`func\`) mirrored from chdb-core, guarded with \`hasattr\` so older chdb-core releases (e.g. 26.3.0, which predates the module-level UDF refactor) still load cleanly
- \`__all__\` extended dynamically based on what chdb-core actually exposes

## Behavior matrix
| API | chdb-core 26.3.0 (no UDF/DataStore) | chdb-core with #68 |
|---|---|---|
| \`import chdb\` | ✅ | ✅ |
| \`chdb.query(..., "DataStore")\` | ✅ (self-contained) | ✅ |
| \`chdb.create_function\` etc | ❌ AttributeError (not in \`__all__\`) | ✅ |
| \`Connection.query(..., "DataStore")\` | ❌ engine error | ✅ |

## Test plan
- [x] \`import chdb\` against installed chdb-core 26.3.0
- [x] \`chdb.query(..., "DataStore")\` returns DataStore
- [x] Case-insensitive ("datastore", "DATASTORE", "dataStore")
- [x] ImportError raised when \`chdb.datastore\` import is blocked
- [x] UDF hasattr guards: \`chdb.create_function\` not exposed on 26.3.0 (graceful AttributeError, no import crash)