### PR TITLE
Support writing an in-memory DataFrame to ClickHouse via to_clickhouse

### DIFF
--- a/datastore/core.py
+++ b/datastore/core.py
@@ -5316,10 +5316,11 @@ class DataStore(PandasCompatMixin):
            native connection (source → target, one hop). chDB only ships the
            statement; rows do not round-trip through it.
         3. **DataFrame upload** — pipeline contains Pandas-only ops, OR the
-           DataStore wraps a pure in-memory DataFrame (``source_type ==
-           "dataframe"``) → _execute() locally, then upload via the Python()
-           table function. For a pure-DataFrame source an explicit ``host`` is
-           required (there is no source server to default to); pass
+           DataStore wraps a pure in-memory DataFrame (``DataStore(df)`` or
+           ``DataStore.from_df`` / ``from_dataframe``) → _execute() locally,
+           then upload via the Python() table function. For a pure-DataFrame
+           source an explicit ``host`` is required (there is no source server
+           to default to); pass
            ``host``/``user``/``password`` (and ``secure=True`` for ClickHouse
            Cloud, or use a ``host:9440`` / ``*.clickhouse.cloud`` host which
            auto-enables TLS).
@@ -5371,18 +5372,30 @@ class DataStore(PandasCompatMixin):
                 f"Must be one of: 'fail', 'replace', 'append'"
             )
 
-        # A pure in-memory DataFrame (source_type == "dataframe") has no source
-        # server, so writeback must be told where to go via an explicit target.
-        # When one is given we route through the normal DataFrame-upload path
-        # (a df pipeline is never SQL-pushable, so _to_clickhouse_impl already
-        # materializes locally and uploads via the Python(df) table function);
-        # the only server involved is the ClickHouse target, so the source is
-        # treated as ClickHouse for guard/adapter selection. This is scoped to
-        # to_clickhouse on purpose — create_view / create_materialized_view /
-        # save() need a server-side SQL source a local df cannot provide, and
-        # non-ClickHouse sources (mysql/postgresql) remain rejected by
-        # _require_clickhouse_for_writeback.
-        writing_local_df = (self.source_type or "").lower() == "dataframe"
+        # A DataStore wrapping a pure in-memory DataFrame has no source server
+        # of its own, so writeback must be told where to go via an explicit
+        # target. Both ways of wrapping a frame qualify: the DataStore(df)
+        # constructor (source_type == "dataframe") and the from_df /
+        # from_dataframe factories (default source_type, frame stashed in
+        # _source_df). A pandas-only op on a *ClickHouse-sourced* store also
+        # caches its result into _source_df, but that store keeps its source
+        # host — so gate on "has no source host" to tell "local frame, no
+        # server" apart from "remote source, locally materialized" (the latter
+        # must keep defaulting its target to the source server, not error for a
+        # missing host). When a target is given we route through the normal
+        # DataFrame-upload path (such a pipeline is never SQL-pushable, so
+        # _to_clickhouse_impl materializes locally and uploads via the
+        # Python(df) table function); the only server involved is the
+        # ClickHouse target, so the source is treated as ClickHouse for
+        # guard/adapter selection. This is scoped to to_clickhouse on purpose —
+        # create_view / create_materialized_view / save() need a server-side
+        # SQL source a local df cannot provide, and non-ClickHouse sources
+        # (mysql/postgresql) remain rejected by _require_clickhouse_for_writeback.
+        wraps_local_df = (
+            (self.source_type or "").lower() == "dataframe"
+            or getattr(self, "_source_df", None) is not None
+        )
+        writing_local_df = wraps_local_df and not self._remote_params.get("host")
         if writing_local_df and not host:
             # `not host` (rather than `is None`) so an empty/blank host string
             # gets the clear message here instead of a generic "no connection

--- a/datastore/core.py
+++ b/datastore/core.py
@@ -5315,8 +5315,14 @@ class DataStore(PandasCompatMixin):
            remote(source, ...) so the target pulls source rows over its own
            native connection (source → target, one hop). chDB only ships the
            statement; rows do not round-trip through it.
-        3. **DataFrame upload** — pipeline contains Pandas-only ops →
-           _execute() locally, then upload via the Python() table function.
+        3. **DataFrame upload** — pipeline contains Pandas-only ops, OR the
+           DataStore wraps a pure in-memory DataFrame (``source_type ==
+           "dataframe"``) → _execute() locally, then upload via the Python()
+           table function. For a pure-DataFrame source an explicit ``host`` is
+           required (there is no source server to default to); pass
+           ``host``/``user``/``password`` (and ``secure=True`` for ClickHouse
+           Cloud, or use a ``host:9440`` / ``*.clickhouse.cloud`` host which
+           auto-enables TLS).
 
         For ``if_exists="replace"`` with the pure-remote path,
         ``CREATE OR REPLACE TABLE … AS SELECT`` is used for atomic
@@ -5341,12 +5347,16 @@ class DataStore(PandasCompatMixin):
             partition_by: PARTITION BY expression
             enable_schema_evolution: Auto-adapt column differences (append only)
             host: Target ClickHouse host:port. Defaults to source server.
+                Required when this DataStore wraps a pure in-memory DataFrame
+                (no source server to default to).
             user: Target server user. Defaults to source connection user.
             password: Target server password. Defaults to source connection password.
             secure: Use encrypted connection to target server.
 
         Raises:
             ValueError: If if_exists is not one of "fail"/"replace"/"append".
+            DataStoreError: If this DataStore wraps a pure in-memory DataFrame
+                and no explicit ``host`` is given.
             QueryError: For the DataFrame-upload path with if_exists="replace"
                 when the target already exists (a non-atomic overwrite is
                 refused).
@@ -5361,7 +5371,35 @@ class DataStore(PandasCompatMixin):
                 f"Must be one of: 'fail', 'replace', 'append'"
             )
 
-        with self._target_server_context(host, user, password, secure):
+        # A pure in-memory DataFrame (source_type == "dataframe") has no source
+        # server, so writeback must be told where to go via an explicit target.
+        # When one is given we route through the normal DataFrame-upload path
+        # (a df pipeline is never SQL-pushable, so _to_clickhouse_impl already
+        # materializes locally and uploads via the Python(df) table function);
+        # the only server involved is the ClickHouse target, so the source is
+        # treated as ClickHouse for guard/adapter selection. This is scoped to
+        # to_clickhouse on purpose — create_view / create_materialized_view /
+        # save() need a server-side SQL source a local df cannot provide, and
+        # non-ClickHouse sources (mysql/postgresql) remain rejected by
+        # _require_clickhouse_for_writeback.
+        writing_local_df = (self.source_type or "").lower() == "dataframe"
+        if writing_local_df and not host:
+            # `not host` (rather than `is None`) so an empty/blank host string
+            # gets the clear message here instead of a generic "no connection
+            # info" failure deeper in the upload path.
+            from .exceptions import DataStoreError
+
+            raise DataStoreError(
+                "Writing an in-memory DataFrame to ClickHouse needs an explicit "
+                "target server: to_clickhouse(name, host=..., user=..., "
+                "password=...). A pure DataFrame DataStore has no source server "
+                "to default to."
+            )
+
+        with self._target_server_context(
+            host, user, password, secure,
+            as_clickhouse_target=writing_local_df,
+        ):
             self._to_clickhouse_impl(
                 name=name,
                 if_exists=if_exists,
@@ -7910,6 +7948,7 @@ class DataStore(PandasCompatMixin):
         user: Optional[str] = None,
         password: Optional[str] = None,
         secure: bool = False,
+        as_clickhouse_target: bool = False,
     ):
         """Temporarily override ``_remote_params`` so downstream helpers
         (``_execute_remote_ddl``, ``_get_adapter``, etc.) operate against
@@ -7923,8 +7962,16 @@ class DataStore(PandasCompatMixin):
         create_view / create_materialized_view docstrings promise; falling back
         to "default"/"" would silently break writeback whenever the source uses
         non-default credentials.
+
+        ``as_clickhouse_target`` additionally overrides ``source_type`` to
+        "clickhouse" for the duration. The writeback guard and adapter machinery
+        are keyed on the *source* type; this makes them treat the explicitly
+        given target as a ClickHouse server. Used by ``to_clickhouse`` when
+        uploading a pure in-memory DataFrame (``source_type == "dataframe"``),
+        whose only server in play is the target.
         """
         original = self._remote_params.copy()
+        original_source_type = self.source_type
         # Omitted creds inherit the source connection's values. Use `or` (not a
         # dict default) so a source connection that stored user/password as
         # None — key present, value None — still resolves to valid auth
@@ -7961,10 +8008,13 @@ class DataStore(PandasCompatMixin):
             }
 
         self._remote_params = new_params
+        if as_clickhouse_target:
+            self.source_type = "clickhouse"
         try:
             yield
         finally:
             self._remote_params = original
+            self.source_type = original_source_type
 
     def _require_connection_params(self):
         """
@@ -7989,8 +8039,14 @@ class DataStore(PandasCompatMixin):
         uploads). For a non-ClickHouse source the adapter would emit
         ``mysql()`` / ``postgresql()`` / ... which don't accept the ``query=``
         form, surfacing as a confusing runtime error. Fail early and clearly
-        instead. (Pure-DataFrame stores are caught earlier by
-        ``_require_connection_params`` — they have no host.)
+        instead.
+
+        Pure-DataFrame stores (source_type == "dataframe") still reach this
+        guard via create_view / create_materialized_view and are rejected here
+        (a local df has no server-side SQL source for a view/MV definition).
+        to_clickhouse handles them separately: it uploads the df to the
+        explicit target and runs this guard with source_type overridden to
+        "clickhouse" (see _target_server_context's as_clickhouse_target).
         """
         if (self.source_type or "").lower() not in _CLICKHOUSE_SOURCE_TYPES:
             raise QueryError(

--- a/datastore/tests/test_writeback.py
+++ b/datastore/tests/test_writeback.py
@@ -645,6 +645,270 @@ class TestToClickHouseDataFrameUpload:
 
 
 # ============================================================================
+# to_clickhouse — pure in-memory DataFrame source (no ClickHouse connection)
+# ============================================================================
+
+
+def _local_df():
+    """A small in-memory DataFrame standing in for 'data the user built in
+    Python', with no ClickHouse connection behind it."""
+    return pd.DataFrame({
+        "city": ["Beijing", "Shanghai", "Guangzhou"],
+        "amount": [100.0, 300.0, 400.0],
+        "status": ["completed", "pending", "completed"],
+    })
+
+
+class TestToClickHouseLocalDataFrame:
+    """A DataStore wrapping a pure in-memory DataFrame (source_type ==
+    'dataframe') persists to ClickHouse when an explicit target server is
+    given. The data is materialized locally and uploaded via Python(df) — the
+    same DataFrame-upload path a Pandas-only pipeline takes, just with no
+    source server in play."""
+
+    def test_requires_explicit_host(self):
+        """No target host → there is no server to write to. Must raise a clear
+        DataStoreError (not silently no-op, not the generic source guard).
+        Both an omitted host and a blank host string are rejected the same way."""
+        ds = DataStore(_local_df())
+        with pytest.raises(DataStoreError, match="in-memory DataFrame"):
+            ds.to_clickhouse(f"{DATABASE}.wb_localdf_nohost")
+        with pytest.raises(DataStoreError, match="in-memory DataFrame"):
+            ds.to_clickhouse(f"{DATABASE}.wb_localdf_nohost",
+                             host="", user=USER, password=PASSWORD)
+        # the failed attempts must not mutate the store's identity
+        assert ds.source_type == "dataframe"
+
+    def test_create_view_local_dataframe_with_host_still_rejected(self):
+        """Scope guard: the relaxation is for to_clickhouse only. create_view
+        on a pure df is rejected even WITH an explicit host — a local df has no
+        server-side SQL source for a view definition."""
+        ds = DataStore(_local_df())
+        with pytest.raises(QueryError, match="requires a ClickHouse connection"):
+            ds.create_view(f"{DATABASE}.wb_localdf_view",
+                           host=HOST, user=USER, password=PASSWORD)
+        assert ds.source_type == "dataframe"
+
+    def test_create_materialized_view_local_dataframe_with_host_still_rejected(self):
+        """Scope guard: create_materialized_view on a pure df is rejected even
+        WITH an explicit host."""
+        ds = DataStore(_local_df())
+        with pytest.raises(QueryError, match="requires a ClickHouse connection"):
+            ds.create_materialized_view(
+                name=f"{DATABASE}.wb_localdf_mv",
+                to=f"{DATABASE}.wb_localdf_mv_tgt",
+                host=HOST, user=USER, password=PASSWORD,
+            )
+        assert ds.source_type == "dataframe"
+
+    def test_save_view_and_mv_local_dataframe_rejected(self):
+        """Scope guard: save() has no host param (it writes to the source
+        server), so a pure df has nowhere to go — save(type='view'/'
+        materialized_view') is rejected. Only to_clickhouse (data upload) is
+        relaxed for local DataFrames."""
+        ds = DataStore(_local_df())
+        with pytest.raises(DataStoreError):
+            ds.save(f"{DATABASE}.wb_localdf_save_view", type="view")
+        with pytest.raises(DataStoreError):
+            ds.save(f"{DATABASE}.wb_localdf_save_mv",
+                    type="materialized_view", to=f"{DATABASE}.wb_localdf_save_tgt")
+        assert ds.source_type == "dataframe"
+
+    def test_fail_creates_and_inserts_exact_values(self):
+        target = "wb_localdf_fail"
+        _drop(target)
+        try:
+            DataStore(_local_df()).to_clickhouse(
+                f"{DATABASE}.{target}",
+                host=HOST, user=USER, password=PASSWORD, order_by="city",
+            )
+            assert _count(target) == 3
+            got = _select_all(target, order_by="city")
+            assert list(got["city"]) == ["Beijing", "Guangzhou", "Shanghai"]
+            assert list(got["amount"]) == [100.0, 400.0, 300.0]
+            assert list(got["status"]) == ["completed", "completed", "pending"]
+        finally:
+            _drop(target)
+
+    def test_fail_when_target_exists_raises(self):
+        target = "wb_localdf_exists"
+        _drop(target)
+        try:
+            DataStore(_local_df()).to_clickhouse(
+                f"{DATABASE}.{target}",
+                host=HOST, user=USER, password=PASSWORD, order_by="city",
+            )
+            with pytest.raises(ExecutionError, match="already exists"):
+                DataStore(_local_df()).to_clickhouse(
+                    f"{DATABASE}.{target}",
+                    host=HOST, user=USER, password=PASSWORD, order_by="city",
+                )
+        finally:
+            _drop(target)
+
+    def test_replace_new_creates_then_refuses_existing(self):
+        """replace + target absent → create+insert; replace + target present →
+        the non-atomic upload path refuses rather than risk a data-loss window,
+        and the temporary source_type override is restored after the raise."""
+        target = "wb_localdf_replace"
+        _drop(target)
+        try:
+            DataStore(_local_df()).to_clickhouse(
+                f"{DATABASE}.{target}", if_exists="replace",
+                host=HOST, user=USER, password=PASSWORD, order_by="city",
+            )
+            assert _count(target) == 3
+            got = _select_all(target, order_by="city")
+            assert list(got["city"]) == ["Beijing", "Guangzhou", "Shanghai"]
+            assert list(got["amount"]) == [100.0, 400.0, 300.0]
+
+            ds = DataStore(_local_df())
+            with pytest.raises(QueryError, match="Cannot atomically replace"):
+                ds.to_clickhouse(
+                    f"{DATABASE}.{target}", if_exists="replace",
+                    host=HOST, user=USER, password=PASSWORD, order_by="city",
+                )
+            assert ds.source_type == "dataframe"   # restored after exception
+            assert _count(target) == 3             # original data untouched
+        finally:
+            _drop(target)
+
+    def test_append_accumulates(self):
+        target = "wb_localdf_append"
+        _drop(target)
+        try:
+            DataStore(_local_df()).to_clickhouse(
+                f"{DATABASE}.{target}",
+                host=HOST, user=USER, password=PASSWORD, order_by="city",
+            )
+            DataStore(_local_df()).to_clickhouse(
+                f"{DATABASE}.{target}", if_exists="append",
+                host=HOST, user=USER, password=PASSWORD,
+            )
+            assert _count(target) == 6
+            got = _select_all(target, order_by="city, amount")
+            # each of the 3 source rows now appears twice
+            assert list(got["city"]) == [
+                "Beijing", "Beijing", "Guangzhou", "Guangzhou",
+                "Shanghai", "Shanghai",
+            ]
+            assert list(got["amount"]) == [100.0, 100.0, 400.0, 400.0, 300.0, 300.0]
+        finally:
+            _drop(target)
+
+    def test_engine_order_by_list_and_partition_by(self):
+        target = "wb_localdf_engine"
+        _drop(target)
+        try:
+            DataStore(_local_df()).to_clickhouse(
+                f"{DATABASE}.{target}",
+                host=HOST, user=USER, password=PASSWORD,
+                engine="MergeTree()", order_by=["city", "status"],
+                partition_by="status",
+            )
+            assert _count(target) == 3
+            engine_full = str(_q(
+                f"SELECT engine_full FROM remote('{HOST}','system','tables',"
+                f"'{USER}','{PASSWORD}') "
+                f"WHERE database='{DATABASE}' AND name='{target}'"
+            ).iloc[0, 0]).upper()
+            assert "PARTITION BY" in engine_full
+            assert "ORDER BY" in engine_full
+            got = _select_all(target, order_by="city")
+            assert list(got["city"]) == ["Beijing", "Guangzhou", "Shanghai"]
+            assert list(got["amount"]) == [100.0, 400.0, 300.0]
+            assert list(got["status"]) == ["completed", "completed", "pending"]
+        finally:
+            _drop(target)
+
+    def test_index_true_with_index_label(self):
+        target = "wb_localdf_index"
+        _drop(target)
+        try:
+            df = _local_df().set_index(pd.Index([10, 20, 30], name="rid"))
+            DataStore(df).to_clickhouse(
+                f"{DATABASE}.{target}", index=True, index_label="row_id",
+                host=HOST, user=USER, password=PASSWORD, order_by="row_id",
+            )
+            cols = dict(_columns(target))
+            assert "row_id" in cols and "rid" not in cols
+            got = _select_all(target, order_by="row_id")
+            assert list(got["row_id"]) == [10, 20, 30]
+        finally:
+            _drop(target)
+
+    def test_pandas_transform_on_local_df_flows_through(self):
+        """A computed column added via a Pandas transform on a local df still
+        lands on the server (it's all the same upload path)."""
+        target = "wb_localdf_computed"
+        _drop(target)
+        try:
+            ds = DataStore(_local_df()).transform(
+                lambda df: df.assign(amount_x2=df["amount"] * 2)
+            )
+            ds.to_clickhouse(
+                f"{DATABASE}.{target}",
+                host=HOST, user=USER, password=PASSWORD, order_by="city",
+            )
+            got = _select_all(target, order_by="city")
+            assert "amount_x2" in got.columns
+            assert all(got["amount_x2"] == got["amount"] * 2)
+        finally:
+            _drop(target)
+
+    def test_source_type_restored_and_store_still_usable(self):
+        """The temporary source_type override must not leak: the store is still
+        a 'dataframe' store afterwards and remains usable as a local df."""
+        target = "wb_localdf_restore"
+        _drop(target)
+        try:
+            ds = DataStore(_local_df())
+            assert ds.source_type == "dataframe"
+            ds.to_clickhouse(
+                f"{DATABASE}.{target}",
+                host=HOST, user=USER, password=PASSWORD, order_by="city",
+            )
+            assert ds.source_type == "dataframe"
+            assert len(ds) == 3
+        finally:
+            _drop(target)
+
+
+@requires_target
+class TestToClickHouseLocalDataFrameCrossServer:
+    """Persist a pure local DataFrame onto a *different* server — the
+    'push to ClickHouse Cloud' shape: a distinct host with distinct
+    credentials, reached over the network."""
+
+    def test_uploads_to_target_server_only(self):
+        target = "wb_localdf_cross"
+        _drop(target, db=TARGET.database, srv=TARGET)
+        try:
+            DataStore(_local_df()).to_clickhouse(
+                f"{TARGET.database}.{target}",
+                host=TARGET.host, user=TARGET.user, password=TARGET.password,
+                order_by="city",
+            )
+            assert _count(target, db=TARGET.database, srv=TARGET) == 3
+            got = _select_all(
+                target, db=TARGET.database, order_by="city", srv=TARGET
+            )
+            assert list(got["city"]) == ["Beijing", "Guangzhou", "Shanghai"]
+            assert list(got["amount"]) == [100.0, 400.0, 300.0]
+            assert list(got["status"]) == ["completed", "completed", "pending"]
+
+            # The table must NOT have been created on the source server.
+            on_source = _q(
+                f"SELECT count() FROM remote('{HOST}','system','tables',"
+                f"'{USER}','{PASSWORD}') WHERE database='{TARGET.database}' "
+                f"AND name='{target}'"
+            ).iloc[0, 0]
+            assert int(on_source) == 0
+        finally:
+            _drop(target, db=TARGET.database, srv=TARGET)
+
+
+# ============================================================================
 # Schema evolution
 # ============================================================================
 

--- a/datastore/tests/test_writeback.py
+++ b/datastore/tests/test_writeback.py
@@ -873,6 +873,39 @@ class TestToClickHouseLocalDataFrame:
         finally:
             _drop(target)
 
+    def test_from_df_and_from_dataframe_factories(self):
+        """A DataFrame wrapped via the from_df / from_dataframe factories (which
+        keep source_type='chdb' and stash the frame in _source_df, unlike the
+        DataStore(df) constructor which uses source_type='dataframe') must write
+        just the same. Both representations are 'a local frame with no source
+        server', so to_clickhouse routes both through the upload path."""
+        for factory in (DataStore.from_df, DataStore.from_dataframe):
+            target = f"wb_localdf_{factory.__name__}"
+            _drop(target)
+            try:
+                ds = factory(_local_df())
+                # sanity: this is the non-'dataframe' representation
+                assert ds.source_type != "dataframe"
+                ds.to_clickhouse(
+                    f"{DATABASE}.{target}",
+                    host=HOST, user=USER, password=PASSWORD, order_by="city",
+                )
+                got = _select_all(target, order_by="city")
+                assert len(got) == 3
+                assert list(got["city"]) == ["Beijing", "Guangzhou", "Shanghai"]
+                assert list(got["amount"]) == [100.0, 400.0, 300.0]
+                assert list(got["status"]) == ["completed", "completed", "pending"]
+                # the temporary source_type override must be restored
+                assert ds.source_type != "dataframe"
+            finally:
+                _drop(target)
+
+    def test_from_df_factory_requires_explicit_host(self):
+        """The no-host guard applies to the from_df representation too."""
+        ds = DataStore.from_df(_local_df())
+        with pytest.raises(DataStoreError, match="in-memory DataFrame"):
+            ds.to_clickhouse(f"{DATABASE}.wb_localdf_fromdf_nohost")
+
 
 @requires_target
 class TestToClickHouseLocalDataFrameCrossServer:


### PR DESCRIPTION
## What

`DataStore.to_clickhouse()` now accepts a **pure in-memory pandas DataFrame** (`source_type == "dataframe"`) as the source, when an explicit target `host` is given. Previously this was rejected even with a host.

```python
import pandas as pd
from datastore import DataStore

df = pd.DataFrame({"city": ["Beijing", "Shanghai"], "amount": [100.0, 300.0]})

DataStore(df).to_clickhouse(
    "analytics.sales",
    host="myorg.region.aws.clickhouse.cloud",   # *.clickhouse.cloud / :9440 auto-enables TLS
    user="default", password="...",
    order_by="city",
)
```

## Why

The DataFrame-upload path (`_execute()` locally → `DESCRIBE Python(df)` → `INSERT … FROM Python(df)`) never needed a ClickHouse *source* — it already runs for ClickHouse-sourced stores whose pipeline has Pandas-only ops. A pure-DataFrame store was blocked only by two couplings keyed on the **source** type rather than the **target**:

1. the `_require_clickhouse_for_writeback` guard (rejects `source_type != clickhouse`), and
2. `_get_adapter()` (no adapter for `"dataframe"`).

The `host=` parameter sets *where* to write but didn't change either decision, so an explicit ClickHouse target was ignored. This is a guard/adapter coupling, not a technical limit.

## How

`to_clickhouse()` detects a pure-DataFrame source and, when an explicit host is given, runs the existing DataFrame-upload path with the target treated as ClickHouse — via a scoped `source_type` override in `_target_server_context` that is **restored even on exception**. An explicit, non-empty host is required (a df has no source server to default to); omitting it raises a clear `DataStoreError`.

**Scope is deliberately narrow:**
- `create_view` / `create_materialized_view` / `save()` still reject a pure df — they need a server-side SQL source a local df cannot provide (a VIEW stores a query, an MV is an insert-trigger on a server-side table; `Python(df)` is local-only and can't be persisted into a server-side definition).
- non-ClickHouse sources (mysql/postgresql) remain rejected by `_require_clickhouse_for_writeback`.

## Tests

New `TestToClickHouseLocalDataFrame` (+ a cross-server case), all asserting exact values and row order per the repo's testing principles:
- `fail` / `replace` (new + refuse-existing) / `append`, with value + order checks
- `engine` / `order_by` (list) / `partition_by`
- `index=True` + `index_label`
- a Pandas `transform` on a local df
- no-host **and** empty-host guard → `DataStoreError`
- `source_type` restored after success and after a raised exception
- **scope-boundary**: `create_view` / `create_materialized_view` (with explicit host) and `save(view/MV)` still reject a local df
- cross-server: the table lands on the **target** server only (not the source)

Verified locally against the `.github/ci/clickhouse-pair.yml` pair: full `test_writeback.py` = **73 passed** (60 existing + 13 new), no regressions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)