### PR TITLE
ci: fix wheel release trigger (created -> published)

### DIFF
--- a/.github/workflows/build_linux_arm64_wheels-gh.yml
+++ b/.github/workflows/build_linux_arm64_wheels-gh.yml
@@ -7,7 +7,7 @@ on:
         description: 'Release Version Tag'
         required: true
   release:
-    types: [created]
+    types: [published]
   push:
     branches:
       - main

--- a/.github/workflows/build_linux_x86_wheels.yml
+++ b/.github/workflows/build_linux_x86_wheels.yml
@@ -7,7 +7,7 @@ on:
         description: 'Release Version Tag'
         required: true
   release:
-    types: [created]
+    types: [published]
   push:
     branches:
       - main

--- a/.github/workflows/build_macos_arm64_wheels.yml
+++ b/.github/workflows/build_macos_arm64_wheels.yml
@@ -7,7 +7,7 @@ on:
         description: 'Release Version Tag'
         required: true
   release:
-    types: [created]
+    types: [published]
   push:
     branches:
       - main

--- a/.github/workflows/build_macos_x86_wheels.yml
+++ b/.github/workflows/build_macos_x86_wheels.yml
@@ -7,7 +7,7 @@ on:
         description: 'Release Version Tag'
         required: true
   release:
-    types: [created]
+    types: [published]
   push:
     branches:
       - main


### PR DESCRIPTION
## What
`release: types: [created]` does **not** fire when a release is first saved as a
**draft** and published later — only `published` does. This switches all four
wheel-build workflows to `types: [published]`, which fires both on a direct
publish and on publishing a draft.

## Why
chdb-core v26.5.0 hit exactly this: the release was drafted then published, so the
`[created]` publish workflows never ran — leaving PyPI and the GitHub release
assets empty until a manual `workflow_dispatch`. chdb's workflows have the same
trigger, so this hardens chdb against the same draft-then-publish miss.

## Change
`.github/workflows/build_{linux_x86,linux_arm64-gh,macos_x86,macos_arm64}_wheels*.yml`:
`release: types: [created]` → `[published]` (4 files, 1 line each).

🤖 Generated with [Claude Code](https://claude.com/claude-code)