### PR TITLE
test(datastore): require chdb-core>=26.5.0; un-xfail Array-in-Nullable cases it fixes

### DIFF
--- a/datastore/tests/test_chdb_dtype_differences.py
+++ b/datastore/tests/test_chdb_dtype_differences.py
@@ -15,7 +15,6 @@ in older chDB versions. As of 2026-01-06, chDB correctly preserves dtypes.
 import numpy as np
 import pandas as pd
 import pytest
-from tests.xfail_markers import chdb_array_nullable
 
 import chdb
 
@@ -96,7 +95,6 @@ class TestChDBArrayNullableLimitation:
         assert pd.isna(pd_result.iloc[1])
         assert pd.isna(ds_result.iloc[1])
 
-    @chdb_array_nullable
     def test_raw_sql_split_without_ifnull_fails(self):
         """
         Using splitByWhitespace directly in SQL without ifNull fails

--- a/datastore/tests/test_chdb_limitations_tracker.py
+++ b/datastore/tests/test_chdb_limitations_tracker.py
@@ -17,7 +17,6 @@ import pandas as pd
 import pytest
 
 from tests.xfail_markers import (
-    chdb_array_nullable,
     chdb_no_normalize_utf8,
     chdb_no_quantile_array,
     chdb_datetime_timezone,
@@ -61,13 +60,12 @@ class TestTypeSupportLimitations:
         assert len(result) == 1
         assert result['val'].iloc[0] == 3
 
-    @chdb_array_nullable
     def test_array_in_nullable(self):
         """Check if chDB allows Array inside Nullable type."""
         df = pd.DataFrame({'text': ['hello world', 'foo bar', None]})
         ds = DataStore(df)
         # str.findall returns array - used to fail with Array in Nullable error
-        result = ds['text'].str.findall(r'\w+')._get_df()
+        result = ds['text'].str.findall(r'\w+')
         assert len(result) == 3
 
 

--- a/datastore/tests/test_exploratory_batch11_advanced_indexing.py
+++ b/datastore/tests/test_exploratory_batch11_advanced_indexing.py
@@ -13,7 +13,7 @@ Testing areas:
 """
 
 import pytest
-from tests.xfail_markers import chdb_array_nullable, chdb_no_normalize_utf8, lazy_extractall_multiindex
+from tests.xfail_markers import chdb_no_normalize_utf8, lazy_extractall_multiindex
 import pandas as pd
 import numpy as np
 from datastore import DataStore
@@ -408,7 +408,6 @@ class TestAdvancedStringOperations:
         ds_result = get_value(ds_result)
         assert_frame_equal(ds_result, pd_result)
 
-    @chdb_array_nullable
     def test_str_findall(self):
         """str.findall returns all matches."""
         pd_df = pd.DataFrame({'text': ['a1b2c3', 'x9', 'no_match']})

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,7 +28,7 @@ classifiers = [
     "Topic :: Scientific/Engineering",
 ]
 dependencies = [
-    "chdb-core>=26.1.0",
+    "chdb-core>=26.5.0",
     "pandas>=2.1.0",
     "pyarrow>=13.0.0"
 ]

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 # Production dependencies
-chdb-core>=26.1.0
+chdb-core>=26.5.0
 pandas>=2.1.0
 pyarrow>=13.0.0


### PR DESCRIPTION
## What
chdb-core **v26.5** removes the "Array(T) cannot be inside Nullable" limitation, so
`str.findall` / `splitByWhitespace` over nullable columns now work. This drops the
`@chdb_array_nullable` xfail from the three datastore tests that genuinely pass on v26.5,
and raises the `chdb-core` dependency floor to `>=26.5.0`.

## Changes
- **Un-xfail (now real PASS):**
  - `test_str_findall`
  - `test_raw_sql_split_without_ifnull_fails`
  - `test_array_in_nullable` — also fixes a stale `._get_df()` call on a `ColumnExpr`
    (materialize via `len()`, per the lazy-execution convention)
- **Kept as `strict=True` XFAIL:** `test_explode_series` — fails for an *unrelated* reason
  (explode's `arrayJoin` doesn't convert a Python-list column to `Array(T)`), not the
  Nullable limitation. `xfail_markers.py` is therefore unchanged.
- **Dependency:** `chdb-core>=26.1.0` → `>=26.5.0` in `requirements.txt` and `pyproject.toml`.

## Validation
Ran the 4 affected tests against `chdb-core==26.5.0` (engine 26.5.1.1):
`3 passed, 1 xfailed` — `strict=True` preserved (no XPASS).

🤖 Generated with [Claude Code](https://claude.com/claude-code)