### PR TITLE
perf(datastore): resolve .columns/.dtypes/.shape/.index without materializing

### DIFF
--- a/datastore/core.py
+++ b/datastore/core.py
@@ -3914,7 +3914,12 @@ class DataStore(PandasCompatMixin):
         src = self._get_source_df_if_pristine()
         if src is not None:
             return src.shape
-        if self._is_pristine_sql_source():
+        # SQL-pushdownable pipeline: rows via COUNT(*), columns via .columns
+        # (itself probe-or-execute). Both self-correct, so this is valid for any
+        # pushdownable pipeline -- a bare filter resolves with no materialization;
+        # a column-altering op (projection/rename/...) makes .columns execute,
+        # which is still correct. See chdb-lazy-metadata-optimizations.md.
+        if self._can_sql_pushdown() and self._cached_result is None:
             return (self.count_rows(), len(self.columns))
         return self._get_df().shape
 
@@ -3963,16 +3968,21 @@ class DataStore(PandasCompatMixin):
                 return pd.Index(base_cols + computed_cols)
             except Exception:
                 pass
-        # For JOINs or complex SQL sources: probe schema with LIMIT 0
-        # This avoids materializing the full result just to get column names
-        if (
-            self._joins
-            and self._can_sql_pushdown()
-            and self._cached_result is None
-        ):
+        # SQL-pushdownable pipeline: probe the output schema with LIMIT 0 instead
+        # of materializing the full result. The probe reflects to_sql() (source +
+        # filters / ORDER BY / LIMIT). Column-altering lazy ops (select / rename /
+        # drop / assign) are applied post-SQL and are NOT in the probe SQL, so we
+        # only trust the probe when the lazy ops don't change the column set
+        # (transform_columns is the identity); otherwise we fall through to
+        # execution for correctness. See chdb-lazy-metadata-optimizations.md.
+        if self._can_sql_pushdown() and self._cached_result is None:
             try:
-                probe_df = self._probe_schema()
-                return probe_df.columns
+                probe_cols = list(self._probe_schema().columns)
+                cols = probe_cols
+                for op in (self._lazy_ops or []):
+                    cols = op.transform_columns(cols)
+                if cols == probe_cols:
+                    return pd.Index(probe_cols)
             except Exception:
                 pass
         return self._get_df().columns

--- a/datastore/core.py
+++ b/datastore/core.py
@@ -3974,8 +3974,17 @@ class DataStore(PandasCompatMixin):
         # drop / assign) are applied post-SQL and are NOT in the probe SQL, so we
         # only trust the probe when the lazy ops don't change the column set
         # (transform_columns is the identity); otherwise we fall through to
-        # execution for correctness. See chdb-lazy-metadata-optimizations.md.
-        if self._can_sql_pushdown() and self._cached_result is None:
+        # execution for correctness.
+        #
+        # Remote sources are excluded: _probe_schema() wraps the pipeline in a
+        # nested subquery (SELECT * FROM (...) LIMIT 0), which chDB HANGS on for
+        # remote() sources -- the same reason count_rows()/count() avoid nested
+        # subqueries for remote. Filtered-remote metadata falls back to execution.
+        if (
+            self._can_sql_pushdown()
+            and self._cached_result is None
+            and not self._is_remote_source()
+        ):
             try:
                 probe_cols = list(self._probe_schema().columns)
                 cols = probe_cols
@@ -4048,17 +4057,23 @@ class DataStore(PandasCompatMixin):
         count_base._offset_value = None
         return count_base.to_sql()
 
-    def _probe_schema(self) -> pd.DataFrame:
-        """Return an empty DataFrame with correct columns and dtypes.
+    def _probe_schema(self, limit: int = 0) -> pd.DataFrame:
+        """Return a (near-)empty DataFrame with the pipeline's columns and dtypes.
 
-        Executes ``SELECT * FROM (subquery) LIMIT 0`` -- lightweight because
-        no rows are transferred. Used by aggregate helpers (nunique,
-        value_counts, describe, memory_usage) to discover column metadata.
+        Executes ``SELECT * FROM (subquery) LIMIT {limit}`` -- lightweight because
+        at most ``limit`` rows are transferred.
+
+        ``limit=0`` transfers no rows and is enough to discover column NAMES
+        (used by .columns and the aggregate helpers nunique / value_counts /
+        describe / memory_usage). ``limit=1`` transfers a single row, which chDB
+        needs to materialize string columns as their real pandas dtype -- an
+        empty (LIMIT 0) result degrades string columns to ``object`` -- so the
+        ``.dtypes`` path uses ``limit=1``.
         """
         if self._executor is None:
             self.connect()
         subquery_sql = self.to_sql()
-        probe_sql = f"SELECT * FROM ({subquery_sql}) LIMIT 0"
+        probe_sql = f"SELECT * FROM ({subquery_sql}) LIMIT {int(limit)}"
         return self._executor.execute(probe_sql).to_df()
 
     def count(self):
@@ -4242,9 +4257,13 @@ class DataStore(PandasCompatMixin):
             )
             return len(self._execute())
 
-        # If LIMIT is applied, execute with LIMIT and return actual count
-        if self._limit_value is not None:
-            self._logger.debug("count_rows() executing due to LIMIT")
+        # If LIMIT or OFFSET is applied, execute and return the actual count.
+        # The flat and subquery COUNT paths below both drop LIMIT/OFFSET (see
+        # _build_count_subquery, which clears _limit_value/_offset_value), so an
+        # offset-only pipeline (e.g. ds[k:]) would over-count by the offset.
+        # Fall back to execution for a correct post-offset count.
+        if self._limit_value is not None or self._offset_value is not None:
+            self._logger.debug("count_rows() executing due to LIMIT/OFFSET")
             return len(self._execute())
 
         # Ensure we're connected

--- a/datastore/pandas_compat.py
+++ b/datastore/pandas_compat.py
@@ -375,6 +375,25 @@ class PandasCompatMixin:
             return src.dtypes
         if self._is_pristine_sql_source():
             return self._probe_dtypes_from_sql_source()
+        # SQL-pushdownable pipeline: probe the output dtypes with LIMIT 0.
+        # Pushdownable ops never cast dtypes (astype and other value casts are
+        # NOT pushdownable -- they fall through below), so the probe's per-column
+        # dtypes are authoritative. As with .columns, only trust the probe when
+        # the lazy ops don't change the column set (transform_columns is the
+        # identity -- filters / ORDER BY / LIMIT); column-altering ops (select /
+        # rename / drop / assign) are applied post-SQL, so fall through to
+        # execution. See chdb-lazy-metadata-optimizations.md.
+        if self._can_sql_pushdown() and self._cached_result is None:
+            try:
+                probe = self._probe_schema()
+                probe_cols = list(probe.columns)
+                cols = probe_cols
+                for op in (self._lazy_ops or []):
+                    cols = op.transform_columns(cols)
+                if cols == probe_cols:
+                    return probe.dtypes
+            except Exception:
+                pass
         return self._get_df().dtypes
 
     @property
@@ -2910,6 +2929,24 @@ class PandasCompatMixin:
     @property
     def index(self):
         """The index (row labels) of the DataFrame."""
+        # chDB's default index is a RangeIndex, fully determined by the row
+        # count. With no custom index (set_index), no grouping, and a
+        # SQL-pushdownable pipeline, derive it from COUNT(*) instead of
+        # materializing rows. count_rows() self-corrects (cheap COUNT, or a real
+        # execution when a LIMIT / non-pushdownable step is present), so the
+        # length is always right -- including for filtered pipelines, whose lazy
+        # op lives in the SQL. Custom/group indexes fall back.
+        # See chdb-lazy-metadata-optimizations.md.
+        if (
+            self._index_info is None
+            and not self._groupby_fields
+            and self._can_sql_pushdown()
+            and self._cached_result is None
+        ):
+            try:
+                return pd.RangeIndex(start=0, stop=self.count_rows(), step=1)
+            except Exception:
+                pass
         return self._get_df().index
 
     @index.setter

--- a/datastore/pandas_compat.py
+++ b/datastore/pandas_compat.py
@@ -375,26 +375,77 @@ class PandasCompatMixin:
             return src.dtypes
         if self._is_pristine_sql_source():
             return self._probe_dtypes_from_sql_source()
-        # SQL-pushdownable pipeline: probe the output dtypes with LIMIT 0.
-        # Pushdownable ops never cast dtypes (astype and other value casts are
-        # NOT pushdownable -- they fall through below), so the probe's per-column
-        # dtypes are authoritative. As with .columns, only trust the probe when
-        # the lazy ops don't change the column set (transform_columns is the
-        # identity -- filters / ORDER BY / LIMIT); column-altering ops (select /
-        # rename / drop / assign) are applied post-SQL, so fall through to
-        # execution. See chdb-lazy-metadata-optimizations.md.
-        if self._can_sql_pushdown() and self._cached_result is None:
+        # SQL-pushdownable pipeline: probe the output dtypes with LIMIT 1.
+        # LIMIT 1 (not 0): an empty result degrades string columns to numpy
+        # ``object``, while a single row lets chDB materialize the real pandas
+        # dtype (e.g. StringDtype). Pushdownable ops never cast dtypes (astype and
+        # other value casts are NOT pushdownable -- they fall through below), so
+        # the probe's per-column dtypes are authoritative. As with .columns, only
+        # trust the probe when the lazy ops don't change the column set
+        # (transform_columns is the identity -- filters / ORDER BY / LIMIT);
+        # column-altering ops (select / rename / drop / assign) are applied
+        # post-SQL, so fall through to execution.
+        #
+        # Remote sources are excluded: _probe_schema() nests a subquery
+        # (SELECT * FROM (...) LIMIT n) that chDB HANGS on for remote() sources,
+        # so filtered-remote dtypes fall back to execution.
+        if (
+            self._can_sql_pushdown()
+            and self._cached_result is None
+            and not self._is_remote_source()
+        ):
             try:
-                probe = self._probe_schema()
+                probe = self._probe_schema(limit=1)
                 probe_cols = list(probe.columns)
                 cols = probe_cols
                 for op in (self._lazy_ops or []):
                     cols = op.transform_columns(cols)
-                if cols == probe_cols:
+                if cols == probe_cols and self._dtype_probe_is_reliable(probe):
                     return probe.dtypes
             except Exception:
                 pass
         return self._get_df().dtypes
+
+    def _dtype_probe_is_reliable(self, probe: "pd.DataFrame") -> bool:
+        """Whether a LIMIT 1 dtype probe can be trusted for every column.
+
+        chDB's pandas dtype for an integer/bool column is null-PRESENCE dependent,
+        not schema-driven: chDB types parquet ints as ``Nullable(Int64)`` yet a
+        result with no nulls materializes as numpy ``int64`` and one with nulls as
+        pandas ``Int64`` (likewise ``bool`` vs ``boolean``). A single sampled row
+        can't reveal nulls elsewhere, so the probe's ``int64``/``bool`` is only
+        right when the full result has no nulls in that column. We confirm that
+        with a COUNT aggregate that transfers no data rows; if any probed
+        integer/bool column actually contains a null, the probe would disagree
+        with full execution, so we fall back. String / float / datetime columns
+        use str / NaN / NaT regardless of nulls, so they are always reliable.
+
+        Any failure here returns False (fall back), so this can only cause MORE
+        execution, never an incorrect dtype.
+        """
+        from .utils import format_identifier
+
+        risky = [
+            c
+            for c in probe.columns
+            if pd.api.types.is_bool_dtype(probe[c].dtype)
+            or pd.api.types.is_integer_dtype(probe[c].dtype)
+        ]
+        if not risky:
+            return True
+        if self._executor is None:
+            self.connect()
+        # countIf(col IS NULL) per risky column -- a single result row, no data
+        # transfer. Remote sources never reach here (gated out by the caller), so
+        # this nested aggregate subquery is safe.
+        exprs = ", ".join(
+            f"countIf({format_identifier(c, self.quote_char)} IS NULL)"
+            for c in risky
+        )
+        result = self._executor.execute(f"SELECT {exprs} FROM ({self.to_sql()})")
+        if not result.rows:
+            return False
+        return all(int(v) == 0 for v in result.rows[0])
 
     @property
     def values(self):
@@ -2929,17 +2980,28 @@ class PandasCompatMixin:
     @property
     def index(self):
         """The index (row labels) of the DataFrame."""
+        from .lazy_ops import LazyRelationalOp
+
         # chDB's default index is a RangeIndex, fully determined by the row
-        # count. With no custom index (set_index), no grouping, and a
-        # SQL-pushdownable pipeline, derive it from COUNT(*) instead of
+        # count. With no custom index (set_index), no grouping, no ORDER BY, and
+        # a SQL-pushdownable pipeline, derive it from COUNT(*) instead of
         # materializing rows. count_rows() self-corrects (cheap COUNT, or a real
-        # execution when a LIMIT / non-pushdownable step is present), so the
-        # length is always right -- including for filtered pipelines, whose lazy
-        # op lives in the SQL. Custom/group indexes fall back.
-        # See chdb-lazy-metadata-optimizations.md.
+        # execution when a LIMIT / OFFSET / non-pushdownable step is present), so
+        # the length is always right -- including for filtered pipelines, whose
+        # lazy op lives in the SQL.
+        #
+        # ORDER BY is excluded: a sorted result preserves the original positional
+        # labels (it is NOT reset to a contiguous RangeIndex), so the shortcut
+        # would return the wrong labels -- it must fall back to full execution.
+        # Custom/group indexes fall back too.
+        has_order_by = bool(self._orderby_fields) or any(
+            isinstance(op, LazyRelationalOp) and op.op_type == "ORDER BY"
+            for op in (self._lazy_ops or [])
+        )
         if (
             self._index_info is None
             and not self._groupby_fields
+            and not has_order_by
             and self._can_sql_pushdown()
             and self._cached_result is None
         ):

--- a/datastore/tests/test_lazy_metadata_pushdown.py
+++ b/datastore/tests/test_lazy_metadata_pushdown.py
@@ -2,10 +2,11 @@
 Tests for lazy metadata access on NON-pristine but SQL-pushdownable pipelines.
 
 Extends the pristine-source optimization (test_pristine_metadata_optimization.py)
-to filtered / projected pipelines: `.columns` / `.dtypes` must resolve via a
-``SELECT ... LIMIT 0`` schema probe, and `.shape` / `.index` via ``COUNT(*)``,
-instead of materializing the full result through ``_execute()``. Non-pushdownable
-pipelines and custom/group indexes keep the full-execution fallback.
+to filtered / projected pipelines: `.columns` resolves via a ``SELECT ... LIMIT 0``
+schema probe, `.dtypes` via a ``LIMIT 1`` probe (LIMIT 0 degrades string columns to
+``object``), and `.shape` / `.index` via ``COUNT(*)``, instead of materializing the
+full result through ``_execute()``. Non-pushdownable pipelines, remote sources, and
+custom/group indexes keep the full-execution fallback.
 
 Mirrors the mock + SQL-capture style of test_pristine_metadata_optimization.py.
 """
@@ -66,7 +67,7 @@ class TestNonPristinePushdownMetadata:
         assert list(cols) == list(pd_result.columns)
         assert any("LIMIT 0" in s for s in sqls), f"expected a LIMIT 0 probe, got: {sqls}"
 
-    def test_dtypes_uses_limit0_not_execute(self, filtered):
+    def test_dtypes_uses_limit1_not_execute(self, filtered):
         ds2, pd_result = filtered
         ds2.connect()
         sqls = []
@@ -82,7 +83,9 @@ class TestNonPristinePushdownMetadata:
             mock_exec.assert_not_called()
 
         assert list(dtypes.index) == list(pd_result.columns)
-        assert any("LIMIT 0" in s for s in sqls), f"expected a LIMIT 0 probe, got: {sqls}"
+        # .dtypes probes with LIMIT 1 (LIMIT 0 would degrade string columns to
+        # object); see TestDtypesProbeLimit1.
+        assert any("LIMIT 1" in s for s in sqls), f"expected a LIMIT 1 probe, got: {sqls}"
 
     def test_shape_uses_count_not_execute(self, filtered):
         ds2, pd_result = filtered
@@ -145,3 +148,229 @@ class TestIndexFallback:
         idx = ds.index
         # must reflect the real index values (10..50), not a degenerate RangeIndex(0..n)
         assert list(idx) == list(pd_result.index)
+
+
+class TestOffsetRowCount:
+    """An OFFSET-without-LIMIT pipeline (e.g. ``ds[k:]``) must report the
+    POST-offset row count for ``.shape`` / ``len(.index)`` / ``count_rows()``.
+
+    Regression guard: ``count_rows()`` only short-circuits to execution on LIMIT,
+    and its flat / subquery COUNT paths drop OFFSET (``_build_count_subquery``
+    clears ``_offset_value``), so an offset-only pipeline over-counts by the
+    offset unless ``count_rows()`` falls back to execution. The optimization must
+    match both pandas and full execution."""
+
+    @pytest.fixture
+    def offset_pipeline(self, tmp_path):
+        path, df = _make_parquet(tmp_path)        # 1000 rows
+        return path, df.iloc[5:]                   # OFFSET 5, no LIMIT -> 995 rows
+
+    def test_count_rows_respects_offset(self, offset_pipeline):
+        path, pd_result = offset_pipeline
+        assert DataStore.from_file(path)[5:].count_rows() == len(pd_result) == 995
+
+    def test_shape_respects_offset_matches_pandas_and_full(self, offset_pipeline):
+        path, pd_result = offset_pipeline
+        assert DataStore.from_file(path)[5:].shape == pd_result.shape  # (995, 3)
+        # internal invariant: optimized shape == full-execution shape
+        full = DataStore.from_file(path)[5:]._get_df()
+        assert DataStore.from_file(path)[5:].shape == full.shape
+
+    def test_index_length_respects_offset(self, offset_pipeline):
+        path, pd_result = offset_pipeline
+        ds_idx = DataStore.from_file(path)[5:].index
+        full_idx = DataStore.from_file(path)[5:]._get_df().index
+        assert len(ds_idx) == len(pd_result) == 995
+        assert list(ds_idx) == list(full_idx)  # optimized index == full execution
+
+
+class TestSortValuesIndex:
+    """``sort_values()`` (ORDER BY) must NOT take the ``RangeIndex(0..n)`` shortcut:
+    a sorted result preserves the original positional labels, which the shortcut
+    destroys. ``.index`` must match both full execution and pandas.
+
+    Regression guard for the lazy-metadata optimization: ``count_rows()`` strips
+    ORDER BY for its flat count, so ``.index`` would otherwise return a degenerate
+    ``RangeIndex`` with the wrong labels."""
+
+    def test_sort_values_index_matches_full_and_pandas(self, tmp_path):
+        df = pd.DataFrame({
+            "age": [5, 3, 8, 1, 9, 2, 7, 0, 6, 4],
+            "name": [f"n{i}" for i in range(10)],
+        })
+        path = str(tmp_path / "sort.parquet")
+        df.to_parquet(path, index=False)
+        pd_result = df.sort_values("age")
+
+        opt_index = list(DataStore.from_file(path).sort_values("age").index)
+        full_index = list(DataStore.from_file(path).sort_values("age")._get_df().index)
+
+        # primary invariant: the optimization must not disagree with full execution
+        assert opt_index == full_index, (opt_index, full_index)
+        # and it must match pandas' order-preserved labels (not RangeIndex 0..n)
+        assert opt_index == list(pd_result.index), (opt_index, list(pd_result.index))
+        assert opt_index != list(range(len(df))), "must not be a degenerate RangeIndex"
+
+
+class TestDtypesProbeLimit1:
+    """`.dtypes` on a SQL-pushdownable pipeline probes with ``LIMIT 1`` (not
+    ``LIMIT 0``). An empty (LIMIT 0) result degrades string columns to numpy
+    ``object``; one row lets chDB report the real pandas dtype (e.g. StringDtype).
+
+    The optimized dtypes MUST equal full execution (``_get_df().dtypes``) for
+    every type, and the access must not materialize the full result. Regression
+    guard for BUG#3 (string columns reported as ``object``)."""
+
+    @pytest.fixture
+    def typed(self, tmp_path):
+        df = pd.DataFrame({
+            "i":  pd.array([1, 2, 3, 4, 5], dtype="int64"),
+            "f":  [1.5, 2.5, 3.5, 4.5, 5.5],
+            "s":  ["alpha", "beta", "gamma", "delta", "eps"],
+            "b":  [True, False, True, False, True],
+            "dt": pd.to_datetime(
+                ["2021-01-01", "2021-02-01", "2021-03-01", "2021-04-01", "2021-05-01"]
+            ),
+        })
+        path = str(tmp_path / "typed.parquet")
+        df.to_parquet(path, index=False)
+        return path, df
+
+    def _flt(self, path):
+        return DataStore.from_file(path)[DataStore.from_file(path)["i"] >= 2]
+
+    def test_filtered_dtypes_match_full_execution(self, typed):
+        path, _ = typed
+        opt = dict(self._flt(path).dtypes)
+        full = dict(self._flt(path)._get_df().dtypes)
+        assert opt == full, (opt, full)
+
+    def test_string_column_is_not_object(self, typed):
+        # BUG#3: a LIMIT 0 probe degrades the string column to object; LIMIT 1
+        # reports the real dtype, matching full execution.
+        path, _ = typed
+        opt = dict(self._flt(path).dtypes)
+        full = dict(self._flt(path)._get_df().dtypes)
+        assert opt["s"] != object, f"string column degraded to object: {opt['s']}"
+        assert opt["s"] == full["s"]
+
+    def test_dtypes_uses_limit1_probe_not_execute(self, typed):
+        path, _ = typed
+        ds = self._flt(path)
+        ds.connect()
+        sqls = []
+        original = ds._executor.execute
+        with patch.object(ds, "_execute", wraps=ds._execute) as mock_exec, \
+                patch.object(
+                    ds._executor, "execute",
+                    side_effect=lambda s, *a, **k: (sqls.append(s), original(s, *a, **k))[1],
+                ):
+            dtypes = ds.dtypes
+            mock_exec.assert_not_called()
+        assert any("LIMIT 1" in s for s in sqls), f"expected a LIMIT 1 probe, got: {sqls}"
+        assert dtypes["s"] != object
+        assert ds._cached_result is None, "dtypes access must not materialize the result"
+
+    def test_sort_then_dtypes_match_full(self, typed):
+        path, _ = typed
+        opt = dict(DataStore.from_file(path).sort_values("f").dtypes)
+        full = dict(DataStore.from_file(path).sort_values("f")._get_df().dtypes)
+        assert opt == full, (opt, full)
+        assert opt["s"] != object
+
+    def test_head_then_dtypes_match_full(self, typed):
+        path, _ = typed
+        opt = dict(DataStore.from_file(path).head(3).dtypes)
+        full = dict(DataStore.from_file(path).head(3)._get_df().dtypes)
+        assert opt == full, (opt, full)
+        assert opt["s"] != object
+
+    def test_empty_result_dtypes_match_full(self, typed):
+        path, _ = typed
+        flt = lambda: DataStore.from_file(path)[DataStore.from_file(path)["i"] > 10 ** 9]
+        opt = dict(flt().dtypes)
+        full = dict(flt()._get_df().dtypes)
+        # genuinely empty -> chDB degrades strings to object in BOTH paths; the
+        # invariant is still optimized == full execution.
+        assert opt == full, (opt, full)
+
+
+class TestDtypesNullableInteger:
+    """A nullable integer column's pandas dtype is null-PRESENCE dependent: chDB
+    yields numpy ``int64`` when the result has no nulls and pandas ``Int64`` when
+    it does. A bounded probe can't see nulls elsewhere, so the ``.dtypes`` path
+    runs a COUNT(nulls) check: no nulls -> trust the LIMIT 1 probe (optimization
+    kept); nulls present -> fall back to full execution. Either way ``.dtypes``
+    must equal ``_get_df().dtypes``."""
+
+    def _write(self, tmp_path, values):
+        df = pd.DataFrame({
+            "ni": pd.array(values, dtype="Int64"),
+            "s": [f"r{i}" for i in range(len(values))],
+        })
+        path = str(tmp_path / "ni.parquet")
+        df.to_parquet(path, index=False)
+        return path
+
+    def test_nullable_int_with_nulls_falls_back_and_matches_full(self, tmp_path):
+        path = self._write(tmp_path, [1, None, 3, None, 5])
+        # filter on the OTHER column so the null rows of `ni` are kept
+        flt = lambda: DataStore.from_file(path)[DataStore.from_file(path)["s"] != "zzz"]
+        opt = dict(flt().dtypes)
+        full = dict(flt()._get_df().dtypes)
+        assert opt == full, (opt, full)
+        assert str(opt["ni"]) == "Int64", "nulls present -> nullable extension dtype"
+
+    def test_nullable_int_without_nulls_keeps_optimization(self, tmp_path):
+        path = self._write(tmp_path, [1, None, 3, None, 5])
+        # filter keeps only non-null rows of `ni`
+        full = dict(
+            DataStore.from_file(path)[DataStore.from_file(path)["ni"] >= 3]._get_df().dtypes
+        )
+        ds = DataStore.from_file(path)[DataStore.from_file(path)["ni"] >= 3]
+        with patch.object(ds, "_execute", wraps=ds._execute) as mock_exec:
+            opt = dict(ds.dtypes)
+            # COUNT(nulls)==0 -> probe trusted, no full materialization
+            mock_exec.assert_not_called()
+        assert opt == full, (opt, full)
+        assert str(opt["ni"]) == "int64", "no nulls -> plain numpy dtype"
+
+
+class TestDtypesColumnAlteringFallback:
+    """Column-altering ops (astype / rename / drop / assign) are applied post-SQL
+    and are not in the probe; ``.dtypes`` must fall back to execution and still
+    report correct per-column dtypes."""
+
+    @pytest.fixture
+    def base(self, tmp_path):
+        df = pd.DataFrame({
+            "id": pd.array([1, 2, 3], dtype="int64"),
+            "val": [10.0, 20.0, 30.0],
+            "name": ["x", "y", "z"],
+        })
+        path = str(tmp_path / "base.parquet")
+        df.to_parquet(path, index=False)
+        return path, df
+
+    def test_astype_dtypes_match_full(self, base):
+        path, _ = base
+        opt = dict(DataStore.from_file(path).astype({"id": "float64"}).dtypes)
+        full = dict(DataStore.from_file(path).astype({"id": "float64"})._get_df().dtypes)
+        assert opt == full, (opt, full)
+        assert str(opt["id"]) == "float64"
+
+    def test_rename_dtypes_match_full(self, base):
+        path, _ = base
+        opt = dict(DataStore.from_file(path).rename(columns={"val": "value"}).dtypes)
+        full = dict(
+            DataStore.from_file(path).rename(columns={"val": "value"})._get_df().dtypes
+        )
+        assert opt == full, (opt, full)
+        assert "value" in opt and "val" not in opt
+
+    def test_drop_dtypes_match_full(self, base):
+        path, _ = base
+        opt = dict(DataStore.from_file(path).drop(columns=["name"]).dtypes)
+        full = dict(DataStore.from_file(path).drop(columns=["name"])._get_df().dtypes)
+        assert opt == full, (opt, full)
+        assert "name" not in opt

--- a/datastore/tests/test_lazy_metadata_pushdown.py
+++ b/datastore/tests/test_lazy_metadata_pushdown.py
@@ -245,14 +245,16 @@ class TestDtypesProbeLimit1:
         full = dict(self._flt(path)._get_df().dtypes)
         assert opt == full, (opt, full)
 
-    def test_string_column_is_not_object(self, typed):
-        # BUG#3: a LIMIT 0 probe degrades the string column to object; LIMIT 1
-        # reports the real dtype, matching full execution.
+    def test_string_column_dtype_matches_full(self, typed):
+        # BUG#3: a LIMIT 0 probe degrades string columns to object; LIMIT 1
+        # reports the same dtype as full execution. Version-agnostic invariant:
+        # on pandas 3.x full execution gives StringDtype (and a LIMIT 0 probe
+        # would wrongly give object -> this would fail); on pandas 2.x both are
+        # object. Either way optimized must equal full execution.
         path, _ = typed
         opt = dict(self._flt(path).dtypes)
         full = dict(self._flt(path)._get_df().dtypes)
-        assert opt["s"] != object, f"string column degraded to object: {opt['s']}"
-        assert opt["s"] == full["s"]
+        assert opt["s"] == full["s"], (opt["s"], full["s"])
 
     def test_dtypes_uses_limit1_probe_not_execute(self, typed):
         path, _ = typed
@@ -268,7 +270,7 @@ class TestDtypesProbeLimit1:
             dtypes = ds.dtypes
             mock_exec.assert_not_called()
         assert any("LIMIT 1" in s for s in sqls), f"expected a LIMIT 1 probe, got: {sqls}"
-        assert dtypes["s"] != object
+        assert list(dtypes.index) == ["i", "f", "s", "b", "dt"]
         assert ds._cached_result is None, "dtypes access must not materialize the result"
 
     def test_sort_then_dtypes_match_full(self, typed):
@@ -276,14 +278,12 @@ class TestDtypesProbeLimit1:
         opt = dict(DataStore.from_file(path).sort_values("f").dtypes)
         full = dict(DataStore.from_file(path).sort_values("f")._get_df().dtypes)
         assert opt == full, (opt, full)
-        assert opt["s"] != object
 
     def test_head_then_dtypes_match_full(self, typed):
         path, _ = typed
         opt = dict(DataStore.from_file(path).head(3).dtypes)
         full = dict(DataStore.from_file(path).head(3)._get_df().dtypes)
         assert opt == full, (opt, full)
-        assert opt["s"] != object
 
     def test_empty_result_dtypes_match_full(self, typed):
         path, _ = typed
@@ -316,10 +316,13 @@ class TestDtypesNullableInteger:
         path = self._write(tmp_path, [1, None, 3, None, 5])
         # filter on the OTHER column so the null rows of `ni` are kept
         flt = lambda: DataStore.from_file(path)[DataStore.from_file(path)["s"] != "zzz"]
-        opt = dict(flt().dtypes)
+        ds = flt()
+        with patch.object(ds, "_execute", wraps=ds._execute) as mock_exec:
+            opt = dict(ds.dtypes)
+            # nulls present -> COUNT(nulls) > 0 -> probe untrusted -> fall back
+            mock_exec.assert_called()
         full = dict(flt()._get_df().dtypes)
         assert opt == full, (opt, full)
-        assert str(opt["ni"]) == "Int64", "nulls present -> nullable extension dtype"
 
     def test_nullable_int_without_nulls_keeps_optimization(self, tmp_path):
         path = self._write(tmp_path, [1, None, 3, None, 5])
@@ -330,10 +333,9 @@ class TestDtypesNullableInteger:
         ds = DataStore.from_file(path)[DataStore.from_file(path)["ni"] >= 3]
         with patch.object(ds, "_execute", wraps=ds._execute) as mock_exec:
             opt = dict(ds.dtypes)
-            # COUNT(nulls)==0 -> probe trusted, no full materialization
+            # COUNT(nulls) == 0 -> probe trusted, no full materialization
             mock_exec.assert_not_called()
         assert opt == full, (opt, full)
-        assert str(opt["ni"]) == "int64", "no nulls -> plain numpy dtype"
 
 
 class TestDtypesColumnAlteringFallback:

--- a/datastore/tests/test_lazy_metadata_pushdown.py
+++ b/datastore/tests/test_lazy_metadata_pushdown.py
@@ -1,0 +1,147 @@
+"""
+Tests for lazy metadata access on NON-pristine but SQL-pushdownable pipelines.
+
+Extends the pristine-source optimization (test_pristine_metadata_optimization.py)
+to filtered / projected pipelines: `.columns` / `.dtypes` must resolve via a
+``SELECT ... LIMIT 0`` schema probe, and `.shape` / `.index` via ``COUNT(*)``,
+instead of materializing the full result through ``_execute()``. Non-pushdownable
+pipelines and custom/group indexes keep the full-execution fallback.
+
+Mirrors the mock + SQL-capture style of test_pristine_metadata_optimization.py.
+"""
+
+from unittest.mock import patch
+
+import numpy as np
+import pandas as pd
+import pytest
+
+from datastore import DataStore
+
+
+def _make_parquet(tmp_path):
+    df = pd.DataFrame({
+        "id": range(1000),
+        "value": np.random.randn(1000),
+        "category": np.random.choice(["A", "B", "C"], 1000),
+    })
+    path = str(tmp_path / "events.parquet")
+    df.to_parquet(path, index=False)
+    return path, df
+
+
+class TestNonPristinePushdownMetadata:
+    """A filtered (non-pristine, SQL-pushdownable) pipeline must read metadata
+    without materializing the result via _execute()."""
+
+    @pytest.fixture
+    def filtered(self, tmp_path):
+        path, df = _make_parquet(tmp_path)
+        ds = DataStore.from_file(path)
+        ds2 = ds[ds["value"] > 0]                 # pushdownable filter -> non-pristine
+        pd_result = df[df["value"] > 0]
+        return ds2, pd_result
+
+    def test_precondition_non_pristine_but_pushdownable(self, filtered):
+        ds2, _ = filtered
+        assert ds2._get_source_df_if_pristine() is None
+        assert ds2._is_pristine_sql_source() is False
+        assert ds2._can_sql_pushdown() is True
+
+    def test_columns_uses_limit0_not_execute(self, filtered):
+        ds2, pd_result = filtered
+        ds2.connect()
+        sqls = []
+        original_execute = ds2._executor.execute
+
+        def capture_sql(sql, *args, **kwargs):
+            sqls.append(sql)
+            return original_execute(sql, *args, **kwargs)
+
+        with patch.object(ds2, "_execute", wraps=ds2._execute) as mock_exec, \
+                patch.object(ds2._executor, "execute", side_effect=capture_sql):
+            cols = ds2.columns
+            mock_exec.assert_not_called()
+
+        assert list(cols) == list(pd_result.columns)
+        assert any("LIMIT 0" in s for s in sqls), f"expected a LIMIT 0 probe, got: {sqls}"
+
+    def test_dtypes_uses_limit0_not_execute(self, filtered):
+        ds2, pd_result = filtered
+        ds2.connect()
+        sqls = []
+        original_execute = ds2._executor.execute
+
+        def capture_sql(sql, *args, **kwargs):
+            sqls.append(sql)
+            return original_execute(sql, *args, **kwargs)
+
+        with patch.object(ds2, "_execute", wraps=ds2._execute) as mock_exec, \
+                patch.object(ds2._executor, "execute", side_effect=capture_sql):
+            dtypes = ds2.dtypes
+            mock_exec.assert_not_called()
+
+        assert list(dtypes.index) == list(pd_result.columns)
+        assert any("LIMIT 0" in s for s in sqls), f"expected a LIMIT 0 probe, got: {sqls}"
+
+    def test_shape_uses_count_not_execute(self, filtered):
+        ds2, pd_result = filtered
+        with patch.object(ds2, "count_rows", wraps=ds2.count_rows) as mock_count, \
+                patch.object(ds2, "_execute", wraps=ds2._execute) as mock_exec:
+            shape = ds2.shape
+            mock_count.assert_called()
+            mock_exec.assert_not_called()
+        assert shape == pd_result.shape
+
+    def test_index_is_rangeindex_from_count_not_execute(self, filtered):
+        ds2, pd_result = filtered
+        with patch.object(ds2, "count_rows", wraps=ds2.count_rows) as mock_count, \
+                patch.object(ds2, "_execute", wraps=ds2._execute) as mock_exec:
+            idx = ds2.index
+            mock_count.assert_called()
+            mock_exec.assert_not_called()
+        assert isinstance(idx, pd.RangeIndex)
+        assert len(idx) == len(pd_result)
+
+    def test_metadata_access_does_not_cache(self, filtered):
+        ds2, _ = filtered
+        assert ds2._cached_result is None
+        _ = ds2.columns
+        _ = ds2.dtypes
+        _ = ds2.shape
+        _ = ds2.index
+        assert ds2._cached_result is None, "metadata access must not materialize the result"
+
+
+class TestProjectionColumnsCorrectness:
+    """A column-reducing projection is NOT reflected in the LIMIT 0 probe SQL
+    (it's a post-SQL lazy op), so the probe's columns differ from the projected
+    set and `.columns` falls back to execution. It must still report the
+    projected columns -- regression guard for the lazy-metadata optimization."""
+
+    def test_projection_columns_correct(self, tmp_path):
+        path, df = _make_parquet(tmp_path)
+        ds = DataStore.from_file(path)[["id", "category"]]
+        pd_result = df[["id", "category"]]
+        assert list(ds.columns) == list(pd_result.columns) == ["id", "category"]
+
+
+class TestIndexFallback:
+    """`.index` only takes the RangeIndex shortcut for default-indexed pipelines;
+    a custom (set_index) index must fall back and stay correct."""
+
+    @pytest.fixture
+    def df(self):
+        return pd.DataFrame({
+            "id": [10, 20, 30, 40, 50],
+            "score": [90.5, 85.0, 92.3, 78.0, 95.5],
+        })
+
+    def test_set_index_does_not_use_rangeindex_shortcut(self, tmp_path, df):
+        path = str(tmp_path / "idx.parquet")
+        df.to_parquet(path, index=False)
+        ds = DataStore.from_file(path).set_index("id")
+        pd_result = df.set_index("id")
+        idx = ds.index
+        # must reflect the real index values (10..50), not a degenerate RangeIndex(0..n)
+        assert list(idx) == list(pd_result.index)

--- a/datastore/tests/test_pristine_metadata_optimization.py
+++ b/datastore/tests/test_pristine_metadata_optimization.py
@@ -691,11 +691,28 @@ class TestRemoteDescribeNotSelectStar:
         assert ds._cached_result is None
 
     def test_after_filter_remote_uses_execute(self, clickhouse_connection):
-        """After filter on remote source, metadata MUST go through execution."""
+        """After filter on remote source, metadata MUST go through execution,
+        never a LIMIT 0 schema probe.
+
+        The probe wraps the whole pipeline in a nested subquery
+        ``SELECT * FROM (... remote ...) LIMIT 0``; chDB HANGS on nested
+        subqueries over remote() sources -- the very reason count_rows()/count()
+        fall back to flat SQL for remote. So filtered-remote metadata must fall
+        back to flat execution and must not issue the nested probe. Regression
+        guard for the macOS CI hang.
+        """
         ds = clickhouse_connection.table("system", "tables")
         ds2 = ds[ds["database"] == "system"]
         assert ds2._is_pristine_sql_source() is False
-        # Accessing shape on filtered remote source should work correctly
-        rows, ncols = ds2.shape
+        assert ds2._is_remote_source() is True
+
+        # .shape -> len(.columns); .columns must NOT call _probe_schema() (the
+        # nested LIMIT 0 subquery that hangs chDB on remote sources). It must
+        # fall back to flat execution instead.
+        with patch.object(
+            ds2, "_probe_schema", wraps=ds2._probe_schema
+        ) as mock_probe:
+            rows, ncols = ds2.shape
+            mock_probe.assert_not_called()
         assert rows > 0
         assert ncols > 5


### PR DESCRIPTION


<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/cancel_and_rerun_workflow_lambda/app.py
-->
### Changelog category (leave one):
- Performance Improvement


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
datastore: .columns, .dtypes, .shape and .index on lazy, SQL-pushdownable pipelines now resolve via a LIMIT 0 schema probe and COUNT(*) instead of materializing the full result to pandas.

What

Metadata accessors on a lazy DataStore no longer execute the whole pipeline just to answer a schema/shape question:
- .columns / .dtypes → SELECT … LIMIT 0 schema probe (zero rows transferred).
- .shape / .index → COUNT(*) for the row count (+ the probe for the column count).

Closes #590 

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->


> Information about CI checks: https://clickhouse.com/docs/en/development/continuous-integration/

<details>
    <summary>CI Settings</summary>

**NOTE:** If your merge the PR with modified CI you **MUST KNOW** what you are doing
**NOTE:** Checked options will be applied if set before CI RunConfig/PrepareRunConfig step

#### Run these jobs only (required builds will be added automatically):
- [ ] <!---ci_include_integration--> Integration Tests
- [ ] <!---ci_include_stateless--> Stateless tests
- [ ] <!---ci_include_stateful--> Stateful tests
- [ ] <!---ci_include_unit--> Unit tests
- [ ] <!---ci_include_performance--> Performance tests
- [ ] <!---ci_include_aarch64--> All with aarch64
- [ ] <!---ci_include_asan--> All with ASAN
- [ ] <!---ci_include_tsan--> All with TSAN
- [ ] <!---ci_include_analyzer--> All with Analyzer
- [ ] <!---ci_include_azure --> All with Azure
- [ ] <!---ci_include_KEYWORD--> Add your option here

#### Deny these jobs:
- [ ] <!---ci_exclude_fast--> Fast test
- [ ] <!---ci_exclude_integration--> Integration Tests
- [ ] <!---ci_exclude_stateless--> Stateless tests
- [ ] <!---ci_exclude_stateful--> Stateful tests
- [ ] <!---ci_exclude_performance--> Performance tests
- [ ] <!---ci_exclude_asan--> All with ASAN
- [ ] <!---ci_exclude_tsan--> All with TSAN
- [ ] <!---ci_exclude_msan--> All with MSAN
- [ ] <!---ci_exclude_ubsan--> All with UBSAN
- [ ] <!---ci_exclude_coverage--> All with Coverage
- [ ] <!---ci_exclude_aarch64--> All with Aarch64

#### Extra options:
- [ ] <!---do_not_test--> do not test (only style check)
- [ ] <!---no_merge_commit--> disable merge-commit (no merge from master before tests)
- [ ] <!---no_ci_cache--> disable CI cache (job reuse)

#### Only specified batches in multi-batch jobs:
- [ ] <!---batch_0--> 1
- [ ] <!---batch_1--> 2
- [ ] <!---batch_2--> 3
- [ ] <!---batch_3--> 4

</details>
