### PR TITLE
agents: mark beta + accept (database, table) qualification (4.2.0 prep)

### DIFF
--- a/chdb/agents/CONTRACT.md
+++ b/chdb/agents/CONTRACT.md
@@ -1,5 +1,9 @@
 # chDB Agent Tool — cross-language contract
 
+> **Status: beta / experimental (introduced in chdb 4.2.0).** The surface may
+> change in a minor release while it stabilizes across bindings; pin a version if
+> you depend on it.
+
 One behavior, many bindings. This document is the **single source of truth** for
 the chDB agent-tool surface. `chdb.agents.ChDBTool` (Python) is the reference
 implementation; the TypeScript binding (`chdb-node`) and any future language

--- a/chdb/agents/__init__.py
+++ b/chdb/agents/__init__.py
@@ -3,7 +3,16 @@
 `ChDBTool` is the single Python implementation that agent frameworks shim, and
 the reference implementation of the language-neutral contract in CONTRACT.md
 (exercised by conformance/cases.jsonl, shared with the TypeScript binding).
+
+.. note::
+   **Beta / experimental (introduced in chdb 4.2.0).** ``chdb.agents`` is a new
+   API that downstream integrations (mcp-clickhouse, langchain, llama-index)
+   build on. Its surface may change in a minor release while it stabilizes — pin
+   a version if you depend on it. The behavior it does expose is governed by
+   CONTRACT.md.
 """
+
+__beta__ = True
 
 from .errors import (
     ChDBError,
@@ -11,7 +20,7 @@ from .errors import (
     ChDBSyntaxError,
     ChDBUnknownObjectError,
 )
-from .safety import InvalidIdentifier, quote_ident
+from .safety import InvalidIdentifier, quote_ident, quote_string
 from .tool import ChDBTool, QueryResult
 
 __all__ = [
@@ -23,4 +32,6 @@ __all__ = [
     "ChDBUnknownObjectError",
     "InvalidIdentifier",
     "quote_ident",
+    "quote_string",
+    "__beta__",
 ]

--- a/chdb/agents/tool.py
+++ b/chdb/agents/tool.py
@@ -263,12 +263,15 @@ class ChDBTool:
           (so a dotted name is never mis-quoted as a single identifier). This is
           what lets the mcp-clickhouse `(database, table)` tools map onto ChDBTool.
         """
+        # `None` means "not provided"; any other value (including "") is a real
+        # database argument and must be validated — an empty string flows into
+        # quote_ident() and is rejected rather than silently treated as unqualified.
         if "(" in target:
-            if database:
+            if database is not None:
                 raise ChDBError("database qualifier is not valid for a table-function target")
             return target
         ident = quote_ident(target)
-        return "{}.{}".format(quote_ident(database), ident) if database else ident
+        return "{}.{}".format(quote_ident(database), ident) if database is not None else ident
 
     def describe(self, target, *, database=None, params=None):
         """Describe a table (optionally `database`-qualified) OR a table-function

--- a/chdb/agents/tool.py
+++ b/chdb/agents/tool.py
@@ -252,14 +252,28 @@ class ChDBTool:
         sql = "SELECT name FROM system.tables WHERE database = {db:String} ORDER BY name"
         return [r["name"] for r in self.query(sql, params={"db": database}).rows]
 
-    def describe(self, target, *, params=None):
-        """Describe a table OR a table-function expression (e.g. file('x.parquet')).
+    def _qualify(self, target, database=None):
+        """Turn (target[, database]) into a safe SQL source reference.
 
-        A bare identifier is backtick-quoted; an expression containing '(' is a
-        table function and passed through as SQL (its literal args are the one
-        place a value rides in text — read-only + no-write makes that inert).
+        - `target` containing '(' is a table-function expression, passed through
+          as SQL (its literal args are the one place a value rides in text —
+          read-only + no-write makes that inert); a database qualifier is invalid.
+        - otherwise `target` is a table identifier, backtick-quoted; when
+          `database` is given each part is quoted independently as `db`.`table`
+          (so a dotted name is never mis-quoted as a single identifier). This is
+          what lets the mcp-clickhouse `(database, table)` tools map onto ChDBTool.
         """
-        ref = target if "(" in target else quote_ident(target)
+        if "(" in target:
+            if database:
+                raise ChDBError("database qualifier is not valid for a table-function target")
+            return target
+        ident = quote_ident(target)
+        return "{}.{}".format(quote_ident(database), ident) if database else ident
+
+    def describe(self, target, *, database=None, params=None):
+        """Describe a table (optionally `database`-qualified) OR a table-function
+        expression (e.g. file('x.parquet'))."""
+        ref = self._qualify(target, database)
         rows = self.query("DESCRIBE TABLE {} ".format(ref), params=params).rows
         return [
             {"name": r.get("name"), "type": r.get("type"),
@@ -267,8 +281,8 @@ class ChDBTool:
             for r in rows
         ]
 
-    def get_sample_data(self, target, *, limit=5):
-        ref = target if "(" in target else quote_ident(target)
+    def get_sample_data(self, target, *, database=None, limit=5):
+        ref = self._qualify(target, database)
         return self.query(
             "SELECT * FROM {} LIMIT {{n:UInt32}}".format(ref),
             params={"n": int(limit)},
@@ -296,10 +310,10 @@ class ChDBTool:
             {"name": "list_databases", "description": "List databases.", "input_schema": s()},
             {"name": "list_tables", "description": "List tables in a database (current if omitted).",
              "input_schema": s(database={"type": "string"})},
-            {"name": "describe_table", "description": "Describe a table or table function (columns and types).",
-             "input_schema": s(target={"type": "string"})},
+            {"name": "describe_table", "description": "Describe a table (optionally database-qualified) or table function.",
+             "input_schema": s(target={"type": "string"}, database={"type": "string"})},
             {"name": "get_sample_data", "description": "Return a few sample rows from a table or table function.",
-             "input_schema": s(target={"type": "string"}, limit={"type": "integer"})},
+             "input_schema": s(target={"type": "string"}, database={"type": "string"}, limit={"type": "integer"})},
             {"name": "list_functions", "description": "List available SQL functions.",
              "input_schema": s(like={"type": "string"}, limit={"type": "integer"})},
             {"name": "attach_file", "description": "Register a local file as a queryable named table (writable tools only).",
@@ -319,9 +333,9 @@ class ChDBTool:
                 out = method(args.get("sql", ""), params=args.get("params"))
                 result = out.to_dict()
             elif method_name == "describe":
-                result = method(args["target"])
+                result = method(args["target"], database=args.get("database"))
             elif method_name == "get_sample_data":
-                result = method(args["target"], limit=args.get("limit", 5)).to_dict()
+                result = method(args["target"], database=args.get("database"), limit=args.get("limit", 5)).to_dict()
             elif method_name == "list_tables":
                 result = method(args.get("database"))
             elif method_name == "list_functions":

--- a/tests/test_agents_chdbtool.py
+++ b/tests/test_agents_chdbtool.py
@@ -143,6 +143,30 @@ class TestAttachFile(unittest.TestCase):
             tool.close()
 
 
+class TestQualifiedName(unittest.TestCase):
+    def test_describe_and_sample_with_database(self):
+        # (database, table) qualification is what lets mcp-clickhouse's
+        # describe_table(database, table) / get_sample_data(...) map onto ChDBTool.
+        tool = ChDBTool(read_only=False)
+        try:
+            tool.query("CREATE DATABASE dq")
+            tool.query("CREATE TABLE dq.t (x Int32, y String) ENGINE = MergeTree ORDER BY x")
+            tool.query("INSERT INTO dq.t VALUES (1, 'a'), (2, 'b')")
+            cols = [c["name"] for c in tool.describe("t", database="dq")]
+            self.assertEqual(cols, ["x", "y"])
+            self.assertEqual(tool.get_sample_data("t", database="dq", limit=1).row_count, 1)
+        finally:
+            tool.close()
+
+    def test_database_qualifier_rejected_for_table_function(self):
+        tool = ChDBTool(read_only=True)
+        try:
+            with self.assertRaises(ChDBError):
+                tool.describe("numbers(5)", database="dq")
+        finally:
+            tool.close()
+
+
 class TestDataFrameQuery(unittest.TestCase):
     def test_dataframe_query(self):
         import pandas as pd

--- a/tests/test_agents_chdbtool.py
+++ b/tests/test_agents_chdbtool.py
@@ -166,6 +166,15 @@ class TestQualifiedName(unittest.TestCase):
         finally:
             tool.close()
 
+    def test_empty_string_database_is_rejected_not_ignored(self):
+        # an explicit "" must not be silently treated as unqualified
+        tool = ChDBTool(read_only=True)
+        try:
+            with self.assertRaises(InvalidIdentifier):
+                tool.describe("t", database="")
+        finally:
+            tool.close()
+
 
 class TestDataFrameQuery(unittest.TestCase):
     def test_dataframe_query(self):


### PR DESCRIPTION
## What

Two additive follow-ups to `chdb.agents` (merged in #594), prepping it for the 4.2.0 release:

1. **Mark `chdb.agents` beta/experimental** — module docstring, `CONTRACT.md` status banner, and a `__beta__` flag. Downstream integrations (mcp-clickhouse, langchain, llama-index) build on this surface; the marker tells consumers to pin a version while it stabilizes. Also exports `quote_string`.
2. **Accept `(database, table)` qualification in `describe` / `get_sample_data`** — a new optional `database=` keyword. Each part is quoted independently as `` `db`.`table` `` (a dotted name is never mis-quoted as one identifier); a `database` qualifier on a table-function target is rejected.

## Why

`(2)` is what lets **mcp-clickhouse**'s ClickHouse-server-parity tools — `describe_table(database, table)` / `get_sample_data(database, table, limit)` — map **1:1 onto `ChDBTool`** without re-implementing identifier quoting. It's the missing piece for consolidating mcp-clickhouse (and any `(database, table)`-shaped caller) onto the canonical tool instead of a parallel implementation.

Both changes are backward-compatible (new keyword arg; docs/flag only).

## Tests

Built the wheel and ran against a **clean `pip install`** (chdb-core from PyPI + the built wheel, not the source tree):
- `test_agents_conformance` — 16 cases pass
- `test_agents_chdbtool` — 20 unit tests pass (incl. +2 for `(database, table)` qualification and its rejection on table functions)

Also confirmed the built wheel ships `chdb/agents/**` (code + `CONTRACT.md` + `conformance/*`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Mark `chdb.agents` as beta and add database qualification to `ChDBTool`
> - Adds `__beta__ = True` to [chdb/agents/__init__.py](https://github.com/chdb-io/chdb/pull/597/files#diff-391f7dbc116c79a84020ed47a9b55710df784279007f5764ed92b65f754f5b4c) and a note in [CONTRACT.md](https://github.com/chdb-io/chdb/pull/597/files#diff-911bffae59a61a359083551d3c4cd6855e8839e1f73d500396503aac7c9b8298) indicating the API may change in minor releases until stable.
> - Adds a `_qualify` helper to `ChDBTool` in [chdb/agents/tool.py](https://github.com/chdb-io/chdb/pull/597/files#diff-42af4c179ae11b7bed2a88f7e81e658435aac4f2cfb66f39453793c030cea889) that safely builds SQL table references, supporting optional `database` qualification via `quote_ident`.
> - Extends `describe` and `get_sample_data` to accept a `database` argument; the call dispatcher wires it through, and tool schemas advertise it as an optional property.
> - Table-function targets (containing `(`) reject a `database` argument; explicit empty-string databases raise `InvalidIdentifier`.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized d5b4845.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->