### PR TITLE
Zero-copy Arrow interop (to_arrow / __arrow_c_stream__ / from_arrow)

### DIFF
--- a/datastore/connection.py
+++ b/datastore/connection.py
@@ -173,7 +173,12 @@ class Connection:
             raise ConnectionError("Not connected. Call connect() first.")
 
         self._log_query(sql, "Connection", "ArrowTable")
-        return self._conn.query(sql, "ArrowTable")
+        try:
+            return self._conn.query(sql, "ArrowTable")
+        except Exception as e:
+            self._logger.error("[chDB] Arrow query failed: %s", e)
+            friendly_msg = translate_remote_error(e)
+            raise ExecutionError(f"Query execution failed: {friendly_msg}\nSQL: {sql}")
 
     def query_df(
         self,

--- a/datastore/connection.py
+++ b/datastore/connection.py
@@ -155,6 +155,26 @@ class Connection:
             friendly_msg = translate_remote_error(e)
             raise ExecutionError(f"Query execution failed: {friendly_msg}\nSQL: {sql}")
 
+    def query_arrow(self, sql: str):
+        """
+        Execute a SQL query and return a ``pyarrow.Table`` directly from chDB.
+
+        Unlike :meth:`execute` (which materializes a pandas DataFrame via the
+        ``Dataframe`` output format), this requests chDB's ``ArrowTable`` output,
+        preserving ClickHouse's native Arrow types with no pandas round-trip.
+
+        Args:
+            sql: SQL query string
+
+        Returns:
+            pyarrow.Table
+        """
+        if self._conn is None:
+            raise ConnectionError("Not connected. Call connect() first.")
+
+        self._log_query(sql, "Connection", "ArrowTable")
+        return self._conn.query(sql, "ArrowTable")
+
     def query_df(
         self,
         sql: str,

--- a/datastore/core.py
+++ b/datastore/core.py
@@ -3618,7 +3618,15 @@ class DataStore(PandasCompatMixin):
             if table is not None:
                 return table
 
-        return pa.Table.from_pandas(self._execute(), preserve_index=False)
+        # Fallback: convert the pandas result. Arrow has no row index, so surface
+        # a meaningful index (a named index, or group keys from
+        # groupby(as_index=True), or a MultiIndex) as regular columns rather than
+        # dropping it — matching the native path and the docstring Note. A plain
+        # unnamed RangeIndex carries no data and is left out.
+        df = self._execute()
+        if df.index.names != [None]:
+            df = df.reset_index()
+        return pa.Table.from_pandas(df, preserve_index=False)
 
     def __arrow_c_stream__(self, requested_schema=None):
         """

--- a/datastore/core.py
+++ b/datastore/core.py
@@ -2802,7 +2802,8 @@ class DataStore(PandasCompatMixin):
         (``__arrow_c_stream__`` / ``__arrow_c_array__``) — a ``pyarrow.Table``,
         ``polars.DataFrame``, a pandas 3.x DataFrame, another DataStore, a DuckDB
         relation, etc. — as well as raw pyarrow ``Table`` / ``RecordBatch`` /
-        ``RecordBatchReader`` objects.
+        ``RecordBatchReader`` objects, and a plain ``pandas.DataFrame`` (which on
+        pandas 2.x has no PyCapsule interface, so it is handled directly).
 
         Like pandas 3.0's ``DataFrame.from_arrow``, ingest currently relies on
         pyarrow to materialize a pandas frame, so it is *not* zero-copy on import.
@@ -2826,6 +2827,12 @@ class DataStore(PandasCompatMixin):
             2  3    c
         """
         import pyarrow as pa
+
+        # A pandas DataFrame goes straight through from_df: its own dtypes are the
+        # faithful representation, and pandas 2.x DataFrames don't implement the
+        # PyCapsule interface (so the hasattr branch below would miss them).
+        if isinstance(data, pd.DataFrame):
+            return cls.from_df(data, name=name)
 
         if isinstance(data, pa.Table):
             table = data

--- a/datastore/core.py
+++ b/datastore/core.py
@@ -2794,6 +2794,67 @@ class DataStore(PandasCompatMixin):
         return cls.from_df(df, name=name)
 
     @classmethod
+    def from_arrow(cls, data, name: str = None) -> "DataStore":
+        """
+        Create a DataStore from any Arrow-compatible object.
+
+        Accepts anything implementing the Arrow PyCapsule interface
+        (``__arrow_c_stream__`` / ``__arrow_c_array__``) — a ``pyarrow.Table``,
+        ``polars.DataFrame``, a pandas 3.x DataFrame, another DataStore, a DuckDB
+        relation, etc. — as well as raw pyarrow ``Table`` / ``RecordBatch`` /
+        ``RecordBatchReader`` objects.
+
+        Like pandas 3.0's ``DataFrame.from_arrow``, ingest currently relies on
+        pyarrow to materialize a pandas frame, so it is *not* zero-copy on import.
+        The zero-copy, native-typed path is on export — see :meth:`to_arrow` and
+        :meth:`__arrow_c_stream__`.
+
+        Args:
+            data: Arrow-compatible object.
+            name: Optional source name (used in ``explain()`` output).
+
+        Returns:
+            DataStore wrapping the data.
+
+        Example:
+            >>> import pyarrow as pa
+            >>> tbl = pa.table({"n": [1, 2, 3], "name": ["a", "b", "c"]})
+            >>> ds = DataStore.from_arrow(tbl)
+            >>> ds.filter(ds.n > 1).to_df()
+               n name
+            1  2    b
+            2  3    c
+        """
+        import pyarrow as pa
+
+        if isinstance(data, pa.Table):
+            table = data
+        elif isinstance(data, pa.RecordBatch):
+            table = pa.Table.from_batches([data])
+        elif isinstance(data, pa.RecordBatchReader):
+            table = data.read_all()
+        elif hasattr(data, "__arrow_c_stream__") or hasattr(data, "__arrow_c_array__"):
+            # pyarrow >= 14 consumes any PyCapsule producer (Polars, pandas 3.x,
+            # DuckDB, another DataStore, ...).
+            table = pa.table(data)
+        else:
+            raise TypeError(
+                "from_arrow() expects an Arrow-compatible object implementing the "
+                "Arrow PyCapsule interface (__arrow_c_stream__ / __arrow_c_array__); "
+                f"got {type(data).__name__}"
+            )
+
+        # Arrow-backed pandas (``pd.ArrowDtype``) keeps the source's Arrow types
+        # faithfully (nullable ints stay nullable, no int->float coercion), which
+        # chDB's Python() table function reads directly. Fall back to the default
+        # numpy-backed conversion if a type has no Arrow-backed mapping.
+        try:
+            df = table.to_pandas(types_mapper=pd.ArrowDtype)
+        except Exception:
+            df = table.to_pandas()
+        return cls.from_df(df, name=name)
+
+    @classmethod
     def uri(cls, uri: str, **kwargs) -> "DataStore":
         """
         Create DataStore from a URI string with automatic type inference.
@@ -3500,6 +3561,164 @@ class DataStore(PandasCompatMixin):
             >>> df = ds.select("*").filter(ds.age > 18).to_pandas()
         """
         return self.to_df()
+
+    def to_arrow(self, types: str = "native"):
+        """
+        Execute all operations and return a ``pyarrow.Table``.
+
+        Unlike :meth:`to_df`, this avoids a pandas round-trip whenever the whole
+        pipeline pushes down to a single chDB SQL query: chDB emits Arrow
+        directly, so the result keeps ClickHouse's *native* Arrow types
+        (``UInt64`` -> ``uint64``, ``Decimal`` -> ``decimal128``,
+        ``LowCardinality`` -> ``dictionary``, ``Array`` -> ``list``, ...) with no
+        numpy materialization.
+
+        Because ``pyarrow.Table`` implements the Arrow PyCapsule interface, the
+        returned table (and this DataStore itself, via :meth:`__arrow_c_stream__`)
+        can be consumed zero-copy by Polars, DuckDB, pyarrow and pandas 3.x
+        (``pd.DataFrame.from_arrow(ds)``) with no per-library glue.
+
+        Args:
+            types: ``"native"`` (default) returns ClickHouse-native Arrow types
+                for pushed-down queries, falling back to the pandas result for
+                pipelines that need pandas-side ops. ``"pandas"`` always routes
+                through :meth:`to_df`, so the Arrow dtypes line up exactly with
+                ``to_df()`` (pandas-flavored, e.g. ``UInt64`` seen as ``int64``).
+
+        Returns:
+            pyarrow.Table
+
+        Note:
+            Arrow has no row index, so any index produced by ``to_df()`` (e.g.
+            group keys from ``groupby(as_index=True)``) appears as regular
+            columns here.
+
+        Example:
+            >>> ds = DataStore.from_file("data.parquet")
+            >>> tbl = ds.filter(ds.age > 18).to_arrow()
+            >>> import polars as pl
+            >>> pl.from_arrow(ds)          # zero-copy, no glue code
+        """
+        import pyarrow as pa
+
+        if types not in ("native", "pandas"):
+            raise ValueError(
+                f"to_arrow(types=...) must be 'native' or 'pandas', got {types!r}"
+            )
+
+        if types == "native":
+            table = self._try_native_arrow()
+            if table is not None:
+                return table
+
+        return pa.Table.from_pandas(self._execute(), preserve_index=False)
+
+    def __arrow_c_stream__(self, requested_schema=None):
+        """
+        Arrow PyCapsule interface — the pandas 3.0 interchange standard.
+
+        Exposes this DataStore as an Arrow C stream so any Arrow consumer
+        (Polars, DuckDB, pyarrow, ``pd.DataFrame.from_arrow``) can pull the
+        results directly, without depending on this library. Delegates to the
+        ``pyarrow.Table`` produced by :meth:`to_arrow`.
+        """
+        return self.to_arrow().__arrow_c_stream__(requested_schema)
+
+    def _try_native_arrow(self):
+        """
+        Return a ``pyarrow.Table`` produced by a single pushed-down chDB SQL
+        query, or ``None`` when the result can't be produced natively (DataFrame
+        source, pandas-side ops, or a non-SELECT/DML state) so the caller falls
+        back to converting the pandas result.
+        """
+        # DataFrame-backed stores already hold pandas types; there is no
+        # ClickHouse source to read natively, so let the pandas path handle them.
+        if self._source_df is not None:
+            return None
+        if not (self._table_function or self.table_name):
+            return None
+        if isinstance(self._table_function, PythonTableFunction):
+            return None
+        # Only plain SELECT queries can be read as Arrow (not writeback/DML).
+        if self._delete_flag or self._update_fields or self._insert_columns:
+            return None
+
+        try:
+            sql, alias_renames = self._single_sql_query()
+        except Exception as e:  # planning / SQL-build issue -> fall back to pandas
+            self._logger.debug("to_arrow native path unavailable, using pandas: %s", e)
+            return None
+        if sql is None:
+            return None
+
+        if self._executor is None:
+            self.connect()
+        self._logger.debug(
+            "to_arrow native SQL: %s", sql[:2000] + "..." if len(sql) > 2000 else sql
+        )
+        table = self._executor.query_arrow(sql)
+
+        # Rename temp SQL aliases (e.g. ``__agg_score__`` -> ``score``) back to
+        # their user-facing names — the same rename _execute() applies to the
+        # pandas result via _postprocess_sql_result(). Arrow has no row index, so
+        # (unlike to_df) group keys stay as regular columns.
+        if alias_renames:
+            rename_back = {
+                temp: orig
+                for temp, orig in alias_renames.items()
+                if temp in table.column_names
+            }
+            if rename_back:
+                table = table.rename_columns(
+                    [rename_back.get(c, c) for c in table.column_names]
+                )
+        return table
+
+    def _single_sql_query(self):
+        """
+        Return ``(sql, alias_renames)`` iff the entire pipeline collapses to ONE
+        first-segment SQL query against the original source (so the query result
+        is the *final* result); return ``(None, None)`` otherwise. Mirrors the
+        segment planning done in :meth:`_execute`.
+        """
+        from .query_planner import QueryPlanner
+
+        if not self._lazy_ops:
+            # Plain ``SELECT * FROM source`` — fully pushable, no aliases.
+            return self._append_format_settings(self.to_sql(execution_format=True)), {}
+
+        schema = self.schema()
+        planner = QueryPlanner()
+        exec_plan = planner.plan_segments(
+            self._lazy_ops,
+            has_sql_source=True,
+            schema=schema,
+            local_source=False,  # non-Python source (excluded in _try_native_arrow)
+        )
+        if len(exec_plan.segments) != 1:
+            return None, None
+        seg = exec_plan.segments[0]
+        if not (seg.is_sql() and seg.is_first_segment and seg.plan is not None):
+            return None, None
+
+        build_result = SQLExecutionEngine(self).build_sql_from_plan(seg.plan, schema)
+        return (
+            self._append_format_settings(build_result.sql),
+            build_result.alias_renames or {},
+        )
+
+    def _append_format_settings(self, sql: Optional[str]) -> Optional[str]:
+        """Append ``SETTINGS ...`` from ``self._format_settings`` (parity with
+        the first SQL segment in :meth:`_execute`)."""
+        if sql and self._format_settings:
+            settings_parts = []
+            for key, value in self._format_settings.items():
+                if isinstance(value, str):
+                    settings_parts.append(f"{key}='{value}'")
+                else:
+                    settings_parts.append(f"{key}={value}")
+            sql = f"{sql} SETTINGS {', '.join(settings_parts)}"
+        return sql
 
     def to_dict(self, orient: str = "dict", *, into=dict, index: bool = True):
         """

--- a/datastore/executor.py
+++ b/datastore/executor.py
@@ -83,6 +83,22 @@ class Executor:
         self._ensure_connected()
         return self.connection.query_df(sql, df, df_name, preserve_order=preserve_order)
 
+    def query_arrow(self, sql: str):
+        """
+        Execute a SQL query via Connection and return a ``pyarrow.Table``.
+
+        Asks chDB for its native ``ArrowTable`` output, so the result keeps
+        ClickHouse's Arrow types with no pandas round-trip.
+
+        Args:
+            sql: SQL query string
+
+        Returns:
+            pyarrow.Table
+        """
+        self._ensure_connected()
+        return self.connection.query_arrow(sql)
+
     def execute_expression(
         self, expr_sql: str, df: pd.DataFrame, result_column: str = "__result__"
     ) -> pd.Series:

--- a/datastore/tests/test_arrow_interop.py
+++ b/datastore/tests/test_arrow_interop.py
@@ -209,3 +209,116 @@ class TestRoundTrip:
         ds = DataStore.from_file(parquet_path)
         back = DataStore.from_arrow(pl.from_arrow(ds))
         assert back.to_df()["id"].tolist() == [1, 2, 3, 4, 5]
+
+
+# --------------------------------------------------------------------------------------
+# pandas 3.x compatibility
+#
+# Arrow interop is the pandas 3.0 interchange standard. These lock in behaviour for
+# pandas-3.x dtypes as from_arrow() INPUT, pandas as a from_arrow CONSUMER, and the
+# ClickHouse-native Arrow types that survive on export.
+# --------------------------------------------------------------------------------------
+class TestPandas3xIngestDtypes:
+    """pandas 3.x dtypes as input to from_arrow() (values + null positions preserved)."""
+
+    def test_nullable_int_boolean_float(self):
+        df = pd.DataFrame(
+            {
+                "i": pd.array([1, None, 3], dtype="Int64"),
+                "b": pd.array([True, None, False], dtype="boolean"),
+                "f": pd.array([1.5, None, 3.5], dtype="Float64"),
+            }
+        )
+        tbl = DataStore.from_arrow(df).to_arrow()
+        assert tbl.column("i").to_pylist() == [1, None, 3]
+        assert tbl.column("b").to_pylist() == [True, None, False]
+        assert tbl.column("f").to_pylist() == [1.5, None, 3.5]
+
+    def test_pandas3_default_string_dtype(self):
+        df = pd.DataFrame({"s": ["a", "b", "c"]})
+        # pandas 3.0 defaults object strings to the new string dtype
+        assert "str" in str(df["s"].dtype) or "string" in str(df["s"].dtype)
+        tbl = DataStore.from_arrow(df).to_arrow()
+        assert tbl.column("s").to_pylist() == ["a", "b", "c"]
+
+    def test_arrow_backed_dtype(self):
+        df = pd.DataFrame(
+            {
+                "x": pd.array([1, 2, 3], dtype="int64[pyarrow]"),
+                "s": pd.array(["a", "b", "c"], dtype="string[pyarrow]"),
+            }
+        )
+        tbl = DataStore.from_arrow(df).to_arrow()
+        assert tbl.column("x").to_pylist() == [1, 2, 3]
+        assert tbl.column("s").to_pylist() == ["a", "b", "c"]
+
+    def test_datetime(self):
+        df = pd.DataFrame({"t": pd.to_datetime(["2020-01-01", "2020-06-15"])})
+        tbl = DataStore.from_arrow(df).to_arrow()
+        assert pa.types.is_timestamp(tbl.schema.field("t").type)
+
+    def test_tz_aware_datetime(self):
+        df = pd.DataFrame({"t": pd.to_datetime(["2020-01-01"]).tz_localize("UTC")})
+        typ = DataStore.from_arrow(df).to_arrow().schema.field("t").type
+        assert pa.types.is_timestamp(typ) and typ.tz == "UTC"
+
+    def test_categorical(self):
+        df = pd.DataFrame({"c": pd.Categorical(["a", "b", "a"])})
+        tbl = DataStore.from_arrow(df).to_arrow()
+        assert tbl.column("c").to_pylist() == ["a", "b", "a"]
+
+
+class TestPandas3xConsumer:
+    """pandas 3.x consuming a DataStore via ``pd.DataFrame.from_arrow`` (the 3.0 API)."""
+
+    def test_uint64_stays_unsigned(self, parquet_path):
+        pdf = pd.DataFrame.from_arrow(DataStore.from_file(parquet_path))
+        assert "uint" in str(pdf["id"].dtype).lower()
+
+    def test_null_positions_preserved(self, parquet_path):
+        pdf = pd.DataFrame.from_arrow(DataStore.from_file(parquet_path))
+        # opt = [10, None, 30, None, 50] in the fixture
+        assert pdf["opt"].isna().tolist() == [False, True, False, True, False]
+
+
+class TestNativeArrowTypes:
+    """ClickHouse-native Arrow types that survive on export (no pandas coercion)."""
+
+    def _write(self, tmp_path, table):
+        path = tmp_path / "typed.parquet"
+        pq.write_table(table, path)
+        return str(path)
+
+    def test_decimal128_preserved(self, tmp_path):
+        import decimal
+
+        path = self._write(
+            tmp_path,
+            pa.table(
+                {"d": pa.array([decimal.Decimal("1.50"), decimal.Decimal("2.25")], pa.decimal128(5, 2))}
+            ),
+        )
+        typ = DataStore.from_file(path).to_arrow().schema.field("d").type
+        assert pa.types.is_decimal(typ)
+
+    def test_list_preserved(self, tmp_path):
+        path = self._write(
+            tmp_path, pa.table({"a": pa.array([[1, 2], [3]], pa.list_(pa.int64()))})
+        )
+        tbl = DataStore.from_file(path).to_arrow()
+        assert pa.types.is_list(tbl.schema.field("a").type)
+        assert tbl.column("a").to_pylist() == [[1, 2], [3]]
+
+    def test_assign_computed_column(self, tmp_path):
+        path = self._write(tmp_path, pa.table({"a": pa.array([1, 2, 3], pa.int64())}))
+        ds = DataStore.from_file(path)
+        tbl = ds.assign(b=ds.a * 2).to_arrow()
+        assert tbl.column("b").to_pylist() == [2, 4, 6]
+
+    def test_empty_table(self, tmp_path):
+        path = self._write(tmp_path, pa.table({"a": pa.array([], pa.int64())}))
+        assert DataStore.from_file(path).to_arrow().num_rows == 0
+
+    def test_all_null_column(self, tmp_path):
+        path = self._write(tmp_path, pa.table({"a": pa.array([None, None], pa.int64())}))
+        assert DataStore.from_file(path).to_arrow().column("a").to_pylist() == [None, None]

--- a/datastore/tests/test_arrow_interop.py
+++ b/datastore/tests/test_arrow_interop.py
@@ -431,3 +431,52 @@ class TestIbisInterop:
         expr = ibis.memtable(pa.table({"n": [1, 2, 3]}))
         ds = DataStore.from_arrow(expr.to_pyarrow())
         assert ds.to_df()["n"].tolist() == [1, 2, 3]
+
+
+# --------------------------------------------------------------------------------------
+# Regressions for review feedback (PR #596)
+# --------------------------------------------------------------------------------------
+class TestFallbackIndexHandling:
+    """The pandas-fallback path must surface a meaningful index (group keys / named
+    index) as columns instead of dropping it — matching the native path."""
+
+    def test_from_df_groupby_keeps_group_keys(self):
+        # DataFrame source -> _try_native_arrow returns None -> fallback path.
+        ds = DataStore.from_df(
+            pd.DataFrame({"city": ["NY", "LA", "NY", "SF"], "score": [1.0, 2.0, 3.0, 4.0]})
+        )
+        tbl = ds.groupby("city").agg({"score": "sum"}).to_arrow()
+        assert "city" in tbl.column_names
+        got = dict(zip(tbl.column("city").to_pylist(), tbl.column("score").to_pylist()))
+        assert got == {"NY": 4.0, "LA": 2.0, "SF": 4.0}
+
+    def test_types_pandas_groupby_keeps_group_keys(self, parquet_path):
+        ds = DataStore.from_file(parquet_path)
+        tbl = ds.groupby("city").agg({"score": "sum"}).to_arrow(types="pandas")
+        assert "city" in tbl.column_names
+
+    def test_named_index_surfaced_as_column(self):
+        ds = DataStore.from_df(pd.DataFrame({"a": [1, 2], "b": [3, 4]})).set_index("a")
+        tbl = ds.to_arrow()
+        assert set(tbl.column_names) == {"a", "b"}
+
+    def test_plain_rangeindex_not_surfaced(self):
+        ds = DataStore.from_df(pd.DataFrame({"a": [1, 2, 3]}))
+        tbl = ds.filter(ds.a > 1).to_arrow()
+        assert tbl.column_names == ["a"]  # no spurious index column
+
+
+class TestQueryArrowErrorHandling:
+    """query_arrow must translate raw chDB errors into ExecutionError, like execute()."""
+
+    def test_query_arrow_wraps_errors_as_executionerror(self):
+        from datastore.connection import Connection
+        from datastore.exceptions import ExecutionError
+
+        conn = Connection(":memory:")
+        conn.connect()
+        try:
+            with pytest.raises(ExecutionError):
+                conn.query_arrow("SELECT bad syntax !!!")
+        finally:
+            conn.close()

--- a/datastore/tests/test_arrow_interop.py
+++ b/datastore/tests/test_arrow_interop.py
@@ -23,6 +23,14 @@ import pyarrow.parquet as pq
 import pytest
 
 from datastore import DataStore
+from datastore.pandas_col_compat import PANDAS_3_PLUS
+
+# CI runs the suite under both pandas 2.x and pandas 3.x. A few things are pandas
+# 3.0-only: the ``pd.DataFrame.from_arrow`` constructor and the default string dtype.
+requires_pandas3 = pytest.mark.skipif(
+    not PANDAS_3_PLUS,
+    reason="requires pandas 3.0+ (pd.DataFrame.from_arrow / default string dtype)",
+)
 
 
 @pytest.fixture
@@ -132,6 +140,7 @@ class TestArrowCStream:
         assert tbl.num_rows == 5
         assert tbl.schema.field("id").type == pa.uint64()
 
+    @requires_pandas3
     def test_pandas_from_arrow_consumes_datastore(self, parquet_path):
         ds = DataStore.from_file(parquet_path)
         pdf = pd.DataFrame.from_arrow(ds.filter(ds.id > 3))  # pandas 3.0 standard
@@ -234,6 +243,7 @@ class TestPandas3xIngestDtypes:
         assert tbl.column("b").to_pylist() == [True, None, False]
         assert tbl.column("f").to_pylist() == [1.5, None, 3.5]
 
+    @requires_pandas3
     def test_pandas3_default_string_dtype(self):
         df = pd.DataFrame({"s": ["a", "b", "c"]})
         # pandas 3.0 defaults object strings to the new string dtype
@@ -268,6 +278,7 @@ class TestPandas3xIngestDtypes:
         assert tbl.column("c").to_pylist() == ["a", "b", "a"]
 
 
+@requires_pandas3
 class TestPandas3xConsumer:
     """pandas 3.x consuming a DataStore via ``pd.DataFrame.from_arrow`` (the 3.0 API)."""
 
@@ -322,3 +333,101 @@ class TestNativeArrowTypes:
     def test_all_null_column(self, tmp_path):
         path = self._write(tmp_path, pa.table({"a": pa.array([None, None], pa.int64())}))
         assert DataStore.from_file(path).to_arrow().column("a").to_pylist() == [None, None]
+
+
+# --------------------------------------------------------------------------------------
+# Nested / binary / awkward-name types
+#
+# Type fidelity is verified via the NATIVE from_file path (chDB emits Arrow directly),
+# which is independent of the installed pandas version.
+# --------------------------------------------------------------------------------------
+class TestNestedAndBinaryTypes:
+    def _write(self, tmp_path, table):
+        path = tmp_path / "nested.parquet"
+        pq.write_table(table, path)
+        return str(path)
+
+    def test_map_type(self, tmp_path):
+        vals = [[("a", 1), ("b", 2)], [("c", 3)]]
+        path = self._write(
+            tmp_path, pa.table({"m": pa.array(vals, pa.map_(pa.string(), pa.int64()))})
+        )
+        tbl = DataStore.from_file(path).to_arrow()
+        assert pa.types.is_map(tbl.schema.field("m").type)
+        assert tbl.column("m").to_pylist() == vals
+
+    def test_struct_type(self, tmp_path):
+        vals = [{"x": 1, "y": "a"}, {"x": 2, "y": "b"}]
+        path = self._write(
+            tmp_path,
+            pa.table({"s": pa.array(vals, pa.struct([("x", pa.int64()), ("y", pa.string())]))}),
+        )
+        tbl = DataStore.from_file(path).to_arrow()
+        assert pa.types.is_struct(tbl.schema.field("s").type)
+        assert tbl.column("s").to_pylist() == vals
+
+    def test_fixed_size_binary(self, tmp_path):
+        vals = [
+            b"1234567890123456",
+            b"\x00\x11\x22\x33\x44\x55\x66\x77\x88\x99\xaa\xbb\xcc\xdd\xee\xff",
+        ]
+        path = self._write(tmp_path, pa.table({"b": pa.array(vals, pa.binary(16))}))
+        tbl = DataStore.from_file(path).to_arrow()
+        assert pa.types.is_fixed_size_binary(tbl.schema.field("b").type)
+        assert tbl.column("b").to_pylist() == vals
+
+    def test_awkward_column_names(self, tmp_path):
+        tbl_in = pa.Table.from_arrays(
+            [pa.array([1, 2]), pa.array([3, 4]), pa.array([5, 6])],
+            names=["a b", "名前", "with-dash"],
+        )
+        path = self._write(tmp_path, tbl_in)
+        out = DataStore.from_file(path).to_arrow()
+        assert out.column_names == ["a b", "名前", "with-dash"]
+        assert out.column("名前").to_pylist() == [3, 4]
+
+
+# --------------------------------------------------------------------------------------
+# Streaming + requested_schema (Arrow C stream). Pure pyarrow, pandas-version agnostic.
+# --------------------------------------------------------------------------------------
+class TestArrowStreaming:
+    def test_multibatch_reader_ingest(self):
+        tbl = pa.table({"n": list(range(30))})
+        reader = pa.RecordBatchReader.from_batches(tbl.schema, tbl.to_batches(max_chunksize=10))
+        ds = DataStore.from_arrow(reader)  # must drain all batches
+        assert sorted(ds.to_df()["n"].tolist()) == list(range(30))
+
+    def test_c_stream_consumable_via_reader(self, tmp_path):
+        path = tmp_path / "stream.parquet"
+        pq.write_table(pa.table({"n": list(range(1000))}), path)
+        ds = DataStore.from_file(str(path))
+        result = pa.RecordBatchReader.from_stream(ds).read_all()
+        assert result.num_rows == 1000
+
+    def test_requested_schema_compatible_cast(self, tmp_path):
+        path = tmp_path / "cast.parquet"
+        pq.write_table(pa.table({"v": pa.array([1, 2, 3], pa.int64())}), path)
+        ds = DataStore.from_file(str(path))
+        out = pa.RecordBatchReader.from_stream(
+            ds, schema=pa.schema([("v", pa.int32())])
+        ).read_all()
+        assert out.schema.field("v").type == pa.int32()
+        assert out.column("v").to_pylist() == [1, 2, 3]
+
+    def test_requested_schema_incompatible_raises(self, tmp_path):
+        path = tmp_path / "bad.parquet"
+        pq.write_table(pa.table({"v": pa.array([1, 2, 3], pa.int64())}), path)
+        ds = DataStore.from_file(str(path))
+        with pytest.raises(pa.lib.ArrowException):
+            pa.RecordBatchReader.from_stream(
+                ds, schema=pa.schema([("v", pa.list_(pa.int64()))])
+            ).read_all()
+
+
+class TestIbisInterop:
+    def test_ingest_from_ibis(self):
+        ibis = pytest.importorskip("ibis")
+        # ibis produces Arrow; DataStore.from_arrow ingests it.
+        expr = ibis.memtable(pa.table({"n": [1, 2, 3]}))
+        ds = DataStore.from_arrow(expr.to_pyarrow())
+        assert ds.to_df()["n"].tolist() == [1, 2, 3]

--- a/datastore/tests/test_arrow_interop.py
+++ b/datastore/tests/test_arrow_interop.py
@@ -1,0 +1,211 @@
+"""
+Tests for zero-copy Arrow interop on DataStore:
+
+- ``DataStore.to_arrow()``          -> native-typed ``pyarrow.Table`` (no pandas round-trip)
+- ``DataStore.__arrow_c_stream__()``-> Arrow PyCapsule interface (pandas 3.0 standard),
+                                       consumed zero-copy by pyarrow / Polars / DuckDB /
+                                       ``pandas.DataFrame.from_arrow``
+- ``DataStore.from_arrow()``        -> ingest any Arrow PyCapsule producer
+
+The headline win is on export: for a pipeline that fully pushes down to one chDB SQL
+query, chDB emits Arrow directly, so ClickHouse-native Arrow types survive (``UInt64`` ->
+``uint64``) with no numpy materialization.
+"""
+
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).parent.parent))
+
+import pandas as pd
+import pyarrow as pa
+import pyarrow.parquet as pq
+import pytest
+
+from datastore import DataStore
+
+
+@pytest.fixture
+def parquet_path(tmp_path):
+    """A parquet file with varied types, incl. an unsigned int and a nullable int."""
+    tbl = pa.table(
+        {
+            "id": pa.array([1, 2, 3, 4, 5], pa.uint64()),
+            "city": ["NY", "LA", "NY", "SF", "LA"],
+            "score": [1.5, 2.5, 3.5, 4.5, 5.5],
+            "opt": pa.array([10, None, 30, None, 50], pa.int64()),
+        }
+    )
+    path = tmp_path / "people.parquet"
+    pq.write_table(tbl, path)
+    return str(path)
+
+
+# --------------------------------------------------------------------------------------
+# Export: to_arrow() native path
+# --------------------------------------------------------------------------------------
+class TestToArrowNative:
+    def test_returns_pyarrow_table(self, parquet_path):
+        ds = DataStore.from_file(parquet_path)
+        tbl = ds.to_arrow()
+        assert isinstance(tbl, pa.Table)
+        assert tbl.num_rows == 5
+        assert tbl.column_names == ["id", "city", "score", "opt"]
+
+    def test_preserves_native_unsigned_type(self, parquet_path):
+        """The whole point: chDB emits Arrow directly, so UInt64 stays uint64
+        instead of being coerced by a pandas round-trip."""
+        ds = DataStore.from_file(parquet_path)
+        tbl = ds.to_arrow()
+        assert tbl.schema.field("id").type == pa.uint64()
+
+    def test_filter_is_pushed_down(self, parquet_path):
+        ds = DataStore.from_file(parquet_path)
+        tbl = ds.filter(ds.id > 3).to_arrow()
+        assert tbl.num_rows == 2
+        assert tbl.column("id").to_pylist() == [4, 5]
+        # native type survives through the pushed-down filter
+        assert tbl.schema.field("id").type == pa.uint64()
+
+    def test_select_projection(self, parquet_path):
+        ds = DataStore.from_file(parquet_path)
+        tbl = ds.select("id", "city").to_arrow()
+        assert tbl.column_names == ["id", "city"]
+
+    def test_groupby_aggregation_values(self, parquet_path):
+        ds = DataStore.from_file(parquet_path)
+        tbl = ds.groupby("city").agg({"score": "sum"}).to_arrow()
+        got = dict(zip(tbl.column("city").to_pylist(), tbl.column("score").to_pylist()))
+        assert got == {"NY": 5.0, "LA": 8.0, "SF": 4.5}
+
+    def test_native_and_pandas_flavored_have_same_rows(self, parquet_path):
+        """native and pandas-flavored Arrow must carry the SAME rows/columns
+        (comparing as Arrow avoids NaN-vs-NA / dtype-backend noise)."""
+        ds = DataStore.from_file(parquet_path)
+        native = ds.filter(ds.id > 1).to_arrow(types="native")
+        ds2 = DataStore.from_file(parquet_path)
+        pandas_flavored = ds2.filter(ds2.id > 1).to_arrow(types="pandas")
+        assert native.column_names == pandas_flavored.column_names
+        assert native.to_pydict() == pandas_flavored.to_pydict()
+
+    def test_nullable_int_null_survives(self, parquet_path):
+        ds = DataStore.from_file(parquet_path)
+        tbl = ds.to_arrow()
+        assert tbl.column("opt").to_pylist() == [10, None, 30, None, 50]
+
+    def test_invalid_types_arg_raises(self, parquet_path):
+        ds = DataStore.from_file(parquet_path)
+        with pytest.raises(ValueError):
+            ds.to_arrow(types="bogus")
+
+
+# --------------------------------------------------------------------------------------
+# Export: fallback path (DataFrame source / pandas-side ops) still yields a Table
+# --------------------------------------------------------------------------------------
+class TestToArrowFallback:
+    def test_from_df_source_returns_table(self):
+        ds = DataStore.from_df(pd.DataFrame({"a": [1, 2, 3], "b": ["x", "y", "z"]}))
+        tbl = ds.filter(ds.a > 1).to_arrow()
+        assert isinstance(tbl, pa.Table)
+        assert tbl.column("a").to_pylist() == [2, 3]
+
+    def test_types_pandas_matches_to_df_dtypes(self, parquet_path):
+        """types='pandas' routes through to_df(), so Arrow dtypes line up with it."""
+        ds = DataStore.from_file(parquet_path)
+        pandas_flavored = ds.to_arrow(types="pandas")
+        # Values still correct
+        assert pandas_flavored.num_rows == 5
+        # And equivalent to converting to_df() ourselves
+        expected = pa.Table.from_pandas(
+            DataStore.from_file(parquet_path).to_df(), preserve_index=False
+        )
+        assert pandas_flavored.schema == expected.schema
+
+
+# --------------------------------------------------------------------------------------
+# Export: Arrow PyCapsule interface (__arrow_c_stream__) — zero glue for consumers
+# --------------------------------------------------------------------------------------
+class TestArrowCStream:
+    def test_pyarrow_consumes_datastore(self, parquet_path):
+        ds = DataStore.from_file(parquet_path)
+        tbl = pa.table(ds)  # uses __arrow_c_stream__
+        assert tbl.num_rows == 5
+        assert tbl.schema.field("id").type == pa.uint64()
+
+    def test_pandas_from_arrow_consumes_datastore(self, parquet_path):
+        ds = DataStore.from_file(parquet_path)
+        pdf = pd.DataFrame.from_arrow(ds.filter(ds.id > 3))  # pandas 3.0 standard
+        assert pdf["id"].tolist() == [4, 5]
+
+    def test_polars_consumes_datastore(self, parquet_path):
+        pl = pytest.importorskip("polars")
+        ds = DataStore.from_file(parquet_path)
+        plf = pl.from_arrow(ds.filter(ds.id > 3))
+        assert plf.shape == (2, 4)
+        assert str(plf.schema["id"]) == "UInt64"  # native type survives into Polars
+
+    def test_duckdb_consumes_datastore(self, parquet_path):
+        duckdb = pytest.importorskip("duckdb")
+        ds = DataStore.from_file(parquet_path)
+        (count, total) = duckdb.sql("SELECT count(*), sum(id) FROM ds").fetchone()
+        assert count == 5
+        assert total == 15
+
+
+# --------------------------------------------------------------------------------------
+# Import: from_arrow() ingests any Arrow PyCapsule producer
+# --------------------------------------------------------------------------------------
+class TestFromArrow:
+    def test_from_pyarrow_table(self):
+        tbl = pa.table({"n": [1, 2, 3], "s": ["a", "b", "c"]})
+        ds = DataStore.from_arrow(tbl)
+        assert isinstance(ds, DataStore)
+        assert ds.to_df()["n"].tolist() == [1, 2, 3]
+
+    def test_from_record_batch(self):
+        batch = pa.record_batch({"n": [1, 2, 3]})
+        ds = DataStore.from_arrow(batch)
+        assert ds.to_df()["n"].tolist() == [1, 2, 3]
+
+    def test_from_record_batch_reader(self):
+        tbl = pa.table({"n": [1, 2, 3]})
+        reader = tbl.to_reader()
+        ds = DataStore.from_arrow(reader)
+        assert ds.to_df()["n"].tolist() == [1, 2, 3]
+
+    def test_from_pandas(self):
+        ds = DataStore.from_arrow(pd.DataFrame({"n": [1, 2], "s": ["a", "b"]}))
+        assert ds.to_df()["n"].tolist() == [1, 2]
+
+    def test_from_polars(self):
+        pl = pytest.importorskip("polars")
+        ds = DataStore.from_arrow(pl.DataFrame({"n": [1, 2, 3], "s": ["a", "b", "c"]}))
+        assert ds.to_df()["s"].tolist() == ["a", "b", "c"]
+
+    def test_from_datastore(self, parquet_path):
+        src = DataStore.from_file(parquet_path)
+        ds = DataStore.from_arrow(src.filter(src.id > 3))
+        assert ds.to_df()["id"].tolist() == [4, 5]
+
+    def test_bad_input_raises_typeerror(self):
+        with pytest.raises(TypeError):
+            DataStore.from_arrow(object())
+
+
+# --------------------------------------------------------------------------------------
+# Round-trips
+# --------------------------------------------------------------------------------------
+class TestRoundTrip:
+    def test_datastore_arrow_datastore(self, parquet_path):
+        """DataStore -> Arrow -> DataStore -> Arrow preserves values, columns and
+        nullability (compared as Arrow to stay dtype-backend agnostic)."""
+        original = DataStore.from_file(parquet_path).to_arrow()
+        roundtrip = DataStore.from_arrow(original).to_arrow()
+        assert roundtrip.column_names == original.column_names
+        assert roundtrip.to_pydict() == original.to_pydict()
+
+    def test_polars_roundtrip(self, parquet_path):
+        pl = pytest.importorskip("polars")
+        ds = DataStore.from_file(parquet_path)
+        back = DataStore.from_arrow(pl.from_arrow(ds))
+        assert back.to_df()["id"].tolist() == [1, 2, 3, 4, 5]


### PR DESCRIPTION
Adds Arrow interop to `DataStore`, built on the Arrow PyCapsule interface (the pandas 3.0 standard). Lets DataStore results flow to Polars / DuckDB / pandas 3.0 without a pandas round-trip.

## What
- **`to_arrow(types='native'|'pandas')`** — a fully pushed-down pipeline returns a `pyarrow.Table` straight from chDB's `ArrowTable` output (no pandas round-trip), keeping ClickHouse-native types (`UInt64`→`uint64`, nullable ints stay nullable). Falls back to converting the pandas result for pipelines that need pandas-side ops.
- **`__arrow_c_stream__()`** — `pa.table(ds)`, `pl.from_arrow(ds)`, `duckdb.sql('... FROM ds')` and `pd.DataFrame.from_arrow(ds)` all work with no glue code.
- **`from_arrow(data)`** — ingest any PyCapsule producer (pyarrow Table/RecordBatch/reader, Polars, pandas 3.x, DuckDB, another DataStore).
- Adds `Connection.query_arrow` / `Executor.query_arrow`.

## Notes
- Additive only; `to_df()` and existing behavior unchanged.
- Arrow has no row index, so group keys from `groupby(as_index=True)` appear as regular columns.
- Ingest goes through pyarrow (like pandas 3.0's own `from_arrow`), so it is not zero-copy on import; the zero-copy/native-typed path is on export.

## Tests
`datastore/tests/test_arrow_interop.py` — 23 tests: native types, filter/select/groupby pushdown, interop (pyarrow/Polars/DuckDB/pandas), ingest, round-trips. Passing locally.

Closes #595

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add zero-copy Arrow interop (`to_arrow`, `from_arrow`, `__arrow_c_stream__`) to `DataStore`
> - Adds `DataStore.to_arrow(types='native'|'pandas')` which returns a `pyarrow.Table`; in `'native'` mode it pushes down a single SQL query to chDB's Arrow output format, falling back to pandas conversion when pushdown is unavailable.
> - Adds `DataStore.from_arrow(data)` classmethod accepting Arrow PyCapsule objects, `pyarrow.Table`/`RecordBatch`/`RecordBatchReader`, and pandas/Polars DataFrames.
> - Implements `DataStore.__arrow_c_stream__` so `DataStore` objects are directly consumable by PyArrow, Polars, DuckDB, and pandas 3.x without intermediate copies.
> - Adds `Connection.query_arrow` and `Executor.query_arrow` to execute SQL and return a `pyarrow.Table` via chDB's `ArrowTable` output format.
> - A new test module covers round-trips, native type preservation (decimal, list, map, struct, binary), empty/null columns, `requested_schema` casting, and error handling.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 54b97e9.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->