### PR TITLE
docs: llms.txt fixes, link-check CI, and generated llms-full.txt

### DIFF
--- a/.github/workflows/llms-txt-check.yml
+++ b/.github/workflows/llms-txt-check.yml
@@ -1,0 +1,93 @@
+name: llms.txt checks
+
+on:
+  pull_request:
+    paths:
+      - "llms.txt"
+      - "llms-full.txt"
+      - "scripts/generate_llms_full.py"
+  schedule:
+    # Weekly sweep so docs-site slug renames surface even when llms.txt is untouched
+    - cron: "0 6 * * 1"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  check-links:
+    name: Every llms.txt link resolves
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Check links
+        run: |
+          set -u
+          dead=0
+          links=$(grep -oE '\]\(https://[^)]+\)' llms.txt | sed 's/^](//; s/)$//' | sort -u)
+          echo "Checking $(echo "$links" | wc -l) unique links"
+          for url in $links; do
+            code=000
+            for attempt in 1 2 3; do
+              code=$(curl -sL -o /dev/null -w "%{http_code}" --max-time 30 "$url" || echo 000)
+              # Only 404/410 mean the target is gone; 403/429 are rate limits, 000 is transient
+              case "$code" in
+                404|410) sleep $((attempt * 5)) ;;
+                000|429|403) sleep $((attempt * 5)) ;;
+                *) break ;;
+              esac
+            done
+            case "$code" in
+              404|410) echo "DEAD  $code $url"; dead=$((dead + 1)) ;;
+              200)     echo "ok    $code $url" ;;
+              *)       echo "warn  $code $url (not treated as dead)" ;;
+            esac
+          done
+          if [ "$dead" -gt 0 ]; then
+            echo "::error::$dead dead link(s) in llms.txt"
+            exit 1
+          fi
+
+  coverage-diff:
+    name: Coverage vs clickhouse.com/docs/llms.txt
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Diff curated links against the docs-site index
+        run: |
+          set -u
+          # The docs site auto-generates /docs/llms.txt from page frontmatter
+          # (ClickHouse/clickhouse-docs plugins/llms-txt-plugin.ts), so its chdb
+          # entries are the authoritative list of published chDB doc pages.
+          curl -sL --max-time 60 "https://clickhouse.com/docs/llms.txt" -o /tmp/docs_llms.txt
+          if ! grep -q "clickhouse.com/docs/chdb" /tmp/docs_llms.txt; then
+            echo "::warning::could not fetch a usable docs llms.txt; skipping coverage diff"
+            exit 0
+          fi
+          grep -oE 'https://clickhouse\.com/docs/chdb[^) ]*' /tmp/docs_llms.txt | sed 's:/$::' | sort -u > /tmp/docs_urls.txt
+          grep -oE '\]\(https://clickhouse\.com/docs/chdb[^)]*\)' llms.txt | sed 's/^](//; s/)$//; s:/$::' | sort -u > /tmp/curated_urls.txt
+
+          {
+            echo "## llms.txt coverage vs docs site"
+            echo
+            echo "Docs site publishes $(wc -l < /tmp/docs_urls.txt) chDB pages; llms.txt curates $(wc -l < /tmp/curated_urls.txt) of them."
+            echo
+            missing_from_docs=$(comm -23 /tmp/curated_urls.txt /tmp/docs_urls.txt)
+            if [ -n "$missing_from_docs" ]; then
+              echo "### ⚠️ In llms.txt but NOT in the docs index (renamed or unpublished?)"
+              echo
+              echo "$missing_from_docs" | sed 's/^/- /'
+              echo
+            fi
+            uncurated=$(comm -13 /tmp/curated_urls.txt /tmp/docs_urls.txt)
+            if [ -n "$uncurated" ]; then
+              echo "### ℹ️ Published docs pages not in llms.txt (curation candidates, not errors)"
+              echo
+              echo "$uncurated" | sed 's/^/- /'
+            fi
+          } >> "$GITHUB_STEP_SUMMARY"
+
+          # Informational only: the hard pass/fail signal is the HTTP check job.
+          echo "Coverage diff written to job summary"

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -1,0 +1,17069 @@
+# chDB
+
+> chDB is an in-process OLAP SQL engine powered by ClickHouse, embedded as a Python / Bun / Node.js / Go / Rust / C library and compiled to WebAssembly for the browser. It runs ClickHouse's full SQL dialect with 1000+ functions, queries Parquet / CSV / JSON files in place, references pandas / Polars DataFrames directly inside SQL via the `Python(df)` table function, and joins across external sources — S3, Postgres, MySQL, MongoDB, Iceberg, Delta Lake, and remote ClickHouse — in a single query, all without spinning up a server.
+
+Things to remember when using chDB:
+
+- chDB is the embedded form of ClickHouse: same SQL dialect (NOT PostgreSQL-compatible), same 1000+ functions, same MergeTree engine, no daemon required.
+- Query files in place — `file('data.parquet')`, `s3('https://...', 'key', 'secret')`, `url('https://...')`. No load step.
+- DataFrames are first-class via the `Python(df)` table function: `chdb.query("SELECT * FROM Python(df) WHERE x > 10", output_format="DataFrame")` — DataFrame in, DataFrame out, no `register()` call.
+- Query across sources in one statement: `s3()`, `postgresql()`, `mysql()`, `mongodb()`, `iceberg()`, `deltaLake()`, and `remoteSecure('host:9440', db.table, 'user', 'pass')` for a remote ClickHouse cluster — join local files, DataFrames, and remote systems together.
+- Use `chdb.session.Session('path/to/dir')` for persistent storage; in-memory is the default. The DataStore API (`import datastore as pd`) is a pandas-compatible interface that compiles to optimized SQL — up to 247× faster than pandas on COUNT.
+- Documentation pages under `clickhouse.com/docs` return clean Markdown when requested with an `Accept: text/markdown` header — prefer that over parsing the HTML.
+
+---
+
+This file contains the full chDB documentation corpus. The companion index is at https://github.com/chdb-io/chdb/blob/main/llms.txt.
+
+---
+
+# chDB
+
+**URL:** https://clickhouse.com/docs/chdb
+
+chDB is an in-process SQL OLAP Engine powered by ClickHouse
+
+chDB is a fast in-process SQL OLAP Engine powered by [ClickHouse](https://github.com/clickhouse/clickhouse) v25.8.2.1.
+You can use it when you want to get the power of ClickHouse in a programming language without needing to connect to a ClickHouse server.
+
+## Key features
+- **In-process SQL OLAP Engine** - Powered by ClickHouse, no need to install ClickHouse server
+- **Multiple data formats** - Input & Output support for Parquet, CSV, JSON, Arrow, ORC and [70+ more formats](/interfaces/formats)
+- **Minimized data copy** - From C++ to Python with [python memoryview](https://docs.python.org/3/c-api/memoryview.html)
+- **Rich Python Ecosystem Integration** - Native support for Pandas, Arrow, DB API 2.0, seamlessly fits into existing data science workflows
+- **Zero dependencies** - No need for external database installations
+- **DataStore API** - Pandas-compatible API with SQL optimization, supporting 630+ methods
+
+## DataStore: Pandas-Compatible API
+**NEW!** DataStore provides a pandas-compatible API that combines familiar pandas syntax with ClickHouse performance.
+
+:::tip Get Started on Hex
+- 📖 <a href="https://app.hex.tech/partnerships/app/chDB-Tutorial-032XsQ4qoKtlXxcw49joav/latest" target="_blank"><b>Getting Started Tutorial</b></a> — set up your first connection
+- 🚀 <a href="https://app.hex.tech/signup/clickhouse-30" target="_blank"><b>Extended 30-day Hex Trial</b></a> — full access to ClickHouse integrations
+:::
+
+### One-Line Migration
+```python
+# Just change your import - your pandas code works unchanged
+- import pandas as pd
++ from chdb import datastore as pd
+
+df = pd.read_csv("data.csv")
+result = df[df['age'] > 25].groupby('city')['salary'].mean()
+```
+
+### Performance Highlights
+| Operation | pandas | DataStore | Speedup |
+|-----------|--------|-----------|---------|
+| GroupBy count | 347ms | 17ms | **19.93x** |
+| Complex pipeline | 2,047ms | 380ms | **5.39x** |
+| Filter+Sort+Head | 1,537ms | 350ms | **4.40x** |
+
+*Benchmarks on 10M rows*
+
+### DataStore Features
+- **630+ API methods** - 209 pandas DataFrame methods, 185+ accessor methods
+- **Lazy evaluation** - Operations compile to optimized SQL
+- **SQL pushdown** - Filters and aggregations run at the data source
+- **Universal data sources** - Read from files, S3, databases, data lakes
+
+Learn more: [DataStore Documentation](datastore/index.md)
+
+## What languages are supported by chDB?
+chDB has the following language bindings:
+
+* [Python](install/python.md) - [API Reference](api/python.md)
+* [Go](install/go.md)
+* [Rust](install/rust.md)
+* [NodeJS](install/nodejs.md)
+* [Bun](install/bun.md)
+* [C and C++](install/c.md)
+
+## How do I get started?
+* If you're using [Go](install/go.md), [Rust](install/rust.md), [NodeJS](install/nodejs.md), [Bun](install/bun.md) or [C and C++](install/c.md), take a look at the corresponding language pages.
+* If you're using Python, see the [getting started developer guide](getting-started.md) or the [chDB on-demand course](https://learn.clickhouse.com/user_catalog_class/show/1901178).
+
+### For pandas Users
+Start with the DataStore API for a familiar pandas experience with ClickHouse performance:
+
+* [DataStore Quickstart](datastore/quickstart.md) - Installation and one-line migration
+* [Migration from pandas](guides/migration-from-pandas.md) - Step-by-step migration guide
+* [Pandas Cookbook](guides/pandas-cookbook.md) - Common patterns
+* [Key Differences](guides/pandas-differences.md) - Important differences from pandas
+* [Performance Guide](guides/pandas-performance.md) - Optimization tips
+
+### DataStore API Reference
+* [Factory Methods](datastore/factory-methods.md) - Create from files, databases, cloud storage
+* [Query Building](datastore/query-building.md) - SQL-style operations
+* [Pandas Compatibility](datastore/pandas-compat.md) - 209 compatible methods
+* [Accessors](datastore/accessors.md) - .str, .dt, .arr, .json, .url, .ip, .geo
+* [Configuration](configuration/index.md) - Engine, logging, profiling
+* [Debugging](debugging/index.md) - explain(), profiling, logging
+
+### SQL API Guides
+* [Python API Reference](api/python.md) - Complete SQL API documentation
+* [JupySQL](guides/jupysql.md)
+* [Querying Pandas](guides/querying-pandas.md)
+* [Querying Apache Arrow](guides/querying-apache-arrow.md)
+* [Querying data in S3](guides/querying-s3-bucket.md)
+* [Querying Parquet files](guides/querying-parquet.md)
+* [Querying remote ClickHouse](guides/query-remote-clickhouse.md)
+* [Using clickhouse-local database](guides/clickhouse-local.md)
+
+## An introductory video
+Watch a brief introduction to chDB and learn how it brings ClickHouse's power to your Python environment:
+
+<div class='vimeo-container'>
+<iframe width="560" height="315" src="https://www.youtube.com/embed/e_yL0dlX6k4" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" referrerpolicy="strict-origin-when-cross-origin" allowfullscreen></iframe>
+</div>
+
+## Performance benchmarks
+chDB delivers exceptional performance across different scenarios:
+
+- **[ClickBench of embedded engines](https://benchmark.clickhouse.com/#eyJzeXN0ZW0iOnsiQXRoZW5hIChwYXJ0aXRpb25lZCkiOnRydWUsIkF0aGVuYSAoc2luZ2xlKSI6dHJ1ZSwiQXVyb3JhIGZvciBNeVNRTCI6dHJ1ZSwiQXVyb3JhIGZvciBQb3N0Z3JlU1FMIjp0cnVlLCJCeXRlSG91c2UiOnRydWUsImNoREIiOnRydWUsIkNpdHVzIjp0cnVlLCJjbGlja2hvdXNlLWxvY2FsIChwYXJ0aXRpb25lZCkiOnRydWUsImNsaWNraG91c2UtbG9jYWwgKHNpbmdsZSkiOnRydWUsIkNsaWNrSG91c2UiOnRydWUsIkNsaWNrSG91c2UgKHR1bmVkKSI6dHJ1ZSwiQ2xpY2tIb3VzZSAoenN0ZCkiOnRydWUsIkNsaWNrSG91c2UgQ2xvdWQiOnRydWUsIkNsaWNrSG91c2UgKHdlYikiOnRydWUsIkNyYXRlREIiOnRydWUsIkRhdGFiZW5kIjp0cnVlLCJEYXRhRnVzaW9uIChzaW5nbGUpIjp0cnVlLCJBcGFjaGUgRG9yaXMiOnRydWUsIkRydWlkIjp0cnVlLCJEdWNrREIgKFBhcnF1ZXQpIjp0cnVlLCJEdWNrREIiOnRydWUsIkVsYXN0aWNzZWFyY2giOnRydWUsIkVsYXN0aWNzZWFyY2ggKHR1bmVkKSI6ZmFsc2UsIkdyZWVucGx1bSI6dHJ1ZSwiSGVhdnlBSSI6dHJ1ZSwiSHlkcmEiOnRydWUsIkluZm9icmlnaHQiOnRydWUsIktpbmV0aWNhIjp0cnVlLCJNYXJpYURCIENvbHVtblN0b3JlIjp0cnVlLCJNYXJpYURCIjpmYWxzZSwiTW9uZXREQiI6dHJ1ZSwiTW9uZ29EQiI6dHJ1ZSwiTXlTUUwgKE15SVNBTSkiOnRydWUsIk15U1FMIjp0cnVlLCJQaW5vdCI6dHJ1ZSwiUG9zdGdyZVNRTCI6dHJ1ZSwiUG9zdGdyZVNRTCAodHVuZWQpIjpmYWxzZSwiUXVlc3REQiAocGFydGl0aW9uZWQpIjp0cnVlLCJRdWVzdERCIjp0cnVlLCJSZWRzaGlmdCI6dHJ1ZSwiU2VsZWN0REIiOnRydWUsIlNpbmdsZVN0b3JlIjp0cnVlLCJTbm93Zmxha2UiOnRydWUsIlNRTGl0ZSI6dHJ1ZSwiU3RhclJvY2tzIjp0cnVlLCJUaW1lc2NhbGVEQiAoY29tcHJlc3Npb24pIjp0cnVlLCJUaW1lc2NhbGVEQiI6dHJ1ZX0sInR5cGUiOnsic3RhdGVsZXNzIjpmYWxzZSwibWFuYWdlZCI6ZmFsc2UsIkphdmEiOmZhbHNlLCJjb2x1bW4tb3JpZW50ZWQiOmZhbHNlLCJDKysiOmZhbHNlLCJNeVNRTCBjb21wYXRpYmxlIjpmYWxzZSwicm93LW9yaWVudGVkIjpmYWxzZSwiQyI6ZmFsc2UsIlBvc3RncmVTUUwgY29tcGF0aWJsZSI6ZmFsc2UsIkNsaWNrSG91c2UgZGVyaXZhdGl2ZSI6ZmFsc2UsImVtYmVkZGVkIjp0cnVlLCJzZXJ2ZXJsZXNzIjpmYWxzZSwiUnVzdCI6ZmFsc2UsInNlYXJjaCI6ZmFsc2UsImRvY3VtZW50IjpmYWxzZSwidGltZS1zZXJpZXMiOmZhbHNlfSwibWFjaGluZSI6eyJzZXJ2ZXJsZXNzIjp0cnVlLCIxNmFjdSI6dHJ1ZSwiTCI6dHJ1ZSwiTSI6dHJ1ZSwiUyI6dHJ1ZSwiWFMiOnRydWUsImM2YS5tZXRhbCwgNTAwZ2IgZ3AyIjp0cnVlLCJjNmEuNHhsYXJnZSwgNTAwZ2IgZ3AyIjp0cnVlLCJjNS40eGxhcmdlLCA1MDBnYiBncDIiOnRydWUsIjE2IHRocmVhZHMiOnRydWUsIjIwIHRocmVhZHMiOnRydWUsIjI0IHRocmVhZHMiOnRydWUsIjI4IHRocmVhZHMiOnRydWUsIjMwIHRocmVhZHMiOnRydWUsIjQ4IHRocmVhZHMiOnRydWUsIjYwIHRocmVhZHMiOnRydWUsIm01ZC4yNHhsYXJnZSI6dHJ1ZSwiYzVuLjR4bGFyZ2UsIDIwMGdiIGdwMiI6dHJ1ZSwiYzZhLjR4bGFyZ2UsIDE1MDBnYiBncDIiOnRydWUsImRjMi44eGxhcmdlIjp0cnVlLCJyYTMuMTZ4bGFyZ2UiOnRydWUsInJhMy40eGxhcmdlIjp0cnVlLCJyYTMueGxwbHVzIjp0cnVlLCJTMjQiOnRydWUsIlMyIjp0cnVlLCIyWEwiOnRydWUsIjNYTCI6dHJ1ZSwiNFhMIjp0cnVlLCJYTCI6dHJ1ZX0sImNsdXN0ZXJfc2l6ZSI6eyIxIjp0cnVlLCIyIjp0cnVlLCI0Ijp0cnVlLCI4Ijp0cnVlLCIxNiI6dHJ1ZSwiMzIiOnRydWUsIjY0Ijp0cnVlLCIxMjgiOnRydWUsInNlcnZlcmxlc3MiOnRydWUsInVuZGVmaW5lZCI6dHJ1ZX0sIm1ldHJpYyI6ImhvdCIsInF1ZXJpZXMiOlt0cnVlLHRydWUsdHJ1ZSx0cnVlLHRydWUsdHJ1ZSx0cnVlLHRydWUsdHJ1ZSx0cnVlLHRydWUsdHJ1ZSx0cnVlLHRydWUsdHJ1ZSx0cnVlLHRydWUsdHJ1ZSx0cnVlLHRydWUsdHJ1ZSx0cnVlLHRydWUsdHJ1ZSx0cnVlLHRydWUsdHJ1ZSx0cnVlLHRydWUsdHJ1ZSx0cnVlLHRydWUsdHJ1ZSx0cnVlLHRydWUsdHJ1ZSx0cnVlLHRydWUsdHJ1ZSx0cnVlLHRydWUsdHJ1ZSx0cnVlXX0=)** - SQL API performance comparison
+- **[DataFrame Benchmark](https://benchmark.clickhouse.com/#eyJzeXN0ZW0iOnsiQWxsb3lEQiI6dHJ1ZSwiQWxsb3lEQiAodHVuZWQpIjp0cnVlLCJBdGhlbmEgKHBhcnRpdGlvbmVkKSI6dHJ1ZSwiQXRoZW5hIChzaW5nbGUpIjp0cnVlLCJBdXJvcmEgZm9yIE15U1FMIjp0cnVlLCJBdXJvcmEgZm9yIFBvc3RncmVTUUwiOnRydWUsIkJ5Q29uaXR5Ijp0cnVlLCJCeXRlSG91c2UiOnRydWUsImNoREIgKERhdGFGcmFtZSkiOnRydWUsImNoREIgKFBhcnF1ZXQsIHBhcnRpdGlvbmVkKSI6dHJ1ZSwiY2hEQiI6dHJ1ZSwiQ2l0dXMiOnRydWUsIkNsaWNrSG91c2UgQ2xvdWQgKGF3cykiOnRydWUsIkNsaWNrSG91c2UgQ2xvdWQgKGF6dXJlKSI6dHJ1ZSwiQ2xpY2tIb3VzZSBDbG91ZCAoZ2NwKSI6dHJ1ZSwiQ2xpY2tIb3VzZSAoZGF0YSBsYWtlLCBwYXJ0aXRpb25lZCkiOnRydWUsIkNsaWNrSG91c2UgKGRhdGEgbGFrZSwgc2luZ2xlKSI6dHJ1ZSwiQ2xpY2tIb3VzZSAoUGFycXVldCwgcGFydGl0aW9uZWQpIjp0cnVlLCJDbGlja0hvdXNlIChQYXJxdWV0LCBzaW5nbGUpIjp0cnVlLCJDbGlja0hvdXNlICh3ZWIpIjp0cnVlLCJDbGlja0hvdXNlIjp0cnVlLCJDbGlja0hvdXNlICh0dW5lZCkiOnRydWUsIkNsaWNrSG91c2UgKHR1bmVkLCBtZW1vcnkpIjp0cnVlLCJDbG91ZGJlcnJ5Ijp0cnVlLCJDcmF0ZURCIjp0cnVlLCJDcnVuY2h5IEJyaWRnZSBmb3IgQW5hbHl0aWNzIChQYXJxdWV0KSI6dHJ1ZSwiRGF0YWJlbmQiOnRydWUsIkRhdGFGdXNpb24gKFBhcnF1ZXQsIHBhcnRpdGlvbmVkKSI6dHJ1ZSwiRGF0YUZ1c2lvbiAoUGFycXVldCwgc2luZ2xlKSI6dHJ1ZSwiQXBhY2hlIERvcmlzIjp0cnVlLCJEcnVpZCI6dHJ1ZSwiRHVja0RCIChEYXRhRnJhbWUpIjp0cnVlLCJEdWNrREIgKFBhcnF1ZXQsIHBhcnRpdGlvbmVkKSI6dHJ1ZSwiRHVja0RCIjp0cnVlLCJFbGFzdGljc2VhcmNoIjp0cnVlLCJFbGFzdGljc2VhcmNoICh0dW5lZCkiOmZhbHNlLCJHbGFyZURCIjp0cnVlLCJHcmVlbnBsdW0iOnRydWUsIkhlYXZ5QUkiOnRydWUsIkh5ZHJhIjp0cnVlLCJJbmZvYnJpZ2h0Ijp0cnVlLCJLaW5ldGljYSI6dHJ1ZSwiTWFyaWFEQiBDb2x1bW5TdG9yZSI6dHJ1ZSwiTWFyaWFEQiI6ZmFsc2UsIk1vbmV0REIiOnRydWUsIk1vbmdvREIiOnRydWUsIk1vdGhlcmR1Y2siOnRydWUsIk15U1FMIChNeUlTQU0pIjp0cnVlLCJNeVNRTCI6dHJ1ZSwiT3hsYSI6dHJ1ZSwiUGFuZGFzIChEYXRhRnJhbWUpIjp0cnVlLCJQYXJhZGVEQiAoUGFycXVldCwgcGFydGl0aW9uZWQpIjp0cnVlLCJQYXJhZGVEQiAoUGFycXVldCwgc2luZ2xlKSI6dHJ1ZSwiUGlub3QiOnRydWUsIlBvbGFycyAoRGF0YUZyYW1lKSI6dHJ1ZSwiUG9zdGdyZVNRTCAodHVuZWQpIjpmYWxzZSwiUG9zdGdyZVNRTCI6dHJ1ZSwiUXVlc3REQiAocGFydGl0aW9uZWQpIjp0cnVlLCJRdWVzdERCIjp0cnVlLCJSZWRzaGlmdCI6dHJ1ZSwiU2luZ2xlU3RvcmUiOnRydWUsIlNub3dmbGFrZSI6dHJ1ZSwiU1FMaXRlIjp0cnVlLCJTdGFyUm9ja3MiOnRydWUsIlRhYmxlc3BhY2UiOnRydWUsIlRlbWJvIE9MQVAgKGNvbHVtbmFyKSI6dHJ1ZSwiVGltZXNjYWxlREIgKGNvbXByZXNzaW9uKSI6dHJ1ZSwiVGltZXNjYWxlREIiOnRydWUsIlVtYnJhIjp0cnVlfSwidHlwZSI6eyJDIjpmYWxzZSwiY29sdW1uLW9yaWVudGVkIjpmYWxzZSwiUG9zdGdyZVNRTCBjb21wYXRpYmxlIjpmYWxzZSwibWFuYWdlZCI6ZmFsc2UsImdjcCI6ZmFsc2UsInN0YXRlbGVzcyI6ZmFsc2UsIkphdmEiOmZhbHNlLCJDKysiOmZhbHNlLCJNeVNRTCBjb21wYXRpYmxlIjpmYWxzZSwicm93LW9yaWVudGVkIjpmYWxzZSwiQ2xpY2tIb3VzZSBkZXJpdmF0aXZlIjpmYWxzZSwiZW1iZWRkZWQiOmZhbHNlLCJzZXJ2ZXJsZXNzIjpmYWxzZSwiZGF0YWZyYW1lIjp0cnVlLCJhd3MiOmZhbHNlLCJhenVyZSI6ZmFsc2UsImFuYWx5dGljYWwiOmZhbHNlLCJSdXN0IjpmYWxzZSwic2VhcmNoIjpmYWxzZSwiZG9jdW1lbnQiOmZhbHNlLCJzb21ld2hhdCBQb3N0Z3JlU1FMIGNvbXBhdGlibGUiOmZhbHNlLCJ0aW1lLXNlcmllcyI6ZmFsc2V9LCJtYWNoaW5lIjp7IjE2IHZDUFUgMTI4R0IiOnRydWUsIjggdkNQVSA2NEdCIjp0cnVlLCJzZXJ2ZXJsZXNzIjp0cnVlLCIxNmFjdSI6dHJ1ZSwiYzZhLjR4bGFyZ2UsIDUwMGdiIGdwMiI6dHJ1ZSwiTCI6dHJ1ZSwiTSI6dHJ1ZSwiUyI6dHJ1ZSwiWFMiOnRydWUsImM2YS5tZXRhbCwgNTAwZ2IgZ3AyIjp0cnVlLCIxOTJHQiI6dHJ1ZSwiMjRHQiI6dHJ1ZSwiMzYwR0IiOnRydWUsIjQ4R0IiOnRydWUsIjcyMEdCIjp0cnVlLCI5NkdCIjp0cnVlLCJkZXYiOnRydWUsIjcwOEdCIjp0cnVlLCJjNW4uNHhsYXJnZSwgNTAwZ2IgZ3AyIjp0cnVlLCJBbmFseXRpY3MtMjU2R0IgKDY0IHZDb3JlcywgMjU2IEdCKSI6dHJ1ZSwiYzUuNHhsYXJnZSwgNTAwZ2IgZ3AyIjp0cnVlLCJjNmEuNHhsYXJnZSwgMTUwMGdiIGdwMiI6dHJ1ZSwiY2xvdWQiOnRydWUsImRjMi44eGxhcmdlIjp0cnVlLCJyYTMuMTZ4bGFyZ2UiOnRydWUsInJhMy40eGxhcmdlIjp0cnVlLCJyYTMueGxwbHVzIjp0cnVlLCJTMiI6dHJ1ZSwiUzI0Ijp0cnVlLCIyWEwiOnRydWUsIjNYTCI6dHJ1ZSwiNFhMIjp0cnVlLCJYTCI6dHJ1ZSwiTDEgLSAxNkNQVSAzMkdCIjp0cnVlLCJjNmEuNHhsYXJnZSwgNTAwZ2IgZ3AzIjp0cnVlfSwiY2x1c3Rlcl9zaXplIjp7IjEiOnRydWUsIjIiOnRydWUsIjQiOnRydWUsIjgiOnRydWUsIjE2Ijp0cnVlLCIzMiI6dHJ1ZSwiNjQiOnRydWUsIjEyOCI6dHJ1ZSwic2VydmVybGVzcyI6dHJ1ZX0sIm1ldHJpYyI6ImhvdCIsInF1ZXJpZXMiOlt0cnVlLHRydWUsdHJ1ZSx0cnVlLHRydWUsdHJ1ZSx0cnVlLHRydWUsdHJ1ZSx0cnVlLHRydWUsdHJ1ZSx0cnVlLHRydWUsdHJ1ZSx0cnVlLHRydWUsdHJ1ZSx0cnVlLHRydWUsdHJ1ZSx0cnVlLHRydWUsdHJ1ZSx0cnVlLHRydWUsdHJ1ZSx0cnVlLHRydWUsdHJ1ZSx0cnVlLHRydWUsdHJ1ZSx0cnVlLHRydWUsdHJ1ZSx0cnVlLHRydWUsdHJ1ZSx0cnVlLHRydWUsdHJ1ZSx0cnVlXX0=)** - DataFrame engines comparison
+- **[DataStore vs Pandas](datastore/index.md#performance)** - Up to 20x faster than pandas on common operations
+
+<Image img={dfBench} alt='DataFrame benchmark results' size="md"/>
+
+## About chDB
+- Read the full story about the birth of the chDB project on [blog](https://clickhouse.com/blog/chdb-embedded-clickhouse-rocket-engine-on-a-bicycle)
+- Read about chDB and its use cases on the [Blog](https://clickhouse.com/blog/welcome-chdb-to-clickhouse)
+- Take the [chDB on-demand course](https://learn.clickhouse.com/user_catalog_class/show/1901178)
+- Discover chDB in your browser using [codapi examples](https://antonz.org/trying-chdb/)
+- More examples see (https://github.com/chdb-io/chdb/tree/main/examples)
+
+## License
+chDB is available under the Apache License, Version 2.0. See [LICENSE](https://github.com/chdb-io/chdb/blob/main/LICENSE.txt) for more information.
+
+---
+
+# Getting started with chDB
+
+**URL:** https://clickhouse.com/docs/chdb/getting-started
+
+chDB is an in-process SQL OLAP Engine powered by ClickHouse
+
+In this guide, we're going to get up and running with the Python variant of chDB.
+We'll start by querying a JSON file on S3, before creating a table in chDB based on the JSON file, and doing some queries on the data.
+We'll also see how to have queries return data in different formats, including Apache Arrow and Panda, and finally we'll learn how to query Pandas DataFrames. 
+
+## Setup
+Let's first create a virtual environment:
+
+```bash
+python -m venv .venv
+source .venv/bin/activate
+```
+
+And now we'll install chDB.
+Make sure you have version 2.0.3 or higher:
+
+```bash
+pip install "chdb>=2.0.2"
+```
+
+And now we're going to install [ipython](https://ipython.org/):
+
+```bash
+pip install ipython
+```
+
+We're going to use `ipython` to run the commands in the rest of the guide, which you can launch by running:
+
+```bash
+ipython
+```
+
+We'll also be using Pandas and Apache Arrow in this guide, so let's install those libraries too:
+
+```bash
+pip install pandas pyarrow
+```
+
+## Querying a JSON file in S3
+Let's now have a look at how to query a JSON file that's stored in an S3 bucket. 
+The [YouTube dislikes dataset](/getting-started/example-datasets/youtube-dislikes) contains more than 4 billion rows of dislikes on YouTube videos up to 2021.
+We're going to work with one of the JSON files from that dataset.
+
+Import chdb:
+
+```python
+
+```
+
+We can write the following query to describe the structure of one of the JSON files:
+
+```python
+chdb.query(
+  """
+  DESCRIBE s3(
+    's3://clickhouse-public-datasets/youtube/original/files/' ||
+    'youtubedislikes_20211127161229_18654868.1637897329_vid.json.zst',
+    'JSONLines'
+  )
+  SETTINGS describe_compact_output=1
+  """
+)
+```
+
+```text
+"id","Nullable(String)"
+"fetch_date","Nullable(String)"
+"upload_date","Nullable(String)"
+"title","Nullable(String)"
+"uploader_id","Nullable(String)"
+"uploader","Nullable(String)"
+"uploader_sub_count","Nullable(Int64)"
+"is_age_limit","Nullable(Bool)"
+"view_count","Nullable(Int64)"
+"like_count","Nullable(Int64)"
+"dislike_count","Nullable(Int64)"
+"is_crawlable","Nullable(Bool)"
+"is_live_content","Nullable(Bool)"
+"has_subtitles","Nullable(Bool)"
+"is_ads_enabled","Nullable(Bool)"
+"is_comments_enabled","Nullable(Bool)"
+"description","Nullable(String)"
+"rich_metadata","Array(Tuple(
+    call Nullable(String),
+    content Nullable(String),
+    subtitle Nullable(String),
+    title Nullable(String),
+    url Nullable(String)))"
+"super_titles","Array(Tuple(
+    text Nullable(String),
+    url Nullable(String)))"
+"uploader_badges","Nullable(String)"
+"video_badges","Nullable(String)"
+```
+
+We can also count the number of rows in that file:
+
+```python
+chdb.query(
+  """
+  SELECT count()
+  FROM s3(
+    's3://clickhouse-public-datasets/youtube/original/files/' ||
+    'youtubedislikes_20211127161229_18654868.1637897329_vid.json.zst',
+    'JSONLines'
+  )"""
+)
+```
+
+```text
+336432
+```
+
+This file contains just over 300,000 records.
+
+chdb doesn't yet support passing in query parameters, but we can pull out the path and pass it in via an f-String.
+
+```python
+path = 's3://clickhouse-public-datasets/youtube/original/files/youtubedislikes_20211127161229_18654868.1637897329_vid.json.zst'
+```
+
+```python
+chdb.query(
+  f"""
+  SELECT count()
+  FROM s3('{path}','JSONLines')
+  """
+)
+```
+
+:::warning
+This is fine to do with variables defined in your program, but don't do it with user-provided input, otherwise your query is open to SQL injection.
+:::
+
+## Configuring the output format
+The default output format is `CSV`, but we can change that via the `output_format` parameter. 
+chDB supports the ClickHouse data formats, as well as [some of its own](/chdb/reference/data-formats.md), including `DataFrame`, which returns a Pandas DataFrame:
+
+```python
+result = chdb.query(
+  f"""
+  SELECT is_ads_enabled, count()
+  FROM s3('{path}','JSONLines')
+  GROUP BY ALL
+  """,
+  output_format="DataFrame"
+)
+
+print(type(result))
+print(result)
+```
+
+```text
+<class 'pandas.core.frame.DataFrame'>
+   is_ads_enabled  count()
+0           False   301125
+1            True    35307
+```
+
+Or if we want to get back an Apache Arrow table:
+
+```python
+result = chdb.query(
+  f"""
+  SELECT is_live_content, count()
+  FROM s3('{path}','JSONLines')
+  GROUP BY ALL
+  """,
+  output_format="ArrowTable"
+)
+
+print(type(result))
+print(result)
+```
+
+```text
+<class 'pyarrow.lib.Table'>
+pyarrow.Table
+is_live_content: bool
+count(): uint64 not null
+----
+is_live_content: [[false,true]]
+count(): [[315746,20686]]
+```
+
+## Creating a table from JSON file
+Next, let's have a look at how to create a table in chDB. 
+We need to use a different API to do that, so let's first import that:
+
+```python
+from chdb import session as chs
+```
+
+Next, we'll initialize a session.
+If we want the session to be persisted to disk, we need to provide a directory name.
+If we leave it blank, the database will be in-memory and lost as soon as we kill the Python process.
+
+```python
+sess = chs.Session("gettingStarted.chdb")
+```
+
+Next, we'll create a database:
+
+```python
+sess.query("CREATE DATABASE IF NOT EXISTS youtube")
+```
+
+Now we can create a `dislikes` table based on the schema from the JSON file, using the `CREATE...EMPTY AS` technique.
+We'll use the [`schema_inference_make_columns_nullable`](/operations/settings/formats/#schema_inference_make_columns_nullable) setting so that column types aren't all made `Nullable`.
+
+```python
+sess.query(f"""
+  CREATE TABLE youtube.dislikes
+  ORDER BY fetch_date 
+  EMPTY AS 
+  SELECT * 
+  FROM s3('{path}','JSONLines')
+  SETTINGS schema_inference_make_columns_nullable=0
+  """
+)
+```
+
+We can then use the `DESCRIBE` clause to inspect the schema:
+
+```python
+sess.query(f"""
+   DESCRIBE youtube.dislikes
+   SETTINGS describe_compact_output=1
+   """
+)
+```
+
+```text
+"id","String"
+"fetch_date","String"
+"upload_date","String"
+"title","String"
+"uploader_id","String"
+"uploader","String"
+"uploader_sub_count","Int64"
+"is_age_limit","Bool"
+"view_count","Int64"
+"like_count","Int64"
+"dislike_count","Int64"
+"is_crawlable","Bool"
+"is_live_content","Bool"
+"has_subtitles","Bool"
+"is_ads_enabled","Bool"
+"is_comments_enabled","Bool"
+"description","String"
+"rich_metadata","Array(Tuple(
+    call String,
+    content String,
+    subtitle String,
+    title String,
+    url String))"
+"super_titles","Array(Tuple(
+    text String,
+    url String))"
+"uploader_badges","String"
+"video_badges","String"
+```
+
+Next, let's populate that table:
+
+```python
+sess.query(f"""
+  INSERT INTO youtube.dislikes
+  SELECT * 
+  FROM s3('{path}','JSONLines')
+  SETTINGS schema_inference_make_columns_nullable=0
+  """
+)
+```
+
+We could also do both these steps in one go, using the `CREATE...AS` technique.
+Let's create a different table using that technique:
+
+```python
+sess.query(f"""
+  CREATE TABLE youtube.dislikes2
+  ORDER BY fetch_date 
+  AS 
+  SELECT * 
+  FROM s3('{path}','JSONLines')
+  SETTINGS schema_inference_make_columns_nullable=0
+  """
+)
+```
+
+## Querying a table
+Finally, let's query the table:
+
+```sql
+df = sess.query("""
+  SELECT uploader, sum(view_count) AS viewCount, sum(like_count) AS likeCount, sum(dislike_count) AS dislikeCount
+  FROM youtube.dislikes
+  GROUP BY ALL
+  ORDER BY viewCount DESC
+  LIMIT 10
+  """,
+  "DataFrame"
+)
+df
+```
+
+```text
+                             uploader  viewCount  likeCount  dislikeCount
+0                             Jeremih  139066569     812602         37842
+1                     TheKillersMusic  109313116     529361         11931
+2  LetsGoMartin- Canciones Infantiles  104747788     236615        141467
+3                    Xiaoying Cuisine   54458335    1031525         37049
+4                                Adri   47404537     279033         36583
+5                  Diana and Roma IND   43829341     182334        148740
+6                      ChuChuTV Tamil   39244854     244614        213772
+7                            Cheez-It   35342270        108            27
+8                            Anime Uz   33375618    1270673         60013
+9                    RC Cars OFF Road   31952962     101503         49489
+```
+
+Let's say we then add an extra column to the DataFrame to compute the ratio of likes to dislikes.
+We could write the following code:
+
+```python
+df["likeDislikeRatio"] = df["likeCount"] / df["dislikeCount"]
+```
+
+## Querying a Pandas dataframe
+We can then query that DataFrame from chDB:
+
+```python
+chdb.query(
+  """
+  SELECT uploader, likeDislikeRatio
+  FROM Python(df)
+  """,
+  output_format="DataFrame"
+)
+```
+
+```text
+                             uploader  likeDislikeRatio
+0                             Jeremih         21.473548
+1                     TheKillersMusic         44.368536
+2  LetsGoMartin- Canciones Infantiles          1.672581
+3                    Xiaoying Cuisine         27.842182
+4                                Adri          7.627395
+5                  Diana and Roma IND          1.225857
+6                      ChuChuTV Tamil          1.144275
+7                            Cheez-It          4.000000
+8                            Anime Uz         21.173296
+9                    RC Cars OFF Road          2.051021
+```
+
+You can also read more about querying Pandas DataFrames in the [Querying Pandas developer guide](guides/querying-pandas.md).
+
+## Next steps
+Hopefully, this guide has given you a good overview of chDB. 
+To learn more about how to use it, see the following developer guides:
+
+* [Querying Pandas DataFrames](guides/querying-pandas.md)
+* [Querying Apache Arrow](guides/querying-apache-arrow.md)
+* [Using chDB in JupySQL](guides/jupysql.md)
+* [Using chDB with an existing clickhouse-local database](guides/clickhouse-local.md)
+
+---
+
+# chDB for Bun
+
+**URL:** https://clickhouse.com/docs/chdb/install/bun
+
+How to install and use chDB with Bun runtime
+
+chDB-bun provides experimental FFI (Foreign Function Interface) bindings for chDB, enabling you to run ClickHouse queries directly in your Bun applications with zero external dependencies.
+
+## Installation
+### Step 1: Install system dependencies
+First, install the required system dependencies:
+
+#### Install libchdb
+```bash
+curl -sL https://lib.chdb.io | bash
+```
+
+#### Install build tools
+You'll need either `gcc` or `clang` installed on your system:
+
+### Step 2: Install chDB-bun
+```bash
+# Install from the GitHub repository
+bun add github:chdb-io/chdb-bun
+
+# Or clone and build locally
+git clone https://github.com/chdb-io/chdb-bun.git
+cd chdb-bun
+bun install
+bun run build
+```
+
+## Usage
+chDB-bun supports two query modes: ephemeral queries for one-time operations and persistent sessions for maintaining database state.
+
+### Ephemeral queries
+For simple, one-off queries that don't require persistent state:
+
+```typescript
+
+// Basic query
+const result = query("SELECT version()", "CSV");
+console.log(result); // "23.10.1.1"
+
+// Query with different output formats
+const jsonResult = query("SELECT 1 as id, 'Hello' as message", "JSON");
+console.log(jsonResult);
+
+// Query with calculations
+const mathResult = query("SELECT 2 + 2 as sum, pi() as pi_value", "Pretty");
+console.log(mathResult);
+
+// Query system information
+const systemInfo = query("SELECT * FROM system.functions LIMIT 5", "CSV");
+console.log(systemInfo);
+```
+
+### Persistent sessions
+For complex operations that require maintaining state across queries:
+
+```typescript
+
+// Create a session with persistent storage
+const sess = new Session('./chdb-bun-tmp');
+
+try {
+    // Create a database and table
+    sess.query(`
+        CREATE DATABASE IF NOT EXISTS mydb;
+        CREATE TABLE IF NOT EXISTS mydb.users (
+            id UInt32,
+            name String,
+            email String
+        ) ENGINE = MergeTree() ORDER BY id
+    `, "CSV");
+
+    // Insert data
+    sess.query(`
+        INSERT INTO mydb.users VALUES 
+        (1, 'Alice', 'alice@example.com'),
+        (2, 'Bob', 'bob@example.com'),
+        (3, 'Charlie', 'charlie@example.com')
+    `, "CSV");
+
+    // Query the data
+    const users = sess.query("SELECT * FROM mydb.users ORDER BY id", "JSON");
+    console.log("Users:", users);
+
+    // Create and use custom functions
+    sess.query("CREATE FUNCTION IF NOT EXISTS hello AS () -> 'Hello chDB'", "CSV");
+    const greeting = sess.query("SELECT hello() as message", "Pretty");
+    console.log(greeting);
+
+    // Aggregate queries
+    const stats = sess.query(`
+        SELECT 
+            COUNT(*) as total_users,
+            MAX(id) as max_id,
+            MIN(id) as min_id
+        FROM mydb.users
+    `, "JSON");
+    console.log("Statistics:", stats);
+
+} finally {
+    // Always cleanup the session to free resources
+    sess.cleanup(); // This deletes the database files
+}
+```
+
+---
+
+# chDB for C and C++
+
+**URL:** https://clickhouse.com/docs/chdb/install/c
+
+How to install and use chDB with C and C++
+
+chDB provides a native C/C++ API for embedding ClickHouse functionality directly into your applications. The API supports both simple queries and advanced features like persistent connections and streaming query results.
+
+## Installation
+### Step 1: Install libchdb
+Install the chDB library on your system:
+
+```bash
+curl -sL https://lib.chdb.io | bash
+```
+
+### Step 2: Include headers
+Include the chDB header in your project:
+
+```c
+#include <chdb.h>
+```
+
+### Step 3: Link library
+Compile and link your application with chDB:
+
+```bash
+# C compilation
+gcc -o myapp myapp.c -lchdb
+
+# C++ compilation  
+g++ -o myapp myapp.cpp -lchdb
+```
+
+## C Examples
+### Basic connection and queries
+```c
+#include <stdio.h>
+#include <chdb.h>
+
+int main() {
+    // Create connection arguments
+    char* args[] = {"chdb", "--path", "/tmp/chdb-data"};
+    int argc = 3;
+    
+    // Connect to chDB
+    chdb_connection* conn = chdb_connect(argc, args);
+    if (!conn) {
+        printf("Failed to connect to chDB\n");
+        return 1;
+    }
+    
+    // Execute a query
+    chdb_result* result = chdb_query(*conn, "SELECT version()", "CSV");
+    if (!result) {
+        printf("Query execution failed\n");
+        chdb_close_conn(conn);
+        return 1;
+    }
+    
+    // Check for errors
+    const char* error = chdb_result_error(result);
+    if (error) {
+        printf("Query error: %s\n", error);
+    } else {
+        // Get result data
+        char* data = chdb_result_buffer(result);
+        size_t length = chdb_result_length(result);
+        double elapsed = chdb_result_elapsed(result);
+        uint64_t rows = chdb_result_rows_read(result);
+        
+        printf("Result: %.*s\n", (int)length, data);
+        printf("Elapsed: %.3f seconds\n", elapsed);
+        printf("Rows: %llu\n", rows);
+    }
+    
+    // Cleanup
+    chdb_destroy_query_result(result);
+    chdb_close_conn(conn);
+    return 0;
+}
+```
+
+### Streaming queries
+```c
+#include <stdio.h>
+#include <chdb.h>
+
+int main() {
+    char* args[] = {"chdb", "--path", "/tmp/chdb-stream"};
+    chdb_connection* conn = chdb_connect(3, args);
+    
+    if (!conn) {
+        printf("Failed to connect\n");
+        return 1;
+    }
+    
+    // Start streaming query
+    chdb_result* stream_result = chdb_stream_query(*conn, 
+        "SELECT number FROM system.numbers LIMIT 1000000", "CSV");
+    
+    if (!stream_result) {
+        printf("Failed to start streaming query\n");
+        chdb_close_conn(conn);
+        return 1;
+    }
+    
+    uint64_t total_rows = 0;
+    
+    // Process chunks
+    while (true) {
+        chdb_result* chunk = chdb_stream_fetch_result(*conn, stream_result);
+        if (!chunk) break;
+        
+        // Check if we have data in this chunk
+        size_t chunk_length = chdb_result_length(chunk);
+        if (chunk_length == 0) {
+            chdb_destroy_query_result(chunk);
+            break; // End of stream
+        }
+        
+        uint64_t chunk_rows = chdb_result_rows_read(chunk);
+        total_rows += chunk_rows;
+        
+        printf("Processed chunk: %llu rows, %zu bytes\n", chunk_rows, chunk_length);
+        
+        // Process the chunk data here
+        // char* data = chdb_result_buffer(chunk);
+        
+        chdb_destroy_query_result(chunk);
+        
+        // Progress reporting
+        if (total_rows % 100000 == 0) {
+            printf("Progress: %llu rows processed\n", total_rows);
+        }
+    }
+    
+    printf("Streaming complete. Total rows: %llu\n", total_rows);
+    
+    // Cleanup streaming query
+    chdb_destroy_query_result(stream_result);
+    chdb_close_conn(conn);
+    return 0;
+}
+```
+
+### Working with different data formats
+```c
+#include <stdio.h>
+#include <chdb.h>
+
+int main() {
+    char* args[] = {"chdb"};
+    chdb_connection* conn = chdb_connect(1, args);
+    
+    const char* query = "SELECT number, toString(number) as str FROM system.numbers LIMIT 3";
+    
+    // CSV format
+    chdb_result* csv_result = chdb_query(*conn, query, "CSV");
+    printf("CSV Result:\n%.*s\n\n", 
+           (int)chdb_result_length(csv_result), 
+           chdb_result_buffer(csv_result));
+    chdb_destroy_query_result(csv_result);
+    
+    // JSON format
+    chdb_result* json_result = chdb_query(*conn, query, "JSON");
+    printf("JSON Result:\n%.*s\n\n", 
+           (int)chdb_result_length(json_result), 
+           chdb_result_buffer(json_result));
+    chdb_destroy_query_result(json_result);
+    
+    // Pretty format
+    chdb_result* pretty_result = chdb_query(*conn, query, "Pretty");
+    printf("Pretty Result:\n%.*s\n\n", 
+           (int)chdb_result_length(pretty_result), 
+           chdb_result_buffer(pretty_result));
+    chdb_destroy_query_result(pretty_result);
+    
+    chdb_close_conn(conn);
+    return 0;
+}
+```
+
+## C++ example
+```cpp
+#include <iostream>
+#include <string>
+#include <vector>
+#include <chdb.h>
+
+class ChDBConnection {
+private:
+    chdb_connection* conn;
+    
+public:
+    ChDBConnection(const std::vector<std::string>& args) {
+        // Convert string vector to char* array
+        std::vector<char*> argv;
+        for (const auto& arg : args) {
+            argv.push_back(const_cast<char*>(arg.c_str()));
+        }
+        
+        conn = chdb_connect(argv.size(), argv.data());
+        if (!conn) {
+            throw std::runtime_error("Failed to connect to chDB");
+        }
+    }
+    
+    ~ChDBConnection() {
+        if (conn) {
+            chdb_close_conn(conn);
+        }
+    }
+    
+    std::string query(const std::string& sql, const std::string& format = "CSV") {
+        chdb_result* result = chdb_query(*conn, sql.c_str(), format.c_str());
+        if (!result) {
+            throw std::runtime_error("Query execution failed");
+        }
+        
+        const char* error = chdb_result_error(result);
+        if (error) {
+            std::string error_msg(error);
+            chdb_destroy_query_result(result);
+            throw std::runtime_error("Query error: " + error_msg);
+        }
+        
+        std::string data(chdb_result_buffer(result), chdb_result_length(result));
+        
+        // Get query statistics
+        std::cout << "Query statistics:\n";
+        std::cout << "  Elapsed: " << chdb_result_elapsed(result) << " seconds\n";
+        std::cout << "  Rows read: " << chdb_result_rows_read(result) << "\n";
+        std::cout << "  Bytes read: " << chdb_result_bytes_read(result) << "\n";
+        
+        chdb_destroy_query_result(result);
+        return data;
+    }
+};
+
+int main() {
+    try {
+        // Create connection
+        ChDBConnection db({{"chdb", "--path", "/tmp/chdb-cpp"}});
+        
+        // Create and populate table
+        db.query("CREATE TABLE test (id UInt32, value String) ENGINE = MergeTree() ORDER BY id");
+        db.query("INSERT INTO test VALUES (1, 'hello'), (2, 'world'), (3, 'chdb')");
+        
+        // Query with different formats
+        std::cout << "CSV Results:\n" << db.query("SELECT * FROM test", "CSV") << "\n";
+        std::cout << "JSON Results:\n" << db.query("SELECT * FROM test", "JSON") << "\n";
+        
+        // Aggregation query
+        std::cout << "Count: " << db.query("SELECT COUNT(*) FROM test") << "\n";
+        
+    } catch (const std::exception& e) {
+        std::cerr << "Error: " << e.what() << std::endl;
+        return 1;
+    }
+    
+    return 0;
+}
+```
+
+## Error handling best practices
+```c
+#include <stdio.h>
+#include <chdb.h>
+
+int safe_query_example() {
+    chdb_connection* conn = NULL;
+    chdb_result* result = NULL;
+    int return_code = 0;
+    
+    // Create connection
+    char* args[] = {"chdb"};
+    conn = chdb_connect(1, args);
+    if (!conn) {
+        printf("Failed to create connection\n");
+        return 1;
+    }
+    
+    // Execute query
+    result = chdb_query(*conn, "SELECT invalid_syntax", "CSV");
+    if (!result) {
+        printf("Query execution failed\n");
+        return_code = 1;
+        goto cleanup;
+    }
+    
+    // Check for query errors
+    const char* error = chdb_result_error(result);
+    if (error) {
+        printf("Query error: %s\n", error);
+        return_code = 1;
+        goto cleanup;
+    }
+    
+    // Process successful result
+    printf("Result: %.*s\n", 
+           (int)chdb_result_length(result), 
+           chdb_result_buffer(result));
+    
+cleanup:
+    if (result) chdb_destroy_query_result(result);
+    if (conn) chdb_close_conn(conn);
+    return return_code;
+}
+```
+
+## GitHub repository
+- **Main Repository**: [chdb-io/chdb](https://github.com/chdb-io/chdb)
+- **Issues and Support**: Report issues on the [GitHub repository](https://github.com/chdb-io/chdb/issues)
+- **C API Documentation**: [Bindings Documentation](https://github.com/chdb-io/chdb-core/blob/main/bindings.md)
+
+---
+
+# chDB for Go
+
+**URL:** https://clickhouse.com/docs/chdb/install/go
+
+How to install and use chDB with Go
+
+chDB-go provides Go bindings for chDB, enabling you to run ClickHouse queries directly in your Go applications with zero external dependencies.
+
+## Installation
+### Step 1: Install libchdb
+First, install the chDB library:
+
+```bash
+curl -sL https://lib.chdb.io | bash
+```
+
+### Step 2: Install chdb-go
+Install the Go package:
+
+```bash
+go install github.com/chdb-io/chdb-go@latest
+```
+
+Or add it to your `go.mod`:
+
+```bash
+go get github.com/chdb-io/chdb-go
+```
+
+## Usage
+### Command line interface
+chDB-go includes a CLI for quick queries:
+
+```bash
+# Simple query
+./chdb-go "SELECT 123"
+
+# Interactive mode
+./chdb-go
+
+# Interactive mode with persistent storage
+./chdb-go --path /tmp/chdb
+```
+
+### Go Library - quick start
+#### Stateless queries
+For simple, one-off queries:
+
+```go
+package main
+
+    "fmt"
+    "github.com/chdb-io/chdb-go/chdb"
+)
+
+func main() {
+    // Execute a simple query
+    result, err := chdb.Query("SELECT version()", "CSV")
+    if err != nil {
+        panic(err)
+    }
+    fmt.Println(result)
+}
+```
+
+#### Stateful queries with session
+For complex queries with persistent state:
+
+```go
+package main
+
+    "fmt"
+    "github.com/chdb-io/chdb-go/chdb"
+)
+
+func main() {
+    // Create a session with persistent storage
+    session, err := chdb.NewSession("/tmp/chdb-data")
+    if err != nil {
+        panic(err)
+    }
+    defer session.Cleanup()
+
+    // Create database and table
+    _, err = session.Query(`
+        CREATE DATABASE IF NOT EXISTS testdb;
+        CREATE TABLE IF NOT EXISTS testdb.test_table (
+            id UInt32,
+            name String
+        ) ENGINE = MergeTree() ORDER BY id
+    `, "")
+    
+    if err != nil {
+        panic(err)
+    }
+
+    // Insert data
+    _, err = session.Query(`
+        INSERT INTO testdb.test_table VALUES 
+        (1, 'Alice'), (2, 'Bob'), (3, 'Charlie')
+    `, "")
+    
+    if err != nil {
+        panic(err)
+    }
+
+    // Query data
+    result, err := session.Query("SELECT * FROM testdb.test_table ORDER BY id", "Pretty")
+    if err != nil {
+        panic(err)
+    }
+    
+    fmt.Println(result)
+}
+```
+
+#### SQL driver interface
+chDB-go implements Go's `database/sql` interface:
+
+```go
+package main
+
+    "database/sql"
+    "fmt"
+    _ "github.com/chdb-io/chdb-go/chdb/driver"
+)
+
+func main() {
+    // Open database connection
+    db, err := sql.Open("chdb", "")
+    if err != nil {
+        panic(err)
+    }
+    defer db.Close()
+
+    // Query with standard database/sql interface
+    rows, err := db.Query("SELECT COUNT(*) FROM url('https://datasets.clickhouse.com/hits/hits.parquet')")
+    if err != nil {
+        panic(err)
+    }
+    defer rows.Close()
+
+    for rows.Next() {
+        var count int
+        err := rows.Scan(&count)
+        if err != nil {
+            panic(err)
+        }
+        fmt.Printf("Count: %d\n", count)
+    }
+}
+```
+
+#### Query streaming for large datasets
+For processing large datasets that don't fit in memory, use streaming queries:
+
+```go
+package main
+
+    "fmt"
+    "log"
+    "github.com/chdb-io/chdb-go/chdb"
+)
+
+func main() {
+    // Create a session for streaming queries
+    session, err := chdb.NewSession("/tmp/chdb-stream")
+    if err != nil {
+        log.Fatal(err)
+    }
+    defer session.Cleanup()
+
+    // Execute a streaming query for large dataset
+    streamResult, err := session.QueryStreaming(
+        "SELECT number, number * 2 as double FROM system.numbers LIMIT 1000000", 
+        "CSV",
+    )
+    if err != nil {
+        log.Fatal(err)
+    }
+    defer streamResult.Free()
+
+    rowCount := 0
+    
+    // Process data in chunks
+    for {
+        chunk := streamResult.GetNext()
+        if chunk == nil {
+            // No more data
+            break
+        }
+        
+        // Check for streaming errors
+        if err := streamResult.Error(); err != nil {
+            log.Printf("Streaming error: %v", err)
+            break
+        }
+        
+        rowsRead := chunk.RowsRead()
+        // You can process the chunk data here
+        // For example, write to file, send over network, etc.
+        fmt.Printf("Processed chunk with %d rows\n", rowsRead)
+        rowCount += int(rowsRead)
+        if rowCount%100000 == 0 {
+            fmt.Printf("Processed %d rows so far...\n", rowCount)
+        }
+    }
+    
+    fmt.Printf("Total rows processed: %d\n", rowCount)
+}
+```
+
+**Benefits of query streaming:**
+- **Memory efficient** - Process large datasets without loading everything into memory
+- **Real-time processing** - Start processing data as soon as first chunk arrives
+- **Cancellation support** - Can cancel long-running queries with `Cancel()`
+- **Error handling** - Check for errors during streaming with `Error()`
+
+## API documentation
+chDB-go provides both high-level and low-level APIs:
+
+- **[High-Level API Documentation](https://github.com/chdb-io/chdb-go/blob/main/chdb.md)** - Recommended for most use cases
+- **[Low-Level API Documentation](https://github.com/chdb-io/chdb-go/blob/main/lowApi.md)** - For advanced use cases requiring fine-grained control
+
+## System requirements
+- Go 1.21 or later
+- Compatible with Linux, macOS
+
+---
+
+# Language integrations index
+
+**URL:** https://clickhouse.com/docs/chdb/install
+
+Index page for chDB language integrations
+
+Instructions for how to get setup with chDB are available below for the following languages and runtimes:
+
+| Language                               | API Reference                       |
+|----------------------------------------|-------------------------------------|
+| [Python](/chdb/install/python) | [Python API](/chdb/api/python) |
+| [NodeJS](/chdb/install/nodejs) |                                     |
+| [Go](/chdb/install/go)         |                                     |
+| [Rust](/chdb/install/rust)     |                                     |
+| [Bun](/chdb/install/bun)       |                                     |
+| [C and C++](/chdb/install/c)   |                                     |
+
+---
+
+# chDB for Node.js
+
+**URL:** https://clickhouse.com/docs/chdb/install/nodejs
+
+How to install and use chDB with Node.js
+
+chDB-node provides Node.js bindings for chDB, enabling you to run ClickHouse queries directly in your Node.js applications with zero external dependencies.
+
+## Installation
+```bash
+npm install chdb
+```
+
+## Usage
+chDB-node supports two query modes: standalone queries for simple operations and session-based queries for maintaining database state.
+
+### Standalone queries
+For simple, one-off queries that don't require persistent state:
+
+```javascript
+const { query } = require("chdb");
+
+// Basic query
+const result = query("SELECT version()", "CSV");
+console.log("ClickHouse version:", result);
+
+// Query with multiple columns
+const multiResult = query("SELECT 'Hello' as greeting, 'chDB' as engine, 42 as answer", "CSV");
+console.log("Multi-column result:", multiResult);
+
+// Mathematical operations
+const mathResult = query("SELECT 2 + 2 as sum, pi() as pi_value", "JSON");
+console.log("Math result:", mathResult);
+
+// System information
+const systemInfo = query("SELECT * FROM system.functions LIMIT 5", "Pretty");
+console.log("System functions:", systemInfo);
+```
+
+### Session-Based queries
+```javascript
+const { Session } = require("chdb");
+
+// Create a session with persistent storage
+const session = new Session("./chdb-node-data");
+
+try {
+    // Create database and table
+    session.query(`
+        CREATE DATABASE IF NOT EXISTS myapp;
+        CREATE TABLE IF NOT EXISTS myapp.users (
+            id UInt32,
+            name String,
+            email String,
+            created_at DateTime DEFAULT now()
+        ) ENGINE = MergeTree() ORDER BY id
+    `);
+
+    // Insert sample data
+    session.query(`
+        INSERT INTO myapp.users (id, name, email) VALUES 
+        (1, 'Alice', 'alice@example.com'),
+        (2, 'Bob', 'bob@example.com'),
+        (3, 'Charlie', 'charlie@example.com')
+    `);
+
+    // Query the data with different formats
+    const csvResult = session.query("SELECT * FROM myapp.users ORDER BY id", "CSV");
+    console.log("CSV Result:", csvResult);
+
+    const jsonResult = session.query("SELECT * FROM myapp.users ORDER BY id", "JSON");
+    console.log("JSON Result:", jsonResult);
+
+    // Aggregate queries
+    const stats = session.query(`
+        SELECT 
+            COUNT(*) as total_users,
+            MAX(id) as max_id,
+            MIN(created_at) as earliest_signup
+        FROM myapp.users
+    `, "Pretty");
+    console.log("User Statistics:", stats);
+
+} finally {
+    // Always cleanup the session
+    session.cleanup(); // This deletes the database files
+}
+```
+
+### Processing external data
+```javascript
+const { Session } = require("chdb");
+
+const session = new Session("./data-processing");
+
+try {
+    // Process CSV data from URL
+    const result = session.query(`
+        SELECT 
+            COUNT(*) as total_records,
+            COUNT(DISTINCT "UserID") as unique_users
+        FROM url('https://datasets.clickhouse.com/hits/hits.csv', 'CSV') 
+        LIMIT 1000
+    `, "JSON");
+    
+    console.log("External data analysis:", result);
+
+    // Create table from external data
+    session.query(`
+        CREATE TABLE web_analytics AS
+        SELECT * FROM url('https://datasets.clickhouse.com/hits/hits.csv', 'CSV')
+        LIMIT 10000
+    `);
+
+    // Analyze the imported data
+    const analysis = session.query(`
+        SELECT 
+            toDate("EventTime") as date,
+            COUNT(*) as events,
+            COUNT(DISTINCT "UserID") as unique_users
+        FROM web_analytics
+        GROUP BY date
+        ORDER BY date
+        LIMIT 10
+    `, "Pretty");
+    
+    console.log("Daily analytics:", analysis);
+
+} finally {
+    session.cleanup();
+}
+```
+
+## Error handling
+Always handle errors appropriately when working with chDB:
+
+```javascript
+const { query, Session } = require("chdb");
+
+// Error handling for standalone queries
+function safeQuery(sql, format = "CSV") {
+    try {
+        const result = query(sql, format);
+        return { success: true, data: result };
+    } catch (error) {
+        console.error("Query error:", error.message);
+        return { success: false, error: error.message };
+    }
+}
+
+// Example usage
+const result = safeQuery("SELECT invalid_syntax");
+if (result.success) {
+    console.log("Query result:", result.data);
+} else {
+    console.log("Query failed:", result.error);
+}
+
+// Error handling for sessions
+function safeSessionQuery() {
+    const session = new Session("./error-test");
+    
+    try {
+        // This will throw an error due to invalid syntax
+        const result = session.query("CREATE TABLE invalid syntax", "CSV");
+        console.log("Unexpected success:", result);
+    } catch (error) {
+        console.error("Session query error:", error.message);
+    } finally {
+        // Always cleanup, even if an error occurred
+        session.cleanup();
+    }
+}
+
+safeSessionQuery();
+```
+
+## GitHub repository
+- **GitHub Repository**: [chdb-io/chdb-node](https://github.com/chdb-io/chdb-node)
+- **Issues and Support**: Report issues on the [GitHub repository](https://github.com/chdb-io/chdb-node/issues)
+- **NPM Package**: [chdb on npm](https://www.npmjs.com/package/chdb)
+
+---
+
+# Installing chDB for Python
+
+**URL:** https://clickhouse.com/docs/chdb/install/python
+
+How to install chDB for Python
+
+## Requirements
+- Python 3.8+ 
+- Supported platforms: macOS and Linux (x86_64 and ARM64)
+
+## Installation
+```bash
+pip install chdb
+```
+
+## Usage
+### Command line interface
+Run SQL queries directly from the command line:
+
+```bash
+# Basic query
+python3 -m chdb "SELECT 1, 'abc'" Pretty
+
+# Query with formatting
+python3 -m chdb "SELECT version()" JSON
+```
+
+### Basic python usage
+```python
+
+# Simple query
+result = chdb.query("SELECT 1 as id, 'Hello World' as message", "CSV")
+print(result)
+
+# Get query statistics
+print(f"Rows read: {result.rows_read()}")
+print(f"Bytes read: {result.bytes_read()}")
+print(f"Execution time: {result.elapsed()} seconds")
+```
+
+### Connection-based API (recommended)
+For better resource management and performance:
+
+```python
+
+# Create connection (in-memory by default)
+conn = chdb.connect(":memory:")
+# Or use file-based: conn = chdb.connect("mydata.db")
+
+# Create cursor for query execution
+cur = conn.cursor()
+
+# Execute queries
+cur.execute("SELECT number, toString(number) as str FROM system.numbers LIMIT 3")
+
+# Fetch results in different ways
+print(cur.fetchone())    # Single row: (0, '0')
+print(cur.fetchmany(2))  # Multiple rows: ((1, '1'), (2, '2'))
+
+# Get metadata
+print(cur.column_names())  # ['number', 'str']
+print(cur.column_types())  # ['UInt64', 'String']
+
+# Use cursor as iterator
+for row in cur:
+    print(row)
+
+# Always close resources
+cur.close()
+conn.close()
+```
+
+## Data input methods
+### File-based data sources
+chDB supports 70+ data formats for direct file querying:
+
+```python
+
+# Prepare your data
+# ...
+
+# Query Parquet files
+result = chdb.query("""
+    SELECT customer_id, sum(amount) as total
+    FROM file('sales.parquet', Parquet) 
+    GROUP BY customer_id 
+    ORDER BY total DESC 
+    LIMIT 10
+""", 'JSONEachRow')
+
+# Query CSV with headers
+result = chdb.query("""
+    SELECT * FROM file('data.csv', CSVWithNames) 
+    WHERE column1 > 100
+""", 'DataFrame')
+
+# Multiple file formats
+result = chdb.query("""
+    SELECT * FROM file('logs*.jsonl', JSONEachRow)
+    WHERE timestamp > '2024-01-01'
+""", 'Pretty')
+```
+
+### Output format examples
+```python
+# DataFrame for analysis
+df = chdb.query('SELECT * FROM system.numbers LIMIT 5', 'DataFrame')
+print(type(df))  # <class 'pandas.core.frame.DataFrame'>
+
+# Arrow Table for interoperability  
+arrow_table = chdb.query('SELECT * FROM system.numbers LIMIT 5', 'ArrowTable')
+print(type(arrow_table))  # <class 'pyarrow.lib.Table'>
+
+# JSON for APIs
+json_result = chdb.query('SELECT version()', 'JSON')
+print(json_result)
+
+# Pretty format for debugging
+pretty_result = chdb.query('SELECT * FROM system.numbers LIMIT 3', 'Pretty')
+print(pretty_result)
+```
+
+### DataFrame operations
+#### Legacy DataFrame API
+```python
+
+# Join multiple DataFrames
+df1 = pd.DataFrame({'a': [1, 2, 3], 'b': ["one", "two", "three"]})
+df2 = pd.DataFrame({'c': [1, 2, 3], 'd': ["①", "②", "③"]})
+
+result_df = cdf.query(
+    sql="SELECT * FROM __tbl1__ t1 JOIN __tbl2__ t2 ON t1.a = t2.c",
+    tbl1=df1, 
+    tbl2=df2
+)
+print(result_df)
+
+# Query the result DataFrame
+summary = result_df.query('SELECT b, sum(a) FROM __table__ GROUP BY b')
+print(summary)
+```
+
+#### Python table engine (recommended)
+```python
+
+# Query Pandas DataFrame directly
+df = pd.DataFrame({
+    "customer_id": [1, 2, 3, 1, 2],
+    "product": ["A", "B", "A", "C", "A"],
+    "amount": [100, 200, 150, 300, 250],
+    "metadata": [
+        {'category': 'electronics', 'priority': 'high'},
+        {'category': 'books', 'priority': 'low'},
+        {'category': 'electronics', 'priority': 'medium'},
+        {'category': 'clothing', 'priority': 'high'},
+        {'category': 'books', 'priority': 'low'}
+    ]
+})
+
+# Direct DataFrame querying with JSON support
+result = chdb.query("""
+    SELECT 
+        customer_id,
+        sum(amount) as total_spent,
+        toString(metadata.category) as category
+    FROM Python(df)
+    WHERE toString(metadata.priority) = 'high'
+    GROUP BY customer_id, toString(metadata.category)
+    ORDER BY total_spent DESC
+""").show()
+
+# Query Arrow Table
+arrow_table = pa.table({
+    "id": [1, 2, 3, 4],
+    "name": ["Alice", "Bob", "Charlie", "David"],
+    "score": [98, 89, 86, 95]
+})
+
+chdb.query("""
+    SELECT name, score
+    FROM Python(arrow_table)
+    ORDER BY score DESC
+""").show()
+```
+
+### Stateful sessions
+Sessions maintain query state across multiple operations, enabling complex workflows:
+
+```python
+from chdb import session
+
+# Temporary session (auto-cleanup)
+sess = session.Session()
+
+# Or persistent session with specific path
+# sess = session.Session("/path/to/data")
+
+# Create database and tables
+sess.query("CREATE DATABASE IF NOT EXISTS analytics ENGINE = Atomic")
+sess.query("USE analytics")
+
+sess.query("""
+    CREATE TABLE sales (
+        id UInt64,
+        product String,
+        amount Decimal(10,2),
+        sale_date Date
+    ) ENGINE = MergeTree() 
+    ORDER BY (sale_date, id)
+""")
+
+# Insert data
+sess.query("""
+    INSERT INTO sales VALUES 
+        (1, 'Laptop', 999.99, '2024-01-15'),
+        (2, 'Mouse', 29.99, '2024-01-16'),
+        (3, 'Keyboard', 79.99, '2024-01-17')
+""")
+
+# Create materialized views
+sess.query("""
+    CREATE MATERIALIZED VIEW daily_sales AS
+    SELECT 
+        sale_date,
+        count() as orders,
+        sum(amount) as revenue
+    FROM sales 
+    GROUP BY sale_date
+""")
+
+# Query the view
+result = sess.query("SELECT * FROM daily_sales ORDER BY sale_date", "Pretty")
+print(result)
+
+# Session automatically manages resources
+sess.close()  # Optional - auto-closed when object is deleted
+```
+
+### Advanced session features
+```python
+# Session with custom settings
+sess = session.Session(
+    path="/tmp/analytics_db",
+)
+
+# Query performance optimization
+result = sess.query("""
+    SELECT product, sum(amount) as total
+    FROM sales 
+    GROUP BY product
+    ORDER BY total DESC
+    SETTINGS max_threads = 4
+""", "JSON")
+```
+
+See also: [test_stateful.py](https://github.com/chdb-io/chdb-core/blob/main/tests/test_stateful.py).
+
+### Python DB-API 2.0 interface
+Standard database interface for compatibility with existing Python applications:
+
+```python
+
+# Check driver information
+print(f"chDB driver version: {dbapi.get_client_info()}")
+
+# Create connection
+conn = dbapi.connect()
+cursor = conn.cursor()
+
+# Execute queries with parameters
+cursor.execute("""
+    SELECT number, number * ? as doubled 
+    FROM system.numbers 
+    LIMIT ?
+""", (2, 5))
+
+# Get metadata
+print("Column descriptions:", cursor.description)
+print("Row count:", cursor.rowcount)
+
+# Fetch results
+print("First row:", cursor.fetchone())
+print("Next 2 rows:", cursor.fetchmany(2))
+
+# Fetch remaining rows
+for row in cursor.fetchall():
+    print("Row:", row)
+
+# Batch operations
+data = [(1, 'Alice'), (2, 'Bob'), (3, 'Charlie')]
+cursor.execute("""
+    CREATE TABLE temp_users (
+        id UInt64,
+        name String
+    ) ENGINE = MergeTree()
+    ORDER BY (id)
+""")
+cursor.executemany(
+    "INSERT INTO temp_users (id, name) VALUES (?, ?)", 
+    data
+)
+```
+
+### User defined functions (UDF)
+Extend SQL with custom Python functions:
+
+#### Basic UDF usage
+```python
+from chdb.udf import chdb_udf
+from chdb import query
+
+# Simple mathematical function
+@chdb_udf()
+def add_numbers(a, b):
+    return int(a) + int(b)
+
+# String processing function
+@chdb_udf()
+def reverse_string(text):
+    return text[::-1]
+
+# JSON processing function  
+@chdb_udf()
+def extract_json_field(json_str, field):
+    import json
+    try:
+        data = json.loads(json_str)
+        return str(data.get(field, ''))
+    except:
+        return ''
+
+# Use UDFs in queries
+result = query("""
+    SELECT 
+        add_numbers('10', '20') as sum_result,
+        reverse_string('hello') as reversed,
+        extract_json_field('{"name": "John", "age": 30}', 'name') as name
+""")
+print(result)
+```
+
+#### Advanced UDF with custom return types
+```python
+# UDF with specific return type
+@chdb_udf(return_type="Float64")
+def calculate_bmi(height_str, weight_str):
+    height = float(height_str) / 100  # Convert cm to meters
+    weight = float(weight_str)
+    return weight / (height * height)
+
+# UDF for data validation
+@chdb_udf(return_type="UInt8") 
+def is_valid_email(email):
+    import re
+    pattern = r'^[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,}$'
+    return 1 if re.match(pattern, email) else 0
+
+# Use in complex queries
+result = query("""
+    SELECT 
+        name,
+        calculate_bmi(height, weight) as bmi,
+        is_valid_email(email) as has_valid_email
+    FROM (
+        SELECT 
+            'John' as name, '180' as height, '75' as weight, 'john@example.com' as email
+        UNION ALL
+        SELECT 
+            'Jane' as name, '165' as height, '60' as weight, 'invalid-email' as email
+    )
+""", "Pretty")
+print(result)
+```
+
+#### UDF best practices
+1. **Stateless Functions**: UDFs should be pure functions without side effects
+2. **Import Inside Functions**: All required modules must be imported within the UDF
+3. **String Input/Output**: All UDF parameters are strings (TabSeparated format)
+4. **Error Handling**: Include try-catch blocks for robust UDFs
+5. **Performance**: UDFs are called for each row, so optimize for performance
+
+```python
+# Well-structured UDF with error handling
+@chdb_udf(return_type="String")
+def safe_json_extract(json_str, path):
+    import json
+    try:
+        data = json.loads(json_str)
+        keys = path.split('.')
+        result = data
+        for key in keys:
+            if isinstance(result, dict) and key in result:
+                result = result[key]
+            else:
+                return 'null'
+        return str(result)
+    except Exception as e:
+        return f'error: {str(e)}'
+
+# Use with complex nested JSON
+query("""
+    SELECT safe_json_extract(
+        '{"user": {"profile": {"name": "Alice", "age": 25}}}',
+        'user.profile.name'
+    ) as extracted_name
+""")
+```
+
+### Streaming query processing
+Process large datasets with constant memory usage:
+
+```python
+from chdb import session
+
+sess = session.Session()
+
+# Setup large dataset
+sess.query("""
+    CREATE TABLE large_data ENGINE = Memory() AS 
+    SELECT number as id, toString(number) as data 
+    FROM numbers(1000000)
+""")
+
+# Example 1: Basic streaming with context manager
+total_rows = 0
+with sess.send_query("SELECT * FROM large_data", "CSV") as stream:
+    for chunk in stream:
+        chunk_rows = len(chunk.data().split('\n')) - 1
+        total_rows += chunk_rows
+        print(f"Processed chunk: {chunk_rows} rows")
+        
+        # Early termination if needed
+        if total_rows > 100000:
+            break
+
+print(f"Total rows processed: {total_rows}")
+
+# Example 2: Manual iteration with explicit cleanup
+stream = sess.send_query("SELECT * FROM large_data WHERE id % 100 = 0", "JSONEachRow")
+processed_count = 0
+
+while True:
+    chunk = stream.fetch()
+    if chunk is None:
+        break
+    
+    # Process chunk data
+    lines = chunk.data().strip().split('\n')
+    for line in lines:
+        if line:  # Skip empty lines
+            processed_count += 1
+    
+    print(f"Processed {processed_count} records so far...")
+    
+stream.close()  # Important: explicit cleanup
+
+# Example 3: Arrow integration for external libraries
+
+from deltalake import write_deltalake
+
+# Stream results in Arrow format
+stream = sess.send_query("SELECT * FROM large_data LIMIT 100000", "Arrow")
+
+# Create RecordBatchReader with custom batch size
+batch_reader = stream.record_batch(rows_per_batch=10000)
+
+# Export to Delta Lake
+write_deltalake(
+    table_or_uri="./my_delta_table",
+    data=batch_reader,
+    mode="overwrite"
+)
+
+stream.close()
+sess.close()
+```
+
+### Python table engine
+#### Query Pandas DataFrames
+```python
+
+# Complex DataFrame with nested data
+df = pd.DataFrame({
+    "customer_id": [1, 2, 3, 4, 5, 6],
+    "customer_name": ["Alice", "Bob", "Charlie", "Alice", "Bob", "David"],
+    "orders": [
+        {"order_id": 101, "amount": 250.50, "items": ["laptop", "mouse"]},
+        {"order_id": 102, "amount": 89.99, "items": ["book"]},
+        {"order_id": 103, "amount": 1299.99, "items": ["phone", "case", "charger"]},
+        {"order_id": 104, "amount": 45.50, "items": ["pen", "paper"]},
+        {"order_id": 105, "amount": 199.99, "items": ["headphones"]},
+        {"order_id": 106, "amount": 15.99, "items": ["cable"]}
+    ]
+})
+
+# Advanced querying with JSON operations
+result = chdb.query("""
+    SELECT 
+        customer_name,
+        count() as order_count,
+        sum(toFloat64(orders.amount)) as total_spent,
+        arrayStringConcat(
+            arrayDistinct(
+                arrayFlatten(
+                    groupArray(orders.items)
+                )
+            ), 
+            ', '
+        ) as all_items
+    FROM Python(df)
+    GROUP BY customer_name
+    HAVING total_spent > 100
+    ORDER BY total_spent DESC
+""").show()
+
+# Window functions on DataFrames
+window_result = chdb.query("""
+    SELECT 
+        customer_name,
+        toFloat64(orders.amount) as amount,
+        sum(toFloat64(orders.amount)) OVER (
+            PARTITION BY customer_name 
+            ORDER BY toInt32(orders.order_id)
+        ) as running_total
+    FROM Python(df)
+    ORDER BY customer_name, toInt32(orders.order_id)
+""", "Pretty")
+print(window_result)
+```
+
+#### Custom data sources with PyReader
+Implement custom data readers for specialized data sources:
+
+```python
+
+from typing import List, Tuple, Any
+
+class DatabaseReader(chdb.PyReader):
+    """Custom reader for database-like data sources"""
+    
+    def __init__(self, connection_string: str):
+        # Simulate database connection
+        self.data = self._load_data(connection_string)
+        self.cursor = 0
+        self.batch_size = 1000
+        super().__init__(self.data)
+    
+    def _load_data(self, conn_str):
+        # Simulate loading from database
+        return {
+            "id": list(range(1, 10001)),
+            "name": [f"user_{i}" for i in range(1, 10001)],
+            "score": [i * 10 + (i % 7) for i in range(1, 10001)],
+            "metadata": [
+                json.dumps({"level": i % 5, "active": i % 3 == 0})
+                for i in range(1, 10001)
+            ]
+        }
+    
+    def get_schema(self) -> List[Tuple[str, str]]:
+        """Define table schema with explicit types"""
+        return [
+            ("id", "UInt64"),
+            ("name", "String"),
+            ("score", "Int64"),
+            ("metadata", "String")  # JSON stored as string
+        ]
+    
+    def read(self, col_names: List[str], count: int) -> List[List[Any]]:
+        """Read data in batches"""
+        if self.cursor >= len(self.data["id"]):
+            return []  # No more data
+        
+        end_pos = min(self.cursor + min(count, self.batch_size), len(self.data["id"]))
+        
+        # Return data for requested columns
+        result = []
+        for col in col_names:
+            if col in self.data:
+                result.append(self.data[col][self.cursor:end_pos])
+            else:
+                # Handle missing columns
+                result.append([None] * (end_pos - self.cursor))
+        
+        self.cursor = end_pos
+        return result
+
+### JSON Type Inference and Handling
+chDB automatically handles complex nested data structures:
+
+```python
+
+# DataFrame with mixed JSON objects
+df_with_json = pd.DataFrame({
+    "user_id": [1, 2, 3, 4],
+    "profile": [
+        {"name": "Alice", "age": 25, "preferences": ["music", "travel"]},
+        {"name": "Bob", "age": 30, "location": {"city": "NYC", "country": "US"}},
+        {"name": "Charlie", "skills": ["python", "sql", "ml"], "experience": 5},
+        {"score": 95, "rank": "gold", "achievements": [{"title": "Expert", "date": "2024-01-01"}]}
+    ]
+})
+
+# Control JSON inference with settings
+result = chdb.query("""
+    SELECT 
+        user_id,
+        profile.name as name,
+        profile.age as age,
+        length(profile.preferences) as pref_count,
+        profile.location.city as city
+    FROM Python(df_with_json)
+    SETTINGS pandas_analyze_sample = 1000  -- Analyze all rows for JSON detection
+""", "Pretty")
+print(result)
+
+# Advanced JSON operations
+complex_json = chdb.query("""
+    SELECT 
+        user_id,
+        JSONLength(toString(profile)) as json_fields,
+        JSONType(toString(profile), 'preferences') as pref_type,
+        if(
+            JSONHas(toString(profile), 'achievements'),
+            JSONExtractString(toString(profile), 'achievements[0].title'),
+            'None'
+        ) as first_achievement
+    FROM Python(df_with_json)
+""", "JSONEachRow")
+print(complex_json)
+```
+
+## Performance and optimization
+### Benchmarks
+chDB consistently outperforms other embedded engines:
+- **DataFrame operations**: 2-5x faster than traditional DataFrame libraries for analytical queries
+- **Parquet processing**: Competitive with leading columnar engines
+- **Memory efficiency**: Lower memory footprint than alternatives
+
+[More benchmark result details](https://github.com/chdb-io/chdb?tab=readme-ov-file#benchmark)
+
+### Performance tips
+```python
+
+# 1. Use appropriate output formats
+df_result = chdb.query("SELECT * FROM large_table", "DataFrame")  # For analysis
+arrow_result = chdb.query("SELECT * FROM large_table", "Arrow")    # For interop
+native_result = chdb.query("SELECT * FROM large_table", "Native")   # For chDB-to-chDB
+
+# 2. Optimize queries with settings
+fast_result = chdb.query("""
+    SELECT customer_id, sum(amount) 
+    FROM sales 
+    GROUP BY customer_id
+    SETTINGS 
+        max_threads = 8,
+        max_memory_usage = '4G',
+        use_uncompressed_cache = 1
+""", "DataFrame")
+
+# 3. Leverage streaming for large datasets
+from chdb import session
+
+sess = session.Session()
+
+# Setup large dataset
+sess.query("""
+    CREATE TABLE large_sales ENGINE = Memory() AS 
+    SELECT 
+        number as sale_id,
+        number % 1000 as customer_id,
+        rand() % 1000 as amount
+    FROM numbers(10000000)
+""")
+
+# Stream processing with constant memory usage
+total_amount = 0
+processed_rows = 0
+
+with sess.send_query("SELECT customer_id, sum(amount) as total FROM large_sales GROUP BY customer_id", "JSONEachRow") as stream:
+    for chunk in stream:
+        lines = chunk.data().strip().split('\n')
+        for line in lines:
+            if line:  # Skip empty lines
+                import json
+                row = json.loads(line)
+                total_amount += row['total']
+                processed_rows += 1
+        
+        print(f"Processed {processed_rows} customer records, running total: {total_amount}")
+        
+        # Early termination for demo
+        if processed_rows > 1000:
+            break
+
+print(f"Final result: {processed_rows} customers processed, total amount: {total_amount}")
+
+# Stream to external systems (e.g., Delta Lake)
+stream = sess.send_query("SELECT * FROM large_sales LIMIT 1000000", "Arrow")
+batch_reader = stream.record_batch(rows_per_batch=50000)
+
+# Process in batches
+for batch in batch_reader:
+    print(f"Processing batch with {batch.num_rows} rows...")
+    # Transform or export each batch
+    # df_batch = batch.to_pandas()
+    # process_batch(df_batch)
+
+stream.close()
+sess.close()
+```
+
+## GitHub repository
+- **Main Repository**: [chdb-io/chdb](https://github.com/chdb-io/chdb)
+- **Issues and Support**: Report issues on the [GitHub repository](https://github.com/chdb-io/chdb/issues)
+
+---
+
+# Installing chDB for Rust
+
+**URL:** https://clickhouse.com/docs/chdb/install/rust
+
+How to install and use chDB Rust bindingsd
+
+chDB-rust provides experimental FFI (Foreign Function Interface) bindings for chDB, enabling you to run ClickHouse queries directly in your Rust applications with zero external dependencies.
+
+## Installation
+### Install libchdb
+Install the chDB library:
+
+```bash
+curl -sL https://lib.chdb.io | bash
+```
+
+## Usage
+chDB Rust provides both stateless and stateful query execution modes.
+
+### Stateless usage
+For simple queries without persistent state:
+
+```rust
+use chdb_rust::{execute, arg::Arg, format::OutputFormat};
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // Execute a simple query
+    let result = execute(
+        "SELECT version()",
+        Some(&[Arg::OutputFormat(OutputFormat::JSONEachRow)])
+    )?;
+    println!("ClickHouse version: {}", result.data_utf8()?);
+    
+    // Query with CSV file
+    let result = execute(
+        "SELECT * FROM file('data.csv', 'CSV')",
+        Some(&[Arg::OutputFormat(OutputFormat::JSONEachRow)])
+    )?;
+    println!("CSV data: {}", result.data_utf8()?);
+    
+    Ok(())
+}
+```
+
+### Stateful usage (Sessions)
+For queries requiring persistent state like databases and tables:
+
+```rust
+use chdb_rust::{
+    session::SessionBuilder,
+    arg::Arg,
+    format::OutputFormat,
+    log_level::LogLevel
+};
+use tempdir::TempDir;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // Create a temporary directory for database storage
+    let tmp = TempDir::new("chdb-rust")?;
+    
+    // Build session with configuration
+    let session = SessionBuilder::new()
+        .with_data_path(tmp.path())
+        .with_arg(Arg::LogLevel(LogLevel::Debug))
+        .with_auto_cleanup(true)  // Cleanup on drop
+        .build()?;
+
+    // Create database and table
+    session.execute(
+        "CREATE DATABASE demo; USE demo", 
+        Some(&[Arg::MultiQuery])
+    )?;
+
+    session.execute(
+        "CREATE TABLE logs (id UInt64, msg String) ENGINE = MergeTree() ORDER BY id",
+        None,
+    )?;
+
+    // Insert data
+    session.execute(
+        "INSERT INTO logs (id, msg) VALUES (1, 'Hello'), (2, 'World')",
+        None,
+    )?;
+
+    // Query data
+    let result = session.execute(
+        "SELECT * FROM logs ORDER BY id",
+        Some(&[Arg::OutputFormat(OutputFormat::JSONEachRow)]),
+    )?;
+
+    println!("Query results:\n{}", result.data_utf8()?);
+    
+    // Get query statistics
+    println!("Rows read: {}", result.rows_read());
+    println!("Bytes read: {}", result.bytes_read());
+    println!("Query time: {:?}", result.elapsed());
+
+    Ok(())
+}
+```
+
+## Building and testing
+### Build the project
+```bash
+cargo build
+```
+
+### Run tests
+```bash
+cargo test
+```
+
+### Development dependencies
+The project includes these development dependencies:
+- `bindgen` (v0.70.1) - Generate FFI bindings from C headers
+- `tempdir` (v0.3.7) - Temporary directory handling in tests
+- `thiserror` (v1) - Error handling utilities
+
+## Error handling
+chDB Rust provides comprehensive error handling through the `Error` enum:
+
+```rust
+use chdb_rust::{execute, error::Error};
+
+match execute("SELECT 1", None) {
+    Ok(result) => {
+        println!("Success: {}", result.data_utf8()?);
+    },
+    Err(Error::QueryError(msg)) => {
+        eprintln!("Query failed: {}", msg);
+    },
+    Err(Error::NoResult) => {
+        eprintln!("No result returned");
+    },
+    Err(Error::NonUtf8Sequence(e)) => {
+        eprintln!("Invalid UTF-8: {}", e);
+    },
+    Err(e) => {
+        eprintln!("Other error: {}", e);
+    }
+}
+```
+
+## GitHub repository
+You can find the GitHub repository for the project at [chdb-io/chdb-rust](https://github.com/chdb-io/chdb-rust).
+
+---
+
+# chDB Python API reference
+
+**URL:** https://clickhouse.com/docs/chdb/api/python
+
+Complete Python API reference for chDB
+
+## Core Query Functions
+### `chdb.query`
+Execute SQL query using chDB engine.
+
+This is the main query function that executes SQL statements using the embedded
+ClickHouse engine. Supports various output formats and can work with in-memory
+or file-based databases.
+
+**Syntax**
+
+```python
+chdb.query(sql, output_format='CSV', path='', udf_path='')
+```
+
+**Parameters**
+
+| Parameter       | Type  | Default    | Description                                                                                                                                                                                                                                                                                                     |
+|-----------------|-------|------------|-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `sql`           | str   | *required* | SQL query string to execute                                                                                                                                                                                                                                                                                     |
+| `output_format` | str   | `"CSV"`    | Output format for results. Supported formats:<br/>• `"CSV"` - Comma-separated values<br/>• `"JSON"` - JSON format<br/>• `"Arrow"` - Apache Arrow format<br/>• `"Parquet"` - Parquet format<br/>• `"DataFrame"` - Pandas DataFrame<br/>• `"ArrowTable"` - PyArrow Table<br/>• `"Debug"` - Enable verbose logging |
+| `path`          | str   | `""`       | Database file path. Defaults to in-memory database.<br/>Can be a file path or `":memory:"` for in-memory database                                                                                                                                                                                               |
+| `udf_path`      | str   | `""`       | Path to User-Defined Functions directory                                                                                                                                                                                                                                                                        |
+
+**Returns**
+
+Returns the query result in the specified format:
+
+| Return Type        | Condition                                                |
+|--------------------|----------------------------------------------------------|
+| `str`              | For text formats like CSV, JSON                          |
+| `pd.DataFrame`     | When `output_format` is `"DataFrame"` or `"dataframe"`   |
+| `pa.Table`         | When `output_format` is `"ArrowTable"` or `"arrowtable"` |
+| chdb result object | For other formats                                        |
+ 
+**Raises**
+
+| Exception     | Condition                                                        |
+|---------------|------------------------------------------------------------------|
+| `ChdbError`   | If the SQL query execution fails                                 |
+| `ImportError` | If required dependencies are missing for DataFrame/Arrow formats |
+
+**Examples**
+
+```pycon
+>>> # Basic CSV query
+>>> result = chdb.query("SELECT 1, 'hello'")
+>>> print(result)
+"1,hello"
+```
+
+```pycon
+>>> # Query with DataFrame output
+>>> df = chdb.query("SELECT 1 as id, 'hello' as msg", "DataFrame")
+>>> print(df)
+   id    msg
+0   1  hello
+```
+
+```pycon
+>>> # Query with file-based database
+>>> result = chdb.query("CREATE TABLE test (id INT) ENGINE = Memory", path="mydb.chdb")
+```
+
+```pycon
+>>> # Query with UDF
+>>> result = chdb.query("SELECT my_udf('test')", udf_path="/path/to/udfs")
+```
+
+---
+
+### `chdb.sql`
+Execute SQL query using chDB engine.
+
+This is the main query function that executes SQL statements using the embedded
+ClickHouse engine. Supports various output formats and can work with in-memory
+or file-based databases.
+
+**Syntax**
+
+```python
+chdb.sql(sql, output_format='CSV', path='', udf_path='')
+```
+
+**Parameters**
+
+| Parameter       | Type  | Default    | Description                                                                                                                                                                                                                                                                                              |
+|-----------------|-------|------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `sql`           | str   | *required* | SQL query string to execute                                                                                                                                                                                                                                                                              |
+| `output_format` | str   | `"CSV"`    | Output format for results. Supported formats:<br/>• `"CSV"` - Comma-separated values<br/>• `"JSON"` - JSON format<br/>• `"Arrow"` - Apache Arrow format<br/>• `"Parquet"` - Parquet format<br/>• `"DataFrame"` - Pandas DataFrame<br/>• `"ArrowTable"` - PyArrow Table<br/>• `"Debug"` - Enable verbose logging |
+| `path`          | str   | `""`       | Database file path. Defaults to in-memory database.<br/>Can be a file path or `":memory:"` for in-memory database                                                                                                                                                                                         |
+| `udf_path`      | str   | `""`       | Path to User-Defined Functions directory                                                                                                                                                                                                                                                                 |
+
+**Returns**
+
+Returns the query result in the specified format:
+
+| Return Type        | Condition                                                |
+|--------------------|----------------------------------------------------------|
+| `str`              | For text formats like CSV, JSON                          |
+| `pd.DataFrame`     | When `output_format` is `"DataFrame"` or `"dataframe"`   |
+| `pa.Table`         | When `output_format` is `"ArrowTable"` or `"arrowtable"` |
+| chdb result object | For other formats                                        |
+
+**Raises**
+
+| Exception                 | Condition                                                        |
+|---------------------------|------------------------------------------------------------------|
+| [`ChdbError`](#chdberror) | If the SQL query execution fails                                 |
+| `ImportError`             | If required dependencies are missing for DataFrame/Arrow formats |
+
+**Examples**
+
+```pycon
+>>> # Basic CSV query
+>>> result = chdb.query("SELECT 1, 'hello'")
+>>> print(result)
+"1,hello"
+```
+
+```pycon
+>>> # Query with DataFrame output
+>>> df = chdb.query("SELECT 1 as id, 'hello' as msg", "DataFrame")
+>>> print(df)
+   id    msg
+0   1  hello
+```
+
+```pycon
+>>> # Query with file-based database
+>>> result = chdb.query("CREATE TABLE test (id INT) ENGINE = Memory", path="mydb.chdb")
+```
+
+```pycon
+>>> # Query with UDF
+>>> result = chdb.query("SELECT my_udf('test')", udf_path="/path/to/udfs")
+```
+
+---
+
+### `chdb.to_arrowTable`
+Convert query result to PyArrow Table.
+
+Converts a chDB query result to a PyArrow Table for efficient columnar data processing.
+Returns an empty table if the result is empty.
+
+**Syntax**
+
+```python
+chdb.to_arrowTable(res)
+```
+
+**Parameters**
+
+| Parameter    | Description                                           |
+|--------------|-------------------------------------------------------|
+| `res`        | chDB query result object containing binary Arrow data |
+
+**Returns**
+
+| Return type | Description                                |
+|-------------|--------------------------------------------|
+| `pa.Table`  | PyArrow Table containing the query results |
+
+**Raises**
+
+| Error type    | Description                            |
+|---------------|----------------------------------------|
+| `ImportError` | If pyarrow or pandas aren't installed |
+
+**Example**
+
+```pycon
+>>> result = chdb.query("SELECT 1 as id, 'hello' as msg", "Arrow")
+>>> table = chdb.to_arrowTable(result)
+>>> print(table.to_pandas())
+   id    msg
+0   1  hello
+```
+
+---
+
+### `chdb.to_df`
+Convert query result to pandas DataFrame.
+
+Converts a chDB query result to a pandas DataFrame by first converting to
+PyArrow Table and then to pandas using multi-threading for better performance.
+
+**Syntax**
+
+```python
+chdb.to_df(r)
+```
+
+**Parameters**
+
+| Parameter  | Description                                           |
+|------------|-------------------------------------------------------|
+| `r`        | chDB query result object containing binary Arrow data |
+
+**Returns**
+
+| Return Type | Description |
+|-------------|-------------|
+| `pd.DataFrame` | pandas DataFrame containing the query results |
+
+**Raises**
+
+| Exception     | Condition                              |
+|---------------|----------------------------------------|
+| `ImportError` | If pyarrow or pandas aren't installed |
+
+**Example**
+
+```pycon
+>>> result = chdb.query("SELECT 1 as id, 'hello' as msg", "Arrow")
+>>> df = chdb.to_df(result)
+>>> print(df)
+   id    msg
+0   1  hello
+```
+
+## Connection and Session Management
+The following Session Functions are available:
+
+### `chdb.connect`
+Create a connection to chDB background server.
+
+This function establishes a [Connection](#chdb-state-sqlitelike-connection) to the chDB (ClickHouse) database engine.
+Only one open connection is allowed per process.
+Multiple calls with the same connection string will return the same connection object.
+
+```python
+chdb.connect(connection_string: str = ':memory:') → Connection
+```
+
+**Parameters:**
+
+| Parameter           | Type  | Default      | Description                                    |
+|---------------------|-------|--------------|------------------------------------------------|
+| `connection_string` | str   | `":memory:"` | Database connection string. See formats below. |
+
+**Basic formats**
+
+| Format                    | Description                  |
+|---------------------------|------------------------------|
+| `":memory:"`              | In-memory database (default) |
+| `"test.db"`               | Relative path database file  |
+| `"file:test.db"`          | Same as relative path        |
+| `"/path/to/test.db"`      | Absolute path database file  |
+| `"file:/path/to/test.db"` | Same as absolute path        |
+
+**With query parameters**
+
+| Format                                             | Description               |
+|----------------------------------------------------|---------------------------|
+| `"file:test.db?param1=value1&param2=value2"`       | Relative path with params |
+| `"file::memory:?verbose&log-level=test"`           | In-memory with params     |
+| `"///path/to/test.db?param1=value1&param2=value2"` | Absolute path with params |
+
+**Query parameter handling**
+
+Query parameters are passed to ClickHouse engine as startup arguments.
+Special parameter handling:
+
+| Special Parameter  | Becomes        | Description             |
+|--------------------|----------------|-------------------------|
+| `mode=ro`          | `--readonly=1` | Read-only mode          |
+| `verbose`          | (flag)         | Enables verbose logging |
+| `log-level=test`   | (setting)      | Sets logging level      |
+
+For a complete parameter list, see `clickhouse local --help --verbose`
+
+**Returns**
+
+| Return Type  | Description                                                                                                                                                                                                                                        |
+|--------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `Connection` | Database connection object that supports:<br/>• Creating cursors with `Connection.cursor()`<br/>• Direct queries with `Connection.query()`<br/>• Streaming queries with `Connection.send_query()`<br/>• Context manager protocol for automatic cleanup |
+
+**Raises**
+
+| Exception      | Condition                       |
+|----------------|---------------------------------|
+| `RuntimeError` | If connection to database fails |
+
+:::warning
+Only one connection per process is supported.
+Creating a new connection will close any existing connection.
+:::
+
+**Examples**
+
+```pycon
+>>> # In-memory database
+>>> conn = connect()
+>>> conn = connect(":memory:")
+>>>
+>>> # File-based database
+>>> conn = connect("my_data.db")
+>>> conn = connect("/path/to/data.db")
+>>>
+>>> # With parameters
+>>> conn = connect("data.db?mode=ro")  # Read-only mode
+>>> conn = connect(":memory:?verbose&log-level=debug")  # Debug logging
+>>>
+>>> # Using context manager for automatic cleanup
+>>> with connect("data.db") as conn:
+...     result = conn.query("SELECT 1")
+...     print(result)
+>>> # Connection automatically closed
+```
+
+**See also**
+- [`Connection`](#chdb-state-sqlitelike-connection) - Database connection class
+- [`Cursor`](#chdb-state-sqlitelike-cursor) - Database cursor for DB-API 2.0 operations
+
+## Exception Handling
+### **class** `chdb.ChdbError`
+Bases: `Exception`
+
+Base exception class for chDB-related errors.
+
+This exception is raised when chDB query execution fails or encounters
+an error. It inherits from the standard Python Exception class and
+provides error information from the underlying ClickHouse engine.
+
+---
+
+### **class** `chdb.session.Session`
+Bases: `object`
+
+Session will keep the state of query.
+If path is None, it will create a temporary directory and use it as the database path
+and the temporary directory will be removed when the session is closed.
+You can also pass in a path to create a database at that path where will keep your data.
+
+You can also use a connection string to pass in the path and other parameters.
+
+```python
+class chdb.session.Session(path=None)
+```
+
+**Examples**
+
+| Connection String                                  | Description                          |
+|----------------------------------------------------|--------------------------------------|
+| `":memory:"`                                       | In-memory database                   |
+| `"test.db"`                                        | Relative path                        |
+| `"file:test.db"`                                   | Same as above                        |
+| `"/path/to/test.db"`                               | Absolute path                        |
+| `"file:/path/to/test.db"`                          | Same as above                        |
+| `"file:test.db?param1=value1&param2=value2"`       | Relative path with query params      |
+| `"file::memory:?verbose&log-level=test"`           | In-memory database with query params |
+| `"///path/to/test.db?param1=value1&param2=value2"` | Absolute path with query params      |
+
+:::note Connection string args handling
+Connection strings containing query params like “[file:test.db?param1=value1&param2=value2](file:test.db?param1=value1&param2=value2)”
+“param1=value1” will be passed to ClickHouse engine as start up args.
+
+For more details, see `clickhouse local –help –verbose`
+
+Some special args handling:
+- “mode=ro” would be “–readonly=1” for clickhouse (read-only mode)
+:::
+
+:::warning Important
+- There can be only one session at a time. If you want to create a new session, you need to close the existing one.
+- Creating a new session will close the existing one.
+:::
+
+---
+
+#### `cleanup`
+Cleanup session resources with exception handling.
+
+This method attempts to close the session while suppressing any exceptions
+that might occur during the cleanup process. It’s particularly useful in
+error handling scenarios or when you need to ensure cleanup happens regardless
+of the session state.
+
+**Syntax**
+
+```python
+cleanup()
+```
+
+:::note
+This method will never raise an exception, making it safe to call in
+finally blocks or destructors.
+:::
+
+**Examples**
+
+```pycon
+>>> session = Session("test.db")
+>>> try:
+...     session.query("INVALID SQL")
+... finally:
+...     session.cleanup()  # Safe cleanup regardless of errors
+```
+
+**See also**
+- [`close()`](#chdb-session-session-close) - For explicit session closing with error propagation
+
+---
+
+#### `close`
+Close the session and cleanup resources.
+
+This method closes the underlying connection and resets the global session state.
+After calling this method, the session becomes invalid and can't be used for
+further queries.
+
+**Syntax**
+
+```python
+close()
+```
+
+:::note
+This method is automatically called when the session is used as a context manager
+or when the session object is destroyed.
+:::
+
+:::warning Important
+Any attempt to use the session after calling `close()` will result in an error.
+:::
+
+**Examples**
+
+```pycon
+>>> session = Session("test.db")
+>>> session.query("SELECT 1")
+>>> session.close()  # Explicitly close the session
+```
+
+---
+
+#### `query`
+Execute a SQL query and return the results.
+
+This method executes a SQL query against the session’s database and returns
+the results in the specified format. The method supports various output formats
+and maintains session state between queries.
+
+**Syntax**
+
+```python
+query(sql, fmt='CSV', udf_path='')
+```
+
+**Parameters**
+
+| Parameter  | Type  | Default    | Description                                                                                                                                                                                                                                                                                                                  |
+|------------|-------|------------|------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `sql`      | str   | *required* | SQL query string to execute                                                                                                                                                                                                                                                                                                  |
+| `fmt`      | str   | `"CSV"`    | Output format for results. Available formats:<br/>• `"CSV"` - Comma-separated values<br/>• `"JSON"` - JSON format<br/>• `"TabSeparated"` - Tab-separated values<br/>• `"Pretty"` - Pretty-printed table format<br/>• `"JSONCompact"` - Compact JSON format<br/>• `"Arrow"` - Apache Arrow format<br/>• `"Parquet"` - Parquet format |
+| `udf_path` | str   | `""`       | Path to user-defined functions. If not specified, uses the UDF path from session initialization                                                                                                                                                                                                                              |
+
+**Returns**
+
+Returns query results in the specified format.
+The exact return type depends on the format parameter:
+- String formats (CSV, JSON, etc.) return str
+- Binary formats (Arrow, Parquet) return bytes
+
+**Raises**
+
+| Exception      | Condition                           |
+|----------------|-------------------------------------|
+| `RuntimeError` | If the session is closed or invalid |
+| `ValueError`   | If the SQL query is malformed       |
+
+:::note
+The “Debug” format isn't supported and will be automatically converted
+to “CSV” with a warning.
+For debugging, use connection string parameters instead.
+:::
+
+:::warning Warning
+This method executes the query synchronously and loads all results into
+memory. For large result sets, consider using [`send_query()`](#chdb-session-session-send_query) for
+streaming results.
+:::
+
+**Examples**
+
+```pycon
+>>> session = Session("test.db")
+>>>
+>>> # Basic query with default CSV format
+>>> result = session.query("SELECT 1 as number")
+>>> print(result)
+number
+1
+```
+
+```pycon
+>>> # Query with JSON format
+>>> result = session.query("SELECT 1 as number", fmt="JSON")
+>>> print(result)
+{"number": "1"}
+```
+
+```pycon
+>>> # Complex query with table creation
+>>> session.query("CREATE TABLE test (id INT, name String) ENGINE = Memory")
+>>> session.query("INSERT INTO test VALUES (1, 'Alice'), (2, 'Bob')")
+>>> result = session.query("SELECT * FROM test ORDER BY id")
+>>> print(result)
+id,name
+1,Alice
+2,Bob
+```
+
+**See also**
+- [`send_query()`](#chdb-session-session-send_query) - For streaming query execution
+- [`sql`](#chdb-session-session-sql) - Alias for this method
+
+---
+
+#### `send_query`
+Execute a SQL query and return a streaming result iterator.
+
+This method executes a SQL query against the session’s database and returns
+a streaming result object that allows you to iterate over the results without
+loading everything into memory at once. This is particularly useful for large
+result sets.
+
+**Syntax**
+
+```python
+send_query(sql, fmt='CSV') → StreamingResult
+```
+
+**Parameters**
+
+| Parameter  | Type  | Default    | Description                                                                                                                                                                                                                                                                    |
+|------------|-------|------------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `sql`      | str   | *required* | SQL query string to execute                                                                                                                                                                                                                                                    |
+| `fmt`      | str   | `"CSV"`    | Output format for results. Available formats:<br/>• `"CSV"` - Comma-separated values<br/>• `"JSON"` - JSON format<br/>• `"TabSeparated"` - Tab-separated values<br/>• `"JSONCompact"` - Compact JSON format<br/>• `"Arrow"` - Apache Arrow format<br/>• `"Parquet"` - Parquet format |
+
+**Returns**
+
+| Return Type       | Description                                                                                                                                      |
+|-------------------|--------------------------------------------------------------------------------------------------------------------------------------------------|
+| `StreamingResult` | A streaming result iterator that yields query results incrementally. The iterator can be used in for loops or converted to other data structures |
+
+**Raises**
+
+| Exception      | Condition                           |
+|----------------|-------------------------------------|
+| `RuntimeError` | If the session is closed or invalid |
+| `ValueError`   | If the SQL query is malformed       |
+
+:::note
+The “Debug” format isn't supported and will be automatically converted
+to “CSV” with a warning. For debugging, use connection string parameters instead.
+:::
+
+:::warning
+The returned StreamingResult object should be consumed promptly or stored appropriately, as it maintains a connection to the database.
+:::
+
+**Examples**
+
+```pycon
+>>> session = Session("test.db")
+>>> session.query("CREATE TABLE big_table (id INT, data String) ENGINE = MergeTree() order by id")
+>>>
+>>> # Insert large dataset
+>>> for i in range(1000):
+...     session.query(f"INSERT INTO big_table VALUES ({i}, 'data_{i}')")
+>>>
+>>> # Stream results to avoid memory issues
+>>> streaming_result = session.send_query("SELECT * FROM big_table ORDER BY id")
+>>> for chunk in streaming_result:
+...     print(f"Processing chunk: {len(chunk)} bytes")
+...     # Process chunk without loading entire result set
+```
+
+```pycon
+>>> # Using with context manager
+>>> with session.send_query("SELECT COUNT(*) FROM big_table") as stream:
+...     for result in stream:
+...         print(f"Count result: {result}")
+```
+
+**See also**
+- [`query()`](#chdb-session-session-query) - For non-streaming query execution
+- `chdb.state.sqlitelike.StreamingResult` - Streaming result iterator
+
+---
+
+#### `sql`
+Execute a SQL query and return the results.
+
+This method executes a SQL query against the session’s database and returns
+the results in the specified format. The method supports various output formats
+and maintains session state between queries.
+
+**Syntax**
+
+```python
+sql(sql, fmt='CSV', udf_path='')
+```
+
+**Parameters**
+
+| Parameter  | Type  | Default    | Description                                                                                                                                                                                                                                                                                                                  |
+|------------|-------|------------|------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `sql`      | str   | *required* | SQL query string to execute                                                                                                                                                                                                                                                                                                  |
+| `fmt`      | str   | `"CSV"`    | Output format for results. Available formats:<br/>• `"CSV"` - Comma-separated values<br/>• `"JSON"` - JSON format<br/>• `"TabSeparated"` - Tab-separated values<br/>• `"Pretty"` - Pretty-printed table format<br/>• `"JSONCompact"` - Compact JSON format<br/>• `"Arrow"` - Apache Arrow format<br/>• `"Parquet"` - Parquet format |
+| `udf_path` | str   | `""`       | Path to user-defined functions. If not specified, uses the UDF path from session initialization                                                                                                                                                                                                                              |
+
+**Returns**
+
+Returns query results in the specified format.
+The exact return type depends on the format parameter:
+- String formats (CSV, JSON, etc.) return str
+- Binary formats (Arrow, Parquet) return bytes
+
+**Raises:**
+
+| Exception      | Condition                           |
+|----------------|-------------------------------------|
+| `RuntimeError` | If the session is closed or invalid |
+| `ValueError`   | If the SQL query is malformed       |
+
+:::note
+The “Debug” format isn't supported and will be automatically converted
+to “CSV” with a warning. For debugging, use connection string parameters
+instead.
+:::
+
+:::warning Warning
+This method executes the query synchronously and loads all results into
+memory.
+For large result sets, consider using [`send_query()`](#chdb-session-session-send_query) for streaming results.
+:::
+
+**Examples**
+
+```pycon
+>>> session = Session("test.db")
+>>>
+>>> # Basic query with default CSV format
+>>> result = session.query("SELECT 1 as number")
+>>> print(result)
+number
+1
+```
+
+```pycon
+>>> # Query with JSON format
+>>> result = session.query("SELECT 1 as number", fmt="JSON")
+>>> print(result)
+{"number": "1"}
+```
+
+```pycon
+>>> # Complex query with table creation
+>>> session.query("CREATE TABLE test (id INT, name String) ENGINE = MergeTree() order by id")
+>>> session.query("INSERT INTO test VALUES (1, 'Alice'), (2, 'Bob')")
+>>> result = session.query("SELECT * FROM test ORDER BY id")
+>>> print(result)
+id,name
+1,Alice
+2,Bob
+```
+
+**See also**
+- [`send_query()`](#chdb-session-session-send_query) - For streaming query execution
+- [`sql`](#chdb-session-session-sql) - Alias for this method
+
+## State Management
+### `chdb.state.connect`
+Create a [Connection](#chdb-state-sqlitelike-connection) to the chDB background server.
+
+This function establishes a connection to the chDB (ClickHouse) database engine.
+Only one open connection is allowed per process. Multiple calls with the same
+connection string will return the same connection object.
+
+**Syntax**
+
+```python
+chdb.state.connect(connection_string: str = ':memory:') → Connection
+```
+
+**Parameters**
+
+| Parameter                          | Type  | Default      | Description                                    |
+|------------------------------------|-------|--------------|------------------------------------------------|
+| `connection_string(str, optional)` | str   | `":memory:"` | Database connection string. See formats below. |
+
+**Basic formats**
+
+Supported connection string formats:
+
+| Format                    | Description                  |
+|---------------------------|------------------------------|
+| `":memory:"`              | In-memory database (default) |
+| `"test.db"`               | Relative path database file  |
+| `"file:test.db"`          | Same as relative path        |
+| `"/path/to/test.db"`      | Absolute path database file  |
+| `"file:/path/to/test.db"` | Same as absolute path        |
+
+**With query parameters**
+
+| Format                                             | Description               |
+|----------------------------------------------------|---------------------------|
+| `"file:test.db?param1=value1&param2=value2"`       | Relative path with params |
+| `"file::memory:?verbose&log-level=test"`           | In-memory with params     |
+| `"///path/to/test.db?param1=value1&param2=value2"` | Absolute path with params |
+
+**Query parameter handling**
+
+Query parameters are passed to ClickHouse engine as startup arguments.
+Special parameter handling:
+
+| Special Parameter  | Becomes        | Description             |
+|--------------------|----------------|-------------------------|
+| `mode=ro`          | `--readonly=1` | Read-only mode          |
+| `verbose`          | (flag)         | Enables verbose logging |
+| `log-level=test`   | (setting)      | Sets logging level      |
+
+For a complete parameter list, see `clickhouse local --help --verbose`
+
+**Returns**
+
+| Return Type  | Description                                                                                                                                                                                                                                        |
+|--------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `Connection` | Database connection object that supports:<br/>• Creating cursors with `Connection.cursor()`<br/>• Direct queries with `Connection.query()`<br/>• Streaming queries with `Connection.send_query()`<br/>• Context manager protocol for automatic cleanup |
+
+**Raises**
+
+| Exception      | Condition                       |
+|----------------|---------------------------------|
+| `RuntimeError` | If connection to database fails |
+
+:::warning Warning
+Only one connection per process is supported.
+Creating a new connection will close any existing connection.
+:::
+
+**Examples**
+
+```pycon
+>>> # In-memory database
+>>> conn = connect()
+>>> conn = connect(":memory:")
+>>>
+>>> # File-based database
+>>> conn = connect("my_data.db")
+>>> conn = connect("/path/to/data.db")
+>>>
+>>> # With parameters
+>>> conn = connect("data.db?mode=ro")  # Read-only mode
+>>> conn = connect(":memory:?verbose&log-level=debug")  # Debug logging
+>>>
+>>> # Using context manager for automatic cleanup
+>>> with connect("data.db") as conn:
+...     result = conn.query("SELECT 1")
+...     print(result)
+>>> # Connection automatically closed
+```
+
+**See also**
+- `Connection` - Database connection class
+- `Cursor` - Database cursor for DB-API 2.0 operations
+
+### **class** `chdb.state.sqlitelike.Connection`
+Bases: `object`
+
+**Syntax**
+
+```python
+class chdb.state.sqlitelike.Connection(connection_string: str)
+```
+
+---
+
+#### `close`
+Close the connection and cleanup resources.
+
+This method closes the database connection and cleans up any associated
+resources including active cursors. After calling this method, the
+connection becomes invalid and can't be used for further operations.
+
+**Syntax**
+
+```python
+close() → None
+```
+
+:::note
+This method is idempotent - calling it multiple times is safe.
+:::
+
+:::warning Warning
+Any ongoing streaming queries will be cancelled when the connection
+is closed. Ensure all important data is processed before closing.
+:::
+
+**Examples**
+
+```pycon
+>>> conn = connect("test.db")
+>>> # Use connection for queries
+>>> conn.query("CREATE TABLE test (id INT) ENGINE = Memory")
+>>> # Close when done
+>>> conn.close()
+```
+
+```pycon
+>>> # Using with context manager (automatic cleanup)
+>>> with connect("test.db") as conn:
+...     conn.query("SELECT 1")
+...     # Connection automatically closed
+```
+
+---
+
+#### `cursor`
+Create a [Cursor](#chdb-state-sqlitelike-cursor) object for executing queries.
+
+This method creates a database cursor that provides the standard
+DB-API 2.0 interface for executing queries and fetching results.
+The cursor allows for fine-grained control over query execution
+and result retrieval.
+
+**Syntax**
+
+```python
+cursor() → Cursor
+```
+
+**Returns**
+
+| Return Type  | Description                             |
+|--------------|-----------------------------------------|
+| `Cursor`     | A cursor object for database operations |
+
+:::note
+Creating a new cursor will replace any existing cursor associated
+with this connection. Only one cursor per connection is supported.
+:::
+
+**Examples**
+
+```pycon
+>>> conn = connect(":memory:")
+>>> cursor = conn.cursor()
+>>> cursor.execute("CREATE TABLE test (id INT, name String) ENGINE = Memory")
+>>> cursor.execute("INSERT INTO test VALUES (1, 'Alice')")
+>>> cursor.execute("SELECT * FROM test")
+>>> rows = cursor.fetchall()
+>>> print(rows)
+((1, 'Alice'),)
+```
+
+**See also**
+- [`Cursor`](#chdb-state-sqlitelike-cursor) - Database cursor implementation
+
+---
+
+#### `query`
+Execute a SQL query and return the complete results.
+
+This method executes a SQL query synchronously and returns the complete
+result set. It supports various output formats and automatically applies
+format-specific post-processing.
+
+**Syntax**
+
+```python
+query(query: str, format: str = 'CSV') → Any
+```
+
+**Parameters:**
+
+| Parameter  | Type  | Default    | Description                                                                                                                                                                                                                                                                                   |
+|------------|-------|------------|-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `query`    | str   | *required* | SQL query string to execute                                                                                                                                                                                                                                                                   |
+| `format`   | str   | `"CSV"`    | Output format for results. Supported formats:<br/>• `"CSV"` - Comma-separated values (string)<br/>• `"JSON"` - JSON format (string)<br/>• `"Arrow"` - Apache Arrow format (bytes)<br/>• `"Dataframe"` - Pandas DataFrame (requires pandas)<br/>• `"Arrowtable"` - PyArrow Table (requires pyarrow) |
+
+**Returns**
+
+| Return Type        | Description                    |
+|--------------------|--------------------------------|
+| `str`              | For string formats (CSV, JSON) |
+| `bytes`            | For Arrow format               |
+| `pandas.DataFrame` | For dataframe format           |
+| `pyarrow.Table`    | For arrowtable format          |
+
+**Raises**
+
+| Exception      | Condition                                         |
+|----------------|---------------------------------------------------|
+| `RuntimeError` | If query execution fails                          |
+| `ImportError`  | If required packages for format aren't installed |
+
+:::warning Warning
+This method loads the entire result set into memory. For large
+results, consider using [`send_query()`](#chdb-state-sqlitelike-connection-send_query) for streaming.
+:::
+
+**Examples**
+
+```pycon
+>>> conn = connect(":memory:")
+>>>
+>>> # Basic CSV query
+>>> result = conn.query("SELECT 1 as num, 'hello' as text")
+>>> print(result)
+num,text
+1,hello
+```
+
+```pycon
+>>> # DataFrame format
+>>> df = conn.query("SELECT number FROM numbers(5)", "dataframe")
+>>> print(df)
+   number
+0       0
+1       1
+2       2
+3       3
+4       4
+```
+
+**See also**
+- [`send_query()`](#chdb-state-sqlitelike-connection-send_query) - For streaming query execution
+
+---
+
+#### `send_query`
+Execute a SQL query and return a streaming result iterator.
+
+This method executes a SQL query and returns a StreamingResult object
+that allows you to iterate over the results without loading everything
+into memory at once. This is ideal for processing large result sets.
+
+**Syntax**
+
+```python
+send_query(query: str, format: str = 'CSV') → StreamingResult
+```
+
+**Parameters**
+
+| Parameter  | Type  | Default    | Description                                                                                                                                                                                                                                                                  |
+|------------|-------|------------|------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `query`    | str   | *required* | SQL query string to execute                                                                                                                                                                                                                                                  |
+| `format`   | str   | `"CSV"`    | Output format for results. Supported formats:<br/>• `"CSV"` - Comma-separated values<br/>• `"JSON"` - JSON format<br/>• `"Arrow"` - Apache Arrow format (enables record_batch() method)<br/>• `"dataframe"` - Pandas DataFrame chunks<br/>• `"arrowtable"` - PyArrow Table chunks |
+
+**Returns**
+
+| Return Type       | Description                                                                                                                                                                                                                              |
+|-------------------|------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `StreamingResult` | A streaming iterator for query results that supports:<br/>• Iterator protocol (for loops)<br/>• Context manager protocol (with statements)<br/>• Manual fetching with fetch() method<br/>• PyArrow RecordBatch streaming (Arrow format only) |
+
+**Raises**
+
+| Exception      | Condition                                         |
+|----------------|---------------------------------------------------|
+| `RuntimeError` | If query execution fails                          |
+| `ImportError`  | If required packages for format aren't installed |
+
+:::note
+Only the “Arrow” format supports the `record_batch()` method on the returned StreamingResult.
+:::
+
+**Examples**
+
+```pycon
+>>> conn = connect(":memory:")
+>>>
+>>> # Basic streaming
+>>> stream = conn.send_query("SELECT number FROM numbers(1000)")
+>>> for chunk in stream:
+...     print(f"Processing chunk: {len(chunk)} bytes")
+```
+
+```pycon
+>>> # Using context manager for cleanup
+>>> with conn.send_query("SELECT * FROM large_table") as stream:
+...     chunk = stream.fetch()
+...     while chunk:
+...         process_data(chunk)
+...         chunk = stream.fetch()
+```
+
+```pycon
+>>> # Arrow format with RecordBatch streaming
+>>> stream = conn.send_query("SELECT * FROM data", "Arrow")
+>>> reader = stream.record_batch(rows_per_batch=10000)
+>>> for batch in reader:
+...     print(f"Batch shape: {batch.num_rows} x {batch.num_columns}")
+```
+
+**See also**
+- [`query()`](#chdb-state-sqlitelike-connection-query) - For non-streaming query execution
+- [`StreamingResult`](#chdb-state-sqlitelike-streamingresult) - Streaming result iterator
+
+---
+
+### **class** `chdb.state.sqlitelike.StreamingResult`
+Bases: `object`
+
+Streaming result iterator for processing large query results.
+
+This class provides an iterator interface for streaming query results without
+loading the entire result set into memory. It supports various output formats
+and provides methods for manual result fetching and PyArrow RecordBatch streaming.
+
+```python
+class chdb.state.sqlitelike.StreamingResult
+```
+
+---
+
+#### `fetch`
+Fetch the next chunk of streaming results.
+
+This method retrieves the next available chunk of data from the streaming
+query result. The format of the returned data depends on the format specified
+when the streaming query was initiated.
+
+**Syntax**
+
+```python
+fetch() → Any
+```
+
+**Returns**
+
+| Return Type | Description |
+|-------------|-------------|
+| `str` | For text formats (CSV, JSON) |
+| `bytes` | For binary formats (Arrow, Parquet) |
+| `None` | When the result stream is exhausted |
+
+**Examples**
+
+```pycon
+>>> stream = conn.send_query("SELECT * FROM large_table")
+>>> chunk = stream.fetch()
+>>> while chunk is not None:
+...     process_data(chunk)
+...     chunk = stream.fetch()
+```
+
+---
+
+#### `cancel`
+Cancel the streaming query and cleanup resources.
+
+This method cancels any ongoing streaming query and releases associated
+resources. It should be called when you want to stop processing results
+before the stream is exhausted.
+
+**Syntax**
+
+```python
+cancel() → None
+```
+
+**Examples**
+
+```pycon
+>>> stream = conn.send_query("SELECT * FROM very_large_table")
+>>> for i, chunk in enumerate(stream):
+...     if i >= 10:  # Only process first 10 chunks
+...         stream.cancel()
+...         break
+...     process_data(chunk)
+```
+
+---
+
+#### `close`
+Close the streaming result and cleanup resources.
+
+Alias for [`cancel()`](#streamingresult-cancel). Closes the streaming result iterator
+and releases any associated resources.
+
+**Syntax**
+
+```python
+close() → None
+```
+
+---
+
+#### `record_batch`
+Create a PyArrow RecordBatchReader for efficient batch processing.
+
+This method creates a PyArrow RecordBatchReader that allows efficient
+iteration over the query results in Arrow format. This is the most
+efficient way to process large result sets when using PyArrow.
+
+**Syntax**
+
+```python
+record_batch(rows_per_batch: int = 1000000) → pa.RecordBatchReader
+```
+
+**Parameters**
+
+| Parameter | Type | Default | Description |
+|-----------|------|---------|-------------|
+| `rows_per_batch` | int | `1000000` | Number of rows per batch |
+
+**Returns**
+
+| Return Type | Description |
+|-------------|-------------|
+| `pa.RecordBatchReader` | PyArrow RecordBatchReader for iterating over batches |
+
+:::note
+This method is only available when the streaming query was initiated
+with `format="Arrow"`. Using it with other formats will raise an error.
+:::
+
+**Examples**
+
+```pycon
+>>> stream = conn.send_query("SELECT * FROM data", format="Arrow")
+>>> reader = stream.record_batch(rows_per_batch=10000)
+>>> for batch in reader:
+...     print(f"Processing batch: {batch.num_rows} rows")
+...     df = batch.to_pandas()
+...     process_dataframe(df)
+```
+
+---
+
+#### Iterator Protocol
+StreamingResult supports the Python iterator protocol, allowing it to be
+used directly in for loops:
+
+```pycon
+>>> stream = conn.send_query("SELECT number FROM numbers(1000000)")
+>>> for chunk in stream:
+...     print(f"Chunk size: {len(chunk)} bytes")
+```
+
+---
+
+#### Context Manager Protocol
+StreamingResult supports the context manager protocol for automatic
+resource cleanup:
+
+```pycon
+>>> with conn.send_query("SELECT * FROM data") as stream:
+...     for chunk in stream:
+...         process(chunk)
+>>> # Stream automatically closed
+```
+
+---
+
+### **class** `chdb.state.sqlitelike.Cursor`
+Bases: `object`
+
+```python
+class chdb.state.sqlitelike.Cursor(connection)
+```
+
+---
+
+#### `close`
+Close the cursor and cleanup resources.
+
+This method closes the cursor and cleans up any associated resources.
+After calling this method, the cursor becomes invalid and can't be
+used for further operations.
+
+**Syntax**
+
+```python
+close() → None
+```
+
+:::note
+This method is idempotent - calling it multiple times is safe.
+The cursor is also automatically closed when the connection is closed.
+:::
+
+**Examples**
+
+```pycon
+>>> cursor = conn.cursor()
+>>> cursor.execute("SELECT 1")
+>>> result = cursor.fetchone()
+>>> cursor.close()  # Cleanup cursor resources
+```
+
+---
+
+#### `column_names`
+Return a list of column names from the last executed query.
+
+This method returns the column names from the most recently executed
+SELECT query. The names are returned in the same order as they appear
+in the result set.
+
+**Syntax**
+
+```python
+column_names() → list
+```
+
+**Returns**
+
+| Return Type  | Description                                                                                               |
+|--------------|-----------------------------------------------------------------------------------------------------------|
+| `list`       | List of column name strings, or empty list if no query has been executed or the query returned no columns |
+
+**Examples**
+
+```pycon
+>>> cursor = conn.cursor()
+>>> cursor.execute("SELECT id, name, email FROM users LIMIT 1")
+>>> print(cursor.column_names())
+['id', 'name', 'email']
+```
+
+**See also**
+- [`column_types()`](#chdb-state-sqlitelike-cursor-column_types) - Get column type information
+- [`description`](#chdb-state-sqlitelike-cursor-description) - DB-API 2.0 column description
+
+---
+
+#### `column_types`
+Return a list of column types from the last executed query.
+
+This method returns the ClickHouse column type names from the most
+recently executed SELECT query. The types are returned in the same
+order as they appear in the result set.
+
+**Syntax**
+
+```python
+column_types() → list
+```
+
+**Returns**
+
+| Return Type | Description |
+|-------------|-------------|
+| `list` | List of ClickHouse type name strings, or empty list if no query has been executed or the query returned no columns |
+
+**Examples**
+
+```pycon
+>>> cursor = conn.cursor()
+>>> cursor.execute("SELECT toInt32(1), toString('hello')")
+>>> print(cursor.column_types())
+['Int32', 'String']
+```
+
+**See also**
+- [`column_names()`](#chdb-state-sqlitelike-cursor-column_names) - Get column name information
+- [`description`](#chdb-state-sqlitelike-cursor-description) - DB-API 2.0 column description
+
+---
+
+#### `commit`
+Commit any pending transaction.
+
+This method commits any pending database transaction. In ClickHouse,
+most operations are auto-committed, but this method is provided for
+DB-API 2.0 compatibility.
+
+:::note
+ClickHouse typically auto-commits operations, so explicit commits
+are usually not necessary. This method is provided for compatibility
+with standard DB-API 2.0 workflow.
+:::
+
+**Syntax**
+
+```python
+commit() → None
+```
+
+**Examples**
+
+```pycon
+>>> cursor = conn.cursor()
+>>> cursor.execute("INSERT INTO test VALUES (1, 'data')")
+>>> cursor.commit()
+```
+
+---
+
+#### `property description : list`
+Return column description as per DB-API 2.0 specification.
+
+This property returns a list of 7-item tuples describing each column
+in the result set of the last executed SELECT query. Each tuple contains:
+(name, type_code, display_size, internal_size, precision, scale, null_ok)
+
+Currently, only name and type_code are provided, with other fields set to None.
+
+**Returns**
+
+| Return Type | Description |
+|-------------|-------------|
+| `list` | List of 7-tuples describing each column, or empty list if no SELECT query has been executed |
+
+:::note
+This follows the DB-API 2.0 specification for cursor.description.
+Only the first two elements (name and type_code) contain meaningful
+data in this implementation.
+:::
+
+**Examples**
+
+```pycon
+>>> cursor = conn.cursor()
+>>> cursor.execute("SELECT id, name FROM users LIMIT 1")
+>>> for desc in cursor.description:
+...     print(f"Column: {desc[0]}, Type: {desc[1]}")
+Column: id, Type: Int32
+Column: name, Type: String
+```
+
+**See also**
+- [`column_names()`](#chdb-state-sqlitelike-cursor-column_names) - Get just column names
+- [`column_types()`](#chdb-state-sqlitelike-cursor-column_types) - Get just column types
+
+---
+
+#### `execute`
+Execute a SQL query and prepare results for fetching.
+
+This method executes a SQL query and prepares the results for retrieval
+using the fetch methods. It handles the parsing of result data and
+automatic type conversion for ClickHouse data types.
+
+**Syntax**
+
+```python
+execute(query: str) → None
+```
+
+**Parameters:**
+
+| Parameter  | Type  | Description                 |
+|------------|-------|-----------------------------|
+| `query`    | str   | SQL query string to execute |
+
+**Raises**
+
+| Exception | Condition |
+|-----------|-----------|
+| `Exception` | If query execution fails or result parsing fails |
+
+:::note
+This method follows DB-API 2.0 specifications for `cursor.execute()`.
+After execution, use `fetchone()`, `fetchmany()`, or `fetchall()` to
+retrieve results.
+:::
+
+:::note
+The method automatically converts ClickHouse data types to appropriate
+Python types:
+
+- Int/UInt types → int
+- Float types → float
+- String/FixedString → str
+- DateTime → datetime.datetime
+- Date → datetime.date
+- Bool → bool
+:::
+
+**Examples**
+
+```pycon
+>>> cursor = conn.cursor()
+>>>
+>>> # Execute DDL
+>>> cursor.execute("CREATE TABLE test (id INT, name String) ENGINE = Memory")
+>>>
+>>> # Execute DML
+>>> cursor.execute("INSERT INTO test VALUES (1, 'Alice')")
+>>>
+>>> # Execute SELECT and fetch results
+>>> cursor.execute("SELECT * FROM test")
+>>> rows = cursor.fetchall()
+>>> print(rows)
+((1, 'Alice'),)
+```
+
+**See also**
+- [`fetchone()`](#chdb-state-sqlitelike-cursor-fetchone) - Fetch single row
+- [`fetchmany()`](#chdb-state-sqlitelike-cursor-fetchmany) - Fetch multiple rows
+- [`fetchall()`](#chdb-state-sqlitelike-cursor-fetchall) - Fetch all remaining rows
+
+---
+
+#### `fetchall`
+Fetch all remaining rows from the query result.
+
+This method retrieves all remaining rows from the current query result
+set starting from the current cursor position. It returns a tuple of
+row tuples with appropriate Python type conversion applied.
+
+**Syntax**
+
+```python
+fetchall() → tuple
+```
+
+**Returns:**
+
+| Return Type | Description |
+|-------------|-------------|
+| `tuple` | Tuple containing all remaining row tuples from the result set. Returns empty tuple if no rows are available |
+
+:::warning Warning
+This method loads all remaining rows into memory at once. For large
+result sets, consider using [`fetchmany()`](#chdb-state-sqlitelike-cursor-fetchmany) to process results
+in batches.
+:::
+
+**Examples**
+
+```pycon
+>>> cursor = conn.cursor()
+>>> cursor.execute("SELECT id, name FROM users")
+>>> all_users = cursor.fetchall()
+>>> for user_id, user_name in all_users:
+...     print(f"User {user_id}: {user_name}")
+```
+
+**See also**
+- [`fetchone()`](#chdb-state-sqlitelike-cursor-fetchone) - Fetch single row
+- [`fetchmany()`](#chdb-state-sqlitelike-cursor-fetchmany) - Fetch multiple rows in batches
+
+---
+
+#### `fetchmany`
+Fetch multiple rows from the query result.
+
+This method retrieves up to ‘size’ rows from the current query result
+set. It returns a tuple of row tuples, with each row containing column
+values with appropriate Python type conversion.
+
+**Syntax**
+
+```python
+fetchmany(size: int = 1) → tuple
+```
+
+**Parameters**
+
+| Parameter | Type | Default | Description |
+|-----------|------|---------|-------------|
+| `size` | int | `1` | Maximum number of rows to fetch |
+
+**Returns**
+
+| Return Type | Description                                                                                     |
+|-------------|-------------------------------------------------------------------------------------------------|
+| `tuple`     | Tuple containing up to 'size' row tuples. May contain fewer rows if the result set is exhausted |
+
+:::note
+This method follows DB-API 2.0 specifications. It will return fewer
+than ‘size’ rows if the result set is exhausted.
+:::
+
+**Examples**
+
+```pycon
+>>> cursor = conn.cursor()
+>>> cursor.execute("SELECT * FROM large_table")
+>>>
+>>> # Process results in batches
+>>> while True:
+...     batch = cursor.fetchmany(100)  # Fetch 100 rows at a time
+...     if not batch:
+...         break
+...     process_batch(batch)
+```
+
+**See also**
+- [`fetchone()`](#chdb-state-sqlitelike-cursor-fetchone) - Fetch single row
+- [`fetchall()`](#chdb-state-sqlitelike-cursor-fetchall) - Fetch all remaining rows
+
+---
+
+#### `fetchone`
+Fetch the next row from the query result.
+
+This method retrieves the next available row from the current query
+result set. It returns a tuple containing the column values with
+appropriate Python type conversion applied.
+
+**Syntax** 
+
+```python
+fetchone() → tuple | None
+```
+
+**Returns:**
+
+| Return Type       | Description                                                                 |
+|-------------------|-----------------------------------------------------------------------------|
+| `Optional[tuple]` | Next row as a tuple of column values, or None if no more rows are available |
+
+:::note
+This method follows DB-API 2.0 specifications. Column values are
+automatically converted to appropriate Python types based on
+ClickHouse column types.
+:::
+
+**Examples**
+
+```pycon
+>>> cursor = conn.cursor()
+>>> cursor.execute("SELECT id, name FROM users")
+>>> row = cursor.fetchone()
+>>> while row is not None:
+...     user_id, user_name = row
+...     print(f"User {user_id}: {user_name}")
+...     row = cursor.fetchone()
+```
+
+**See also**
+- [`fetchmany()`](#chdb-state-sqlitelike-cursor-fetchmany) - Fetch multiple rows
+- [`fetchall()`](#chdb-state-sqlitelike-cursor-fetchall) - Fetch all remaining rows
+
+---
+
+### `chdb.state.sqlitelike`
+Convert query result to PyArrow Table.
+
+This function converts chdb query results to a PyArrow Table format,
+which provides efficient columnar data access and interoperability
+with other data processing libraries.
+
+**Syntax**
+
+```python
+chdb.state.sqlitelike.to_arrowTable(res)
+```
+
+**Parameters:**
+
+| Parameter  | Type  | Description                                                |
+|------------|-------|------------------------------------------------------------|
+| `res`      | -     | Query result object from chdb containing Arrow format data |
+
+**Returns**
+
+| Return Type     | Description                                |
+|-----------------|--------------------------------------------|
+| `pyarrow.Table` | PyArrow Table containing the query results |
+
+**Raises**
+
+| Exception     | Condition                                       |
+|---------------|-------------------------------------------------|
+| `ImportError` | If pyarrow or pandas packages aren't installed |
+
+:::note
+This function requires both pyarrow and pandas to be installed.
+Install them with: `pip install pyarrow pandas`
+:::
+
+:::warning Warning
+Empty results return an empty PyArrow Table with no schema.
+:::
+
+**Examples**
+
+```pycon
+>>> import chdb
+>>> result = chdb.query("SELECT 1 as num, 'hello' as text", "Arrow")
+>>> table = to_arrowTable(result)
+>>> print(table.schema)
+num: int64
+text: string
+>>> print(table.to_pandas())
+   num   text
+0    1  hello
+```
+
+---
+
+### `chdb.state.sqlitelike.to_df`
+Convert query result to Pandas DataFrame.
+
+This function converts chdb query results to a Pandas DataFrame format
+by first converting to PyArrow Table and then to DataFrame. This provides
+convenient data analysis capabilities with Pandas API.
+
+**Syntax**
+
+```python
+chdb.state.sqlitelike.to_df(r)
+```
+
+**Parameters:**
+
+| Parameter  | Type  | Description                                                |
+|------------|-------|------------------------------------------------------------|
+| `r`        | -     | Query result object from chdb containing Arrow format data |
+
+**Returns:**
+
+| Return Type        | Description                                                                         |
+|--------------------|-------------------------------------------------------------------------------------|
+| `pandas.DataFrame` | DataFrame containing the query results with appropriate column names and data types |
+
+**Raises**
+
+| Exception     | Condition                                       |
+|---------------|-------------------------------------------------|
+| `ImportError` | If pyarrow or pandas packages aren't installed |
+
+:::note
+This function uses multi-threading for the Arrow to Pandas conversion
+to improve performance on large datasets.
+:::
+
+**See also**
+- [`to_arrowTable()`](#chdb-state-sqlitelike-to_arrowtable) - For PyArrow Table format conversion
+
+**Examples**
+
+```pycon
+>>> import chdb
+>>> result = chdb.query("SELECT 1 as num, 'hello' as text", "Arrow")
+>>> df = to_df(result)
+>>> print(df)
+   num   text
+0    1  hello
+>>> print(df.dtypes)
+num      int64
+text    object
+dtype: object
+```
+
+## DataFrame Integration
+### **class** `chdb.dataframe.Table`
+Bases:
+
+```python
+class chdb.dataframe.Table(*args: Any, **kwargs: Any)
+```
+
+## Database API (DBAPI) 2.0 Interface
+chDB provides a Python DB-API 2.0 compatible interface for database connectivity, allowing you to use chDB with tools and frameworks that expect standard database interfaces.
+
+The chDB DB-API 2.0 interface includes:
+
+- **Connections**: Database connection management with connection strings
+- **Cursors**: Query execution and result retrieval
+- **Type System**: DB-API 2.0 compliant type constants and converters
+- **Error Handling**: Standard database exception hierarchy
+- **Thread Safety**: Level 1 thread safety (threads may share modules but not connections)
+
+---
+
+### Core Functions
+The Database API (DBAPI) 2.0 Interface implements the following core functions:
+
+#### `chdb.dbapi.connect`
+Initialize a new database connection.
+
+**Syntax**
+
+```python
+chdb.dbapi.connect(*args, **kwargs)
+```
+
+**Parameters**
+
+| Parameter  | Type  | Default  | Description                                     |
+|------------|-------|----------|-------------------------------------------------|
+| `path`     | str   | `None`   | Database file path. None for in-memory database |
+
+**Raises**
+
+| Exception                            | Condition                           |
+|--------------------------------------|-------------------------------------|
+| [`err.Error`](#chdb-dbapi-err-error) | If connection can't be established |
+
+---
+
+#### `chdb.dbapi.get_client_info()`
+Get client version information.
+
+Returns the chDB client version as a string for MySQLdb compatibility.
+
+**Syntax**
+
+```python
+chdb.dbapi.get_client_info()
+```
+
+**Returns**
+
+| Return Type  | Description                                  |
+|--------------|----------------------------------------------|
+| `str`        | Version string in format 'major.minor.patch' |
+
+---
+
+### Type constructors
+#### `chdb.dbapi.Binary(x)`
+Return x as a binary type.
+
+This function converts the input to bytes type for use with binary
+database fields, following the DB-API 2.0 specification.
+
+**Syntax**
+
+```python
+chdb.dbapi.Binary(x)
+```
+
+**Parameters**
+
+| Parameter  | Type  | Description                     |
+|------------|-------|---------------------------------|
+| `x`        | -     | Input data to convert to binary |
+
+**Returns**
+
+| Return Type  | Description                  |
+|--------------|------------------------------|
+| `bytes`      | The input converted to bytes |
+
+---
+
+### Connection Class
+#### **class** `chdb.dbapi.connections.Connection(path=None)`
+Bases: `object`
+
+DB-API 2.0 compliant connection to chDB database.
+
+This class provides a standard DB-API interface for connecting to and interacting
+with chDB databases. It supports both in-memory and file-based databases.
+
+The connection manages the underlying chDB engine and provides methods for
+executing queries, managing transactions (no-op for ClickHouse), and creating cursors.
+
+```python
+class chdb.dbapi.connections.Connection(path=None)
+```
+
+**Parameters**
+
+| Parameter  | Type  | Default  | Description                                                                                                        |
+|------------|-------|----------|--------------------------------------------------------------------------------------------------------------------|
+| `path`     | str   | `None`   | Database file path. If None, uses in-memory database. Can be a file path like 'database.db' or None for ':memory:' |
+
+**Variables**
+
+| Variable   | Type  | Description                                        |
+|------------|-------|----------------------------------------------------|
+| `encoding` | str   | Character encoding for queries, defaults to 'utf8' |
+| `open`     | bool  | True if connection is open, False if closed        |
+
+**Examples**
+
+```pycon
+>>> # In-memory database
+>>> conn = Connection()
+>>> cursor = conn.cursor()
+>>> cursor.execute("SELECT 1")
+>>> result = cursor.fetchall()
+>>> conn.close()
+```
+
+```pycon
+>>> # File-based database
+>>> conn = Connection('mydata.db')
+>>> with conn.cursor() as cur:
+...     cur.execute("CREATE TABLE users (id INT, name STRING) ENGINE = MergeTree() order by id")
+...     cur.execute("INSERT INTO users VALUES (1, 'Alice')")
+>>> conn.close()
+```
+
+```pycon
+>>> # Context manager usage
+>>> with Connection() as cur:
+...     cur.execute("SELECT version()")
+...     version = cur.fetchone()
+```
+
+:::note
+ClickHouse doesn't support traditional transactions, so commit() and rollback()
+operations are no-ops but provided for DB-API compliance.
+:::
+
+---
+
+#### `close`
+Close the database connection.
+
+Closes the underlying chDB connection and marks this connection as closed.
+Subsequent operations on this connection will raise an Error.
+
+**Syntax**
+
+```python
+close()
+```
+
+**Raises**
+
+| Exception                            | Condition                       |
+|--------------------------------------|---------------------------------|
+| [`err.Error`](#chdb-dbapi-err-error) | If connection is already closed |
+
+---
+
+#### `commit`
+Commit the current transaction.
+
+**Syntax**
+
+```python
+commit()
+```
+
+:::note
+This is a no-op for chDB/ClickHouse as it doesn’t support traditional
+transactions. Provided for DB-API 2.0 compliance.
+:::
+
+---
+
+#### `cursor`
+Create a new cursor for executing queries.
+
+**Syntax**
+
+```python
+cursor(cursor=None)
+```
+
+**Parameters**
+
+| Parameter  | Type  | Description                         |
+|------------|-------|-------------------------------------|
+| `cursor`   | -     | Ignored, provided for compatibility |
+
+**Returns**
+
+| Return Type  | Description                           |
+|--------------|---------------------------------------|
+| `Cursor`     | New cursor object for this connection |
+
+**Raises**
+
+| Exception                            | Condition               |
+|--------------------------------------|-------------------------|
+| [`err.Error`](#chdb-dbapi-err-error) | If connection is closed |
+
+**Example**
+
+```pycon
+>>> conn = Connection()
+>>> cur = conn.cursor()
+>>> cur.execute("SELECT 1")
+>>> result = cur.fetchone()
+```
+
+---
+
+#### `escape`
+Escape a value for safe inclusion in SQL queries.
+
+**Syntax**
+
+```python
+escape(obj, mapping=None)
+```
+
+**Parameters**
+
+| Parameter  | Type  | Description                                   |
+|------------|-------|-----------------------------------------------|
+| `obj`      | -     | Value to escape (string, bytes, number, etc.) |
+| `mapping`  | -     | Optional character mapping for escaping       |
+
+**Returns**
+
+| Return Type  | Description                                           |
+|--------------|-------------------------------------------------------|
+| -            | Escaped version of the input suitable for SQL queries |
+
+**Example**
+
+```pycon
+>>> conn = Connection()
+>>> safe_value = conn.escape("O'Reilly")
+>>> query = f"SELECT * FROM users WHERE name = {safe_value}"
+```
+
+---
+
+#### `escape_string`
+Escape a string value for SQL queries.
+
+**Syntax**
+
+```python
+escape_string(s)
+```
+
+**Parameters**
+
+| Parameter  | Type  | Description      |
+|------------|-------|------------------|
+| `s`        | str   | String to escape |
+
+**Returns**
+
+| Return Type  | Description                           |
+|--------------|---------------------------------------|
+| `str`        | Escaped string safe for SQL inclusion |
+
+---
+
+#### `property open`
+Check if the connection is open.
+
+**Returns**
+
+| Return Type  | Description                                 |
+|--------------|---------------------------------------------|
+| `bool`       | True if connection is open, False if closed |
+
+---
+
+#### `query`
+Execute a SQL query directly and return raw results.
+
+This method bypasses the cursor interface and executes queries directly.
+For standard DB-API usage, prefer using cursor() method.
+
+**Syntax**
+
+```python
+query(sql, fmt='CSV')
+```
+
+**Parameters:**
+
+| Parameter  | Type         | Default    | Description                                                                      |
+|------------|--------------|------------|----------------------------------------------------------------------------------|
+| `sql`      | str or bytes | *required* | SQL query to execute                                                             |
+| `fmt`      | str          | `"CSV"`    | Output format. Supported formats include "CSV", "JSON", "Arrow", "Parquet", etc. |
+
+**Returns**
+
+| Return Type  | Description                          |
+|--------------|--------------------------------------|
+| -            | Query result in the specified format |
+
+**Raises**
+
+| Exception                                              | Condition                              |
+|--------------------------------------------------------|----------------------------------------|
+| [`err.InterfaceError`](#chdb-dbapi-err-interfaceerror) | If connection is closed or query fails |
+
+**Example**
+
+```pycon
+>>> conn = Connection()
+>>> result = conn.query("SELECT 1, 'hello'", "CSV")
+>>> print(result)
+"1,hello\n"
+```
+
+---
+
+#### `property resp`
+Get the last query response.
+
+**Returns**
+
+| Return Type  | Description                                 |
+|--------------|---------------------------------------------|
+| -            | The raw response from the last query() call |
+
+:::note
+This property is updated each time query() is called directly.
+It doesn't reflect queries executed through cursors.
+:::
+
+---
+
+#### `rollback`
+Roll back the current transaction.
+
+**Syntax**
+
+```python
+rollback()
+```
+
+:::note
+This is a no-op for chDB/ClickHouse as it doesn’t support traditional
+transactions. Provided for DB-API 2.0 compliance.
+:::
+
+---
+
+### Cursor Class
+#### **class** `chdb.dbapi.cursors.Cursor`
+Bases: `object`
+
+DB-API 2.0 cursor for executing queries and fetching results.
+
+The cursor provides methods for executing SQL statements, managing query results,
+and navigating through result sets. It supports parameter binding, bulk operations,
+and follows DB-API 2.0 specifications.
+
+Don't create Cursor instances directly. Use `Connection.cursor()` instead.
+
+```python
+class chdb.dbapi.cursors.Cursor(connection)
+```
+
+| Variable          | Type  | Description                                                 |
+|-------------------|-------|-------------------------------------------------------------|
+| `description`     | tuple | Column metadata for the last query result                   |
+| `rowcount`        | int   | Number of rows affected by the last query (-1 if unknown)   |
+| `arraysize`       | int   | Default number of rows to fetch at once (default: 1)        |
+| `lastrowid`       | -     | ID of the last inserted row (if applicable)                 |
+| `max_stmt_length` | int   | Maximum statement size for executemany() (default: 1024000) |
+
+**Examples**
+
+```pycon
+>>> conn = Connection()
+>>> cur = conn.cursor()
+>>> cur.execute("SELECT 1 as id, 'test' as name")
+>>> result = cur.fetchone()
+>>> print(result)  # (1, 'test')
+>>> cur.close()
+```
+
+:::note
+See [DB-API 2.0 Cursor Objects](https://www.python.org/dev/peps/pep-0249/#cursor-objects)
+for complete specification details.
+:::
+
+---
+
+#### `callproc`
+Execute a stored procedure (placeholder implementation).
+
+**Syntax**
+
+```python
+callproc(procname, args=())
+```
+
+**Parameters**
+
+| Parameter  | Type     | Description                         |
+|------------|----------|-------------------------------------|
+| `procname` | str      | Name of stored procedure to execute |
+| `args`     | sequence | Parameters to pass to the procedure |
+
+**Returns**
+
+| Return Type  | Description                              |
+|--------------|------------------------------------------|
+| `sequence`   | The original args parameter (unmodified) |
+
+:::note
+chDB/ClickHouse doesn't support stored procedures in the traditional sense.
+This method is provided for DB-API 2.0 compliance but doesn't perform
+any actual operation. Use execute() for all SQL operations.
+:::
+
+:::warning Compatibility
+This is a placeholder implementation. Traditional stored procedure
+features like OUT/INOUT parameters, multiple result sets, and server
+variables aren't supported by the underlying ClickHouse engine.
+:::
+
+---
+
+#### `close`
+Close the cursor and free associated resources.
+
+After closing, the cursor becomes unusable and any operation will raise an exception.
+Closing a cursor exhausts all remaining data and releases the underlying cursor.
+
+**Syntax**
+
+```python
+close()
+```
+
+---
+
+#### `execute`
+Execute a SQL query with optional parameter binding.
+
+This method executes a single SQL statement with optional parameter substitution.
+It supports multiple parameter placeholder styles for flexibility.
+
+**Syntax**
+
+```python
+execute(query, args=None)
+```
+
+**Parameters**
+
+| Parameter  | Type            | Default    | Description                        |
+|------------|-----------------|------------|------------------------------------|
+| `query`    | str             | *required* | SQL query to execute               |
+| `args`     | tuple/list/dict | `None`     | Parameters to bind to placeholders |
+
+**Returns**
+
+| Return Type  | Description                             |
+|--------------|-----------------------------------------|
+| `int`        | Number of affected rows (-1 if unknown) |
+
+**Parameter Styles**
+
+| Style               | Example                                         |
+|---------------------|-------------------------------------------------|
+| Question mark style | `"SELECT * FROM users WHERE id = ?"`            |
+| Named style         | `"SELECT * FROM users WHERE name = %(name)s"`   |
+| Format style        | `"SELECT * FROM users WHERE age = %s"` (legacy) |
+
+**Examples**
+
+```pycon
+>>> # Question mark parameters
+>>> cur.execute("SELECT * FROM users WHERE id = ? AND age > ?", (123, 18))
+>>>
+>>> # Named parameters
+>>> cur.execute("SELECT * FROM users WHERE name = %(name)s", {'name': 'Alice'})
+>>>
+>>> # No parameters
+>>> cur.execute("SELECT COUNT(*) FROM users")
+```
+
+**Raises**
+
+| Exception                                              | Condition                                 |
+|--------------------------------------------------------|-------------------------------------------|
+| [`ProgrammingError`](#chdb-dbapi-err-programmingerror) | If cursor is closed or query is malformed |
+| [`InterfaceError`](#chdb-dbapi-err-interfaceerror)     | If database error occurs during execution |
+
+---
+
+#### `executemany(query, args)`
+Execute a query multiple times with different parameter sets.
+
+This method efficiently executes the same SQL query multiple times with
+different parameter values. It’s particularly useful for bulk INSERT operations.
+
+**Syntax**
+
+```python
+executemany(query, args)
+```
+
+**Parameters**
+
+| Parameter  | Type     | Description                                                 |
+|------------|----------|-------------------------------------------------------------|
+| `query`    | str      | SQL query to execute multiple times                         |
+| `args`     | sequence | Sequence of parameter tuples/dicts/lists for each execution |
+
+**Returns**
+
+| Return Type  | Description                                         |
+|--------------|-----------------------------------------------------|
+| `int`        | Total number of affected rows across all executions |
+
+**Examples**
+
+```pycon
+>>> # Bulk insert with question mark parameters
+>>> users_data = [(1, 'Alice'), (2, 'Bob'), (3, 'Charlie')]
+>>> cur.executemany("INSERT INTO users VALUES (?, ?)", users_data)
+>>>
+>>> # Bulk insert with named parameters
+>>> users_data = [
+...     {'id': 1, 'name': 'Alice'},
+...     {'id': 2, 'name': 'Bob'}
+... ]
+>>> cur.executemany(
+...     "INSERT INTO users VALUES (%(id)s, %(name)s)",
+...     users_data
+... )
+```
+
+:::note
+This method improves performance for multiple-row INSERT and UPDATE operations
+by optimizing the query execution process.
+:::
+
+---
+
+#### `fetchall()`
+Fetch all remaining rows from the query result.
+
+**Syntax**
+
+```python
+fetchall()
+```
+
+**Returns**
+
+| Return Type  | Description                                    |
+|--------------|------------------------------------------------|
+| `list`       | List of tuples representing all remaining rows |
+
+**Raises**
+
+| Exception                                              | Condition                              |
+|--------------------------------------------------------|----------------------------------------|
+| [`ProgrammingError`](#chdb-dbapi-err-programmingerror) | If execute() hasn't been called first |
+
+:::warning Warning
+This method can consume large amounts of memory for big result sets.
+Consider using `fetchmany()` for large datasets.
+:::
+
+**Example**
+
+```pycon
+>>> cursor.execute("SELECT id, name FROM users")
+>>> all_rows = cursor.fetchall()
+>>> print(len(all_rows))  # Number of total rows
+```
+
+---
+
+#### `fetchmany`
+Fetch multiple rows from the query result.
+
+**Syntax**
+
+```python
+fetchmany(size=1)
+```
+
+**Parameters**
+
+| Parameter  | Type  | Default  | Description                                                      |
+|------------|-------|----------|------------------------------------------------------------------|
+| `size`     | int   | `1`      | Number of rows to fetch. If not specified, uses cursor.arraysize |
+
+**Returns**
+
+| Return Type  | Description                                  |
+|--------------|----------------------------------------------|
+| `list`       | List of tuples representing the fetched rows |
+
+**Raises**
+
+| Exception                                              | Condition                              |
+|--------------------------------------------------------|----------------------------------------|
+| [`ProgrammingError`](#chdb-dbapi-err-programmingerror) | If execute() hasn't been called first |
+
+**Example**
+
+```pycon
+>>> cursor.execute("SELECT id, name FROM users")
+>>> rows = cursor.fetchmany(3)
+>>> print(rows)  # [(1, 'Alice'), (2, 'Bob'), (3, 'Charlie')]
+```
+
+---
+
+#### `fetchone`
+Fetch the next row from the query result.
+
+**Syntax**
+
+```python
+fetchone()
+```
+
+**Returns**
+
+| Return Type     | Description                                            |
+|-----------------|--------------------------------------------------------|
+| `tuple or None` | Next row as a tuple, or None if no more rows available |
+
+**Raises**
+
+| Exception                                              | Condition                              |
+|--------------------------------------------------------|----------------------------------------|
+| [`ProgrammingError`](#chdb-dbapi-err-programmingerror) | If `execute()` hasn't been called first |
+
+**Example**
+
+```pycon
+>>> cursor.execute("SELECT id, name FROM users LIMIT 3")
+>>> row = cursor.fetchone()
+>>> print(row)  # (1, 'Alice')
+>>> row = cursor.fetchone()
+>>> print(row)  # (2, 'Bob')
+```
+
+---
+
+#### `max_stmt_length = 1024000`
+Max statement size which [`executemany()`](#chdb-dbapi-cursors-cursor-executemany) generates.
+
+Default value is 1024000.
+
+---
+
+#### `mogrify`
+Return the exact query string that would be sent to the database.
+
+This method shows the final SQL query after parameter substitution,
+which is useful for debugging and logging purposes.
+
+**Syntax**
+
+```python
+mogrify(query, args=None)
+```
+
+**Parameters**
+
+| Parameter  | Type            | Default    | Description                           |
+|------------|-----------------|------------|---------------------------------------|
+| `query`    | str             | *required* | SQL query with parameter placeholders |
+| `args`     | tuple/list/dict | `None`     | Parameters to substitute              |
+
+**Returns**
+
+| Return Type  | Description                                            |
+|--------------|--------------------------------------------------------|
+| `str`        | The final SQL query string with parameters substituted |
+
+**Example**
+
+```pycon
+>>> cur.mogrify("SELECT * FROM users WHERE id = ?", (123,))
+"SELECT * FROM users WHERE id = 123"
+```
+
+:::note
+This method follows the extension to DB-API 2.0 used by Psycopg.
+:::
+
+---
+
+#### `nextset`
+Move to the next result set (not supported).
+
+**Syntax**
+
+```python
+nextset()
+```
+
+**Returns**
+
+| Return Type  | Description                                                   |
+|--------------|---------------------------------------------------------------|
+| `None`       | Always returns None as multiple result sets aren't supported |
+
+:::note
+chDB/ClickHouse doesn't support multiple result sets from a single query.
+This method is provided for DB-API 2.0 compliance but always returns None.
+:::
+
+---
+
+#### `setinputsizes`
+Set input sizes for parameters (no-op implementation).
+
+**Syntax**
+
+```python
+setinputsizes(*args)
+```
+
+**Parameters**
+
+| Parameter  | Type  | Description                             |
+|------------|-------|-----------------------------------------|
+| `*args`    | -     | Parameter size specifications (ignored) |
+
+:::note
+This method does nothing but is required by DB-API 2.0 specification.
+chDB automatically handles parameter sizing internally.
+:::
+
+---
+
+#### `setoutputsizes`
+Set output column sizes (no-op implementation).
+
+**Syntax**
+
+```python
+setoutputsizes(*args)
+```
+
+**Parameters**
+
+| Parameter  | Type  | Description                          |
+|------------|-------|--------------------------------------|
+| `*args`    | -     | Column size specifications (ignored) |
+
+:::note
+This method does nothing but is required by DB-API 2.0 specification.
+chDB automatically handles output sizing internally.
+:::
+
+---
+
+### Error Classes
+Exception classes for chdb database operations.
+
+This module provides a complete hierarchy of exception classes for handling
+database-related errors in chdb, following the Python Database API Specification v2.0.
+
+The exception hierarchy is structured as follows:
+
+```default
+StandardError
+├── Warning
+└── Error
+    ├── InterfaceError
+    └── DatabaseError
+        ├── DataError
+        ├── OperationalError
+        ├── IntegrityError
+        ├── InternalError
+        ├── ProgrammingError
+        └── NotSupportedError
+```
+
+Each exception class represents a specific category of database errors:
+
+| Exception           | Description                                                 |
+|---------------------|-------------------------------------------------------------|
+| `Warning`           | Non-fatal warnings during database operations               |
+| `InterfaceError`    | Problems with the database interface itself                 |
+| `DatabaseError`     | Base class for all database-related errors                  |
+| `DataError`         | Problems with data processing (invalid values, type errors) |
+| `OperationalError`  | Database operational issues (connectivity, resources)       |
+| `IntegrityError`    | Constraint violations (foreign keys, uniqueness)            |
+| `InternalError`     | Database internal errors and corruption                     |
+| `ProgrammingError`  | SQL syntax errors and API misuse                            |
+| `NotSupportedError` | Unsupported features or operations                          |
+
+:::note
+These exception classes are compliant with Python DB API 2.0 specification
+and provide consistent error handling across different database operations.
+:::
+
+**See also**
+- [Python Database API Specification v2.0](https://peps.python.org/pep-0249/)
+- `chdb.dbapi.connections` - Database connection management
+- `chdb.dbapi.cursors` - Database cursor operations
+
+**Examples**
+
+```pycon
+>>> try:
+...     cursor.execute("SELECT * FROM nonexistent_table")
+... except ProgrammingError as e:
+...     print(f"SQL Error: {e}")
+...
+SQL Error: Table 'nonexistent_table' doesn't exist
+```
+
+```pycon
+>>> try:
+...     cursor.execute("INSERT INTO users (id) VALUES (1), (1)")
+... except IntegrityError as e:
+...     print(f"Constraint violation: {e}")
+...
+Constraint violation: Duplicate entry '1' for key 'PRIMARY'
+```
+
+---
+
+#### **exception** `chdb.dbapi.err.DataError`
+Bases: [`DatabaseError`](#chdb-dbapi-err-databaseerror)
+
+Exception raised for errors that are due to problems with the processed data.
+
+This exception is raised when database operations fail due to issues with
+the data being processed, such as:
+
+- Division by zero operations
+- Numeric values out of range
+- Invalid date/time values
+- String truncation errors
+- Type conversion failures
+- Invalid data format for column type
+
+**Raises**
+
+| Exception | Condition |
+|-----------|-----------|
+| [`DataError`](#chdb-dbapi-err-dataerror) | When data validation or processing fails |
+
+**Examples**
+
+```pycon
+>>> # Division by zero in SQL
+>>> cursor.execute("SELECT 1/0")
+DataError: Division by zero
+```
+
+```pycon
+>>> # Invalid date format
+>>> cursor.execute("INSERT INTO table VALUES ('invalid-date')")
+DataError: Invalid date format
+```
+
+---
+
+#### **exception** `chdb.dbapi.err.DatabaseError`
+Bases: [`Error`](#chdb-dbapi-err-error)
+
+Exception raised for errors that are related to the database.
+
+This is the base class for all database-related errors. It encompasses
+all errors that occur during database operations and are related to the
+database itself rather than the interface.
+
+Common scenarios include:
+
+- SQL execution errors
+- Database connectivity issues
+- Transaction-related problems
+- Database-specific constraints violations
+
+:::note
+This serves as the parent class for more specific database error types
+such as [`DataError`](#chdb-dbapi-err-dataerror), [`OperationalError`](#chdb-dbapi-err-operationalerror), etc.
+:::
+
+---
+
+#### **exception** `chdb.dbapi.err.Error`
+Bases: [`StandardError`](#chdb-dbapi-err-standarderror)
+
+Exception that is the base class of all other error exceptions (not Warning).
+
+This is the base class for all error exceptions in chdb, excluding warnings.
+It serves as the parent class for all database error conditions that prevent
+successful completion of operations.
+
+:::note
+This exception hierarchy follows the Python DB API 2.0 specification.
+:::
+
+**See also**
+- [`Warning`](#chdb-dbapi-err-warning) - For non-fatal warnings that don’t prevent operation completion
+
+#### **exception** `chdb.dbapi.err.IntegrityError`
+Bases: [`DatabaseError`](#chdb-dbapi-err-databaseerror)
+
+Exception raised when the relational integrity of the database is affected.
+
+This exception is raised when database operations violate integrity constraints,
+including:
+
+- Foreign key constraint violations
+- Primary key or unique constraint violations (duplicate keys)
+- Check constraint violations
+- NOT NULL constraint violations
+- Referential integrity violations
+
+**Raises**
+
+| Exception                                          | Condition                                        |
+|----------------------------------------------------|--------------------------------------------------|
+| [`IntegrityError`](#chdb-dbapi-err-integrityerror) | When database integrity constraints are violated |
+
+**Examples**
+
+```pycon
+>>> # Duplicate primary key
+>>> cursor.execute("INSERT INTO users (id, name) VALUES (1, 'John')")
+>>> cursor.execute("INSERT INTO users (id, name) VALUES (1, 'Jane')")
+IntegrityError: Duplicate entry '1' for key 'PRIMARY'
+```
+
+```pycon
+>>> # Foreign key violation
+>>> cursor.execute("INSERT INTO orders (user_id) VALUES (999)")
+IntegrityError: Cannot add or update a child row: foreign key constraint fails
+```
+
+---
+
+#### **exception** `chdb.dbapi.err.InterfaceError`
+Bases: [`Error`](#chdb-dbapi-err-error)
+
+Exception raised for errors that are related to the database interface rather than the database itself.
+
+This exception is raised when there are problems with the database interface
+implementation, such as:
+
+- Invalid connection parameters
+- API misuse (calling methods on closed connections)
+- Interface-level protocol errors
+- Module import or initialization failures
+
+**Raises**
+
+| Exception                                          | Condition                                                                  |
+|----------------------------------------------------|----------------------------------------------------------------------------|
+| [`InterfaceError`](#chdb-dbapi-err-interfaceerror) | When database interface encounters errors unrelated to database operations |
+
+:::note
+These errors are typically programming errors or configuration issues
+that can be resolved by fixing the client code or configuration.
+:::
+
+---
+
+#### **exception** `chdb.dbapi.err.InternalError`
+Bases: [`DatabaseError`](#chdb-dbapi-err-databaseerror)
+
+Exception raised when the database encounters an internal error.
+
+This exception is raised when the database system encounters internal
+errors that aren't caused by the application, such as:
+
+- Invalid cursor state (cursor isn't valid anymore)
+- Transaction state inconsistencies (transaction is out of sync)
+- Database corruption issues
+- Internal data structure corruption
+- System-level database errors
+
+**Raises**
+
+| Exception | Condition |
+|-----------|-----------|
+| [`InternalError`](#chdb-dbapi-err-internalerror) | When database encounters internal inconsistencies |
+
+:::warning Warning
+Internal errors may indicate serious database problems that require
+database administrator attention. These errors are typically not
+recoverable through application-level retry logic.
+:::
+
+:::note
+These errors are generally outside the control of the application
+and may require database restart or repair operations.
+:::
+
+---
+
+#### **exception** `chdb.dbapi.err.NotSupportedError`
+Bases: [`DatabaseError`](#chdb-dbapi-err-databaseerror)
+
+Exception raised when a method or database API isn't supported.
+
+This exception is raised when the application attempts to use database
+features or API methods that aren't supported by the current database
+configuration or version, such as:
+
+- Requesting `rollback()` on connections without transaction support
+- Using advanced SQL features not supported by the database version
+- Calling methods not implemented by the current driver
+- Attempting to use disabled database features
+
+**Raises**
+
+| Exception                                                | Condition                                       |
+|----------------------------------------------------------|-------------------------------------------------|
+| [`NotSupportedError`](#chdb-dbapi-err-notsupportederror) | When unsupported database features are accessed |
+
+**Examples**
+
+```pycon
+>>> # Transaction rollback on non-transactional connection
+>>> connection.rollback()
+NotSupportedError: Transactions are not supported
+```
+
+```pycon
+>>> # Using unsupported SQL syntax
+>>> cursor.execute("SELECT * FROM table WITH (NOLOCK)")
+NotSupportedError: WITH clause not supported in this database version
+```
+
+:::note
+Check database documentation and driver capabilities to avoid
+these errors. Consider graceful fallbacks where possible.
+:::
+
+---
+
+#### **exception** `chdb.dbapi.err.OperationalError`
+Bases: [`DatabaseError`](#chdb-dbapi-err-databaseerror)
+
+Exception raised for errors that are related to the database’s operation.
+
+This exception is raised for errors that occur during database operation
+and aren't necessarily under the control of the programmer, including:
+
+- Unexpected disconnection from database
+- Database server not found or unreachable
+- Transaction processing failures
+- Memory allocation errors during processing
+- Disk space or resource exhaustion
+- Database server internal errors
+- Authentication or authorization failures
+
+**Raises**
+
+| Exception                                              | Condition                                               |
+|--------------------------------------------------------|---------------------------------------------------------|
+| [`OperationalError`](#chdb-dbapi-err-operationalerror) | When database operations fail due to operational issues |
+
+:::note
+These errors are typically transient and may be resolved by retrying
+the operation or addressing system-level issues.
+:::
+
+:::warning Warning
+Some operational errors may indicate serious system problems that
+require administrative intervention.
+:::
+
+---
+
+#### **exception** `chdb.dbapi.err.ProgrammingError`
+Bases: [`DatabaseError`](#chdb-dbapi-err-databaseerror)
+
+Exception raised for programming errors in database operations.
+
+This exception is raised when there are programming errors in the
+application’s database usage, including:
+
+- Table or column not found
+- Table or index already exists when creating
+- SQL syntax errors in statements
+- Wrong number of parameters specified in prepared statements
+- Invalid SQL operations (e.g., DROP on non-existent objects)
+- Incorrect usage of database API methods
+
+**Raises**
+
+| Exception                                              | Condition                                        |
+|--------------------------------------------------------|--------------------------------------------------|
+| [`ProgrammingError`](#chdb-dbapi-err-programmingerror) | When SQL statements or API usage contains errors |
+
+**Examples**
+
+```pycon
+>>> # Table not found
+>>> cursor.execute("SELECT * FROM nonexistent_table")
+ProgrammingError: Table 'nonexistent_table' doesn't exist
+```
+
+```pycon
+>>> # SQL syntax error
+>>> cursor.execute("SELCT * FROM users")
+ProgrammingError: You have an error in your SQL syntax
+```
+
+```pycon
+>>> # Wrong parameter count
+>>> cursor.execute("INSERT INTO users (name, age) VALUES (%s)", ('John',))
+ProgrammingError: Column count doesn't match value count
+```
+
+---
+
+#### **exception** `chdb.dbapi.err.StandardError`
+Bases: `Exception`
+
+Exception related to operation with chdb.
+
+This is the base class for all chdb-related exceptions. It inherits from
+Python’s built-in Exception class and serves as the root of the exception
+hierarchy for database operations.
+
+:::note
+This exception class follows the Python DB API 2.0 specification
+for database exception handling.
+:::
+
+---
+
+#### **exception** `chdb.dbapi.err.Warning`
+Bases: [`StandardError`](#chdb-dbapi-err-standarderror)
+
+Exception raised for important warnings like data truncations while inserting, etc.
+
+This exception is raised when the database operation completes but with
+important warnings that should be brought to the attention of the application.
+Common scenarios include:
+
+- Data truncation during insertion
+- Precision loss in numeric conversions
+- Character set conversion warnings
+
+:::note
+This follows the Python DB API 2.0 specification for warning exceptions.
+:::
+
+---
+
+### Module Constants
+#### `chdb.dbapi.apilevel = '2.0'`
+```python
+str(object=’’) -> str
+str(bytes_or_buffer[, encoding[, errors]]) -> str
+```
+
+Create a new string object from the given object. If encoding or
+errors is specified, then the object must expose a data buffer
+that will be decoded using the given encoding and error handler.
+Otherwise, returns the result of `object._\_str_\_()` (if defined)
+or `repr(object)`.
+
+- encoding defaults to ‘utf-8’.
+- errors defaults to ‘strict’.
+
+---
+
+#### `chdb.dbapi.threadsafety = 1`
+```python
+int([x]) -> integer
+int(x, base=10) -> integer
+```
+
+Convert a number or string to an integer, or return 0 if no arguments
+are given.  If x is a number, return x._\_int_\_().  For floating-point
+numbers, this truncates towards zero.
+
+If x isn't a number or if base is given, then x must be a string,
+bytes, or bytearray instance representing an integer literal in the
+given base.  The literal can be preceded by ‘+’ or ‘-’ and be surrounded
+by whitespace.  The base defaults to 10.  Valid bases are 0 and 2-36.
+Base 0 means to interpret the base from the string as an integer literal.
+
+```python
+>>> int(‘0b100’, base=0)
+4
+```
+
+---
+
+#### `chdb.dbapi.paramstyle = 'format'`
+```python
+str(object=’’) -> str
+str(bytes_or_buffer[, encoding[, errors]]) -> str
+```
+
+Create a new string object from the given object. If encoding or
+errors is specified, then the object must expose a data buffer
+that will be decoded using the given encoding and error handler.
+Otherwise, returns the result of object._\_str_\_() (if defined)
+or repr(object).
+encoding defaults to ‘utf-8’.
+errors defaults to ‘strict’.
+
+---
+
+### Type Constants
+#### `chdb.dbapi.STRING = frozenset({247, 253, 254})`
+Extended frozenset for DB-API 2.0 type comparison.
+
+This class extends frozenset to support DB-API 2.0 type comparison semantics.
+It allows for flexible type checking where individual items can be compared
+against the set using both equality and inequality operators.
+
+This is used for type constants like STRING, BINARY, NUMBER, etc. to enable
+comparisons like “field_type == STRING” where field_type is a single type value.
+
+**Examples**
+
+```pycon
+>>> string_types = DBAPISet([FIELD_TYPE.STRING, FIELD_TYPE.VAR_STRING])
+>>> FIELD_TYPE.STRING == string_types  # Returns True
+>>> FIELD_TYPE.INT != string_types     # Returns True
+>>> FIELD_TYPE.BLOB in string_types    # Returns False
+```
+
+---
+
+#### `chdb.dbapi.BINARY = frozenset({249, 250, 251, 252})`
+Extended frozenset for DB-API 2.0 type comparison.
+
+This class extends frozenset to support DB-API 2.0 type comparison semantics.
+It allows for flexible type checking where individual items can be compared
+against the set using both equality and inequality operators.
+
+This is used for type constants like STRING, BINARY, NUMBER, etc. to enable
+comparisons like “field_type == STRING” where field_type is a single type value.
+
+**Examples**
+
+```pycon
+>>> string_types = DBAPISet([FIELD_TYPE.STRING, FIELD_TYPE.VAR_STRING])
+>>> FIELD_TYPE.STRING == string_types  # Returns True
+>>> FIELD_TYPE.INT != string_types     # Returns True
+>>> FIELD_TYPE.BLOB in string_types    # Returns False
+```
+
+---
+
+#### `chdb.dbapi.NUMBER = frozenset({0, 1, 3, 4, 5, 8, 9, 13})`
+Extended frozenset for DB-API 2.0 type comparison.
+
+This class extends frozenset to support DB-API 2.0 type comparison semantics.
+It allows for flexible type checking where individual items can be compared
+against the set using both equality and inequality operators.
+
+This is used for type constants like STRING, BINARY, NUMBER, etc. to enable
+comparisons like “field_type == STRING” where field_type is a single type value.
+
+**Examples**
+
+```pycon
+>>> string_types = DBAPISet([FIELD_TYPE.STRING, FIELD_TYPE.VAR_STRING])
+>>> FIELD_TYPE.STRING == string_types  # Returns True
+>>> FIELD_TYPE.INT != string_types     # Returns True
+>>> FIELD_TYPE.BLOB in string_types    # Returns False
+```
+
+---
+
+#### `chdb.dbapi.DATE = frozenset({10, 14})`
+Extended frozenset for DB-API 2.0 type comparison.
+
+This class extends frozenset to support DB-API 2.0 type comparison semantics.
+It allows for flexible type checking where individual items can be compared
+against the set using both equality and inequality operators.
+
+This is used for type constants like STRING, BINARY, NUMBER, etc. to enable
+comparisons like “field_type == STRING” where field_type is a single type value.
+
+**Examples**
+
+```pycon
+>>> string_types = DBAPISet([FIELD_TYPE.STRING, FIELD_TYPE.VAR_STRING])
+>>> FIELD_TYPE.STRING == string_types  # Returns True
+>>> FIELD_TYPE.INT != string_types     # Returns True
+>>> FIELD_TYPE.BLOB in string_types    # Returns False
+```
+
+---
+
+#### `chdb.dbapi.TIME = frozenset({11})`
+Extended frozenset for DB-API 2.0 type comparison.
+
+This class extends frozenset to support DB-API 2.0 type comparison semantics.
+It allows for flexible type checking where individual items can be compared
+against the set using both equality and inequality operators.
+
+This is used for type constants like STRING, BINARY, NUMBER, etc. to enable
+comparisons like “field_type == STRING” where field_type is a single type value.
+
+**Examples**
+
+```pycon
+>>> string_types = DBAPISet([FIELD_TYPE.STRING, FIELD_TYPE.VAR_STRING])
+>>> FIELD_TYPE.STRING == string_types  # Returns True
+>>> FIELD_TYPE.INT != string_types     # Returns True
+>>> FIELD_TYPE.BLOB in string_types    # Returns False
+```
+
+---
+
+#### `chdb.dbapi.TIMESTAMP = frozenset({7, 12})`
+Extended frozenset for DB-API 2.0 type comparison.
+
+This class extends frozenset to support DB-API 2.0 type comparison semantics.
+It allows for flexible type checking where individual items can be compared
+against the set using both equality and inequality operators.
+
+This is used for type constants like STRING, BINARY, NUMBER, etc. to enable
+comparisons like “field_type == STRING” where field_type is a single type value.
+
+**Examples**
+
+```pycon
+>>> string_types = DBAPISet([FIELD_TYPE.STRING, FIELD_TYPE.VAR_STRING])
+>>> FIELD_TYPE.STRING == string_types  # Returns True
+>>> FIELD_TYPE.INT != string_types     # Returns True
+>>> FIELD_TYPE.BLOB in string_types    # Returns False
+```
+
+#### `chdb.dbapi.DATETIME = frozenset({7, 12})`
+Extended frozenset for DB-API 2.0 type comparison.
+
+This class extends frozenset to support DB-API 2.0 type comparison semantics.
+It allows for flexible type checking where individual items can be compared
+against the set using both equality and inequality operators.
+
+This is used for type constants like STRING, BINARY, NUMBER, etc. to enable
+comparisons like “field_type == STRING” where field_type is a single type value.
+
+**Examples**
+
+```pycon
+>>> string_types = DBAPISet([FIELD_TYPE.STRING, FIELD_TYPE.VAR_STRING])
+>>> FIELD_TYPE.STRING == string_types  # Returns True
+>>> FIELD_TYPE.INT != string_types     # Returns True
+>>> FIELD_TYPE.BLOB in string_types    # Returns False
+```
+
+---
+
+#### `chdb.dbapi.ROWID = frozenset({})`
+Extended frozenset for DB-API 2.0 type comparison.
+
+This class extends frozenset to support DB-API 2.0 type comparison semantics.
+It allows for flexible type checking where individual items can be compared
+against the set using both equality and inequality operators.
+
+This is used for type constants like STRING, BINARY, NUMBER, etc. to enable
+comparisons like “field_type == STRING” where field_type is a single type value.
+
+**Examples**
+
+```pycon
+>>> string_types = DBAPISet([FIELD_TYPE.STRING, FIELD_TYPE.VAR_STRING])
+>>> FIELD_TYPE.STRING == string_types  # Returns True
+>>> FIELD_TYPE.INT != string_types     # Returns True
+>>> FIELD_TYPE.BLOB in string_types    # Returns False
+```
+
+**Usage Examples**
+
+Basic Query Example:
+
+```python
+
+print("chdb driver version: {0}".format(dbapi.get_client_info()))
+
+# Create connection and cursor
+conn = dbapi.connect()
+cur = conn.cursor()
+
+# Execute query
+cur.execute('SELECT version()')
+print("description:", cur.description)
+print("data:", cur.fetchone())
+
+# Clean up
+cur.close()
+conn.close()
+```
+
+Working with Data:
+
+```python
+
+conn = dbapi.connect()
+cur = conn.cursor()
+
+# Create table
+cur.execute("""
+    CREATE TABLE employees (
+        id UInt32,
+        name String,
+        department String,
+        salary Decimal(10,2)
+    ) ENGINE = Memory
+""")
+
+# Insert data
+cur.execute("""
+    INSERT INTO employees VALUES
+    (1, 'Alice', 'Engineering', 75000.00),
+    (2, 'Bob', 'Marketing', 65000.00),
+    (3, 'Charlie', 'Engineering', 80000.00)
+""")
+
+# Query data
+cur.execute("SELECT * FROM employees WHERE department = 'Engineering'")
+
+# Fetch results
+print("Column names:", [desc[0] for desc in cur.description])
+for row in cur.fetchall():
+    print(row)
+
+conn.close()
+```
+
+Connection Management:
+
+```python
+
+# In-memory database (default)
+conn1 = dbapi.connect()
+
+# Persistent database file
+conn2 = dbapi.connect("./my_database.chdb")
+
+# Connection with parameters
+conn3 = dbapi.connect("./my_database.chdb?log-level=debug&verbose")
+
+# Read-only connection
+conn4 = dbapi.connect("./my_database.chdb?mode=ro")
+
+# Automatic connection cleanup
+with dbapi.connect("test.chdb") as conn:
+    cur = conn.cursor()
+    cur.execute("SELECT count() FROM numbers(1000)")
+    result = cur.fetchone()
+    print(f"Count: {result[0]}")
+    cur.close()
+```
+
+**Best Practices**
+
+1. **Connection Management**: Always close connections and cursors when done
+2. **Context Managers**: Use `with` statements for automatic cleanup
+3. **Batch Processing**: Use `fetchmany()` for large result sets
+4. **Error Handling**: Wrap database operations in try-except blocks
+5. **Parameter Binding**: Use parameterized queries when possible
+6. **Memory Management**: Avoid `fetchall()` for very large datasets
+
+:::note
+- chDB’s DB-API 2.0 interface is compatible with most Python database tools
+- The interface provides Level 1 thread safety (threads may share modules but not connections)
+- Connection strings support the same parameters as chDB sessions
+- All standard DB-API 2.0 exceptions are supported
+:::
+
+:::warning Warning
+- Always close cursors and connections to avoid resource leaks
+- Large result sets should be processed in batches
+- Parameter binding syntax follows format style: `%s`
+:::
+
+## User-Defined Functions (UDF)
+User-defined functions module for chDB.
+
+This module provides functionality for creating and managing user-defined functions (UDFs)
+in chDB. It allows you to extend chDB’s capabilities by writing custom Python functions
+that can be called from SQL queries.
+
+### `chdb.udf.chdb_udf`
+Decorator for chDB Python UDF(User Defined Function).
+
+**Syntax**
+
+```python
+chdb.udf.chdb_udf(return_type='String')
+```
+
+**Parameters**
+
+| Parameter     | Type  | Default    | Description                                                             |
+|---------------|-------|------------|-------------------------------------------------------------------------|
+| `return_type` | str   | `"String"` | Return type of the function. Should be one of the ClickHouse data types |
+
+**Notes**
+
+1. The function should be stateless. Only UDFs are supported, not UDAFs.
+2. Default return type is String. The return type should be one of the ClickHouse data types.
+3. The function should take in arguments of type String. All arguments are strings.
+4. The function will be called for each line of input.
+5. The function should be pure python function. Import all modules used IN THE FUNCTION.
+6. Python interpreter used is the same as the one used to run the script.
+
+**Example**
+
+```python
+@chdb_udf()
+def sum_udf(lhs, rhs):
+    return int(lhs) + int(rhs)
+
+@chdb_udf()
+def func_use_json(arg):
+    import json
+    # ... use json module
+```
+
+---
+
+### `chdb.udf.generate_udf`
+Generate UDF configuration and executable script files.
+
+This function creates the necessary files for a User Defined Function (UDF) in chDB:
+1. A Python executable script that processes input data
+2. An XML configuration file that registers the UDF with ClickHouse
+
+**Syntax**
+
+```python
+chdb.udf.generate_udf(func_name, args, return_type, udf_body)
+```
+
+**Parameters**
+
+| Parameter     | Type  | Description                                 |
+|---------------|-------|---------------------------------------------|
+| `func_name`   | str   | Name of the UDF function                    |
+| `args`        | list  | List of argument names for the function     |
+| `return_type` | str   | ClickHouse return type for the function     |
+| `udf_body`    | str   | Python source code body of the UDF function |
+
+:::note
+This function is typically called by the @chdb_udf decorator and shouldn't
+be called directly by users.
+:::
+
+---
+
+## Utilities
+Utility functions and helpers for chDB.
+
+This module contains various utility functions for working with chDB, including
+data type inference, data conversion helpers, and debugging utilities.
+
+---
+
+### `chdb.utils.convert_to_columnar`
+Converts a list of dictionaries into a columnar format.
+
+This function takes a list of dictionaries and converts it into a dictionary
+where each key corresponds to a column and each value is a list of column values.
+Missing values in the dictionaries are represented as None.
+
+**Syntax**
+
+```python
+chdb.utils.convert_to_columnar(items: List[Dict[str, Any]]) → Dict[str, List[Any]]
+```
+
+**Parameters**
+
+| Parameter  | Type                   | Description                       |
+|------------|------------------------|-----------------------------------|
+| `items`    | `List[Dict[str, Any]]` | A list of dictionaries to convert |
+
+**Returns**
+
+| Return Type            | Description                                                                 |
+|------------------------|-----------------------------------------------------------------------------|
+| `Dict[str, List[Any]]` | A dictionary with keys as column names and values as lists of column values |
+
+**Example**
+
+```pycon
+>>> items = [
+...     {"name": "Alice", "age": 30, "city": "New York"},
+...     {"name": "Bob", "age": 25},
+...     {"name": "Charlie", "city": "San Francisco"}
+... ]
+>>> convert_to_columnar(items)
+{
+    'name': ['Alice', 'Bob', 'Charlie'],
+    'age': [30, 25, None],
+    'city': ['New York', None, 'San Francisco']
+}
+```
+
+---
+
+### `chdb.utils.flatten_dict`
+Flattens a nested dictionary.
+
+This function takes a nested dictionary and flattens it, concatenating nested keys
+with a separator. Lists of dictionaries are serialized to JSON strings.
+
+**Syntax**
+
+```python
+chdb.utils.flatten_dict(d: Dict[str, Any], parent_key: str = '', sep: str = '_') → Dict[str, Any]
+```
+
+**Parameters**
+
+| Parameter    | Type             | Default    | Description                                    |
+|--------------|------------------|------------|------------------------------------------------|
+| `d`          | `Dict[str, Any]` | *required* | The dictionary to flatten                      |
+| `parent_key` | str              | `""`       | The base key to prepend to each key            |
+| `sep`        | str              | `"_"`      | The separator to use between concatenated keys |
+
+**Returns**
+
+| Return Type      | Description            |
+|------------------|------------------------|
+| `Dict[str, Any]` | A flattened dictionary |
+
+**Example**
+
+```pycon
+>>> nested_dict = {
+...     "a": 1,
+...     "b": {
+...         "c": 2,
+...         "d": {
+...             "e": 3
+...         }
+...     },
+...     "f": [4, 5, {"g": 6}],
+...     "h": [{"i": 7}, {"j": 8}]
+... }
+>>> flatten_dict(nested_dict)
+{
+    'a': 1,
+    'b_c': 2,
+    'b_d_e': 3,
+    'f_0': 4,
+    'f_1': 5,
+    'f_2_g': 6,
+    'h': '[{"i": 7}, {"j": 8}]'
+}
+```
+
+---
+
+### `chdb.utils.infer_data_type`
+Infers the most suitable data type for a list of values.
+
+This function examines a list of values and determines the most appropriate
+data type that can represent all the values in the list. It considers integer,
+unsigned integer, decimal, and float types, and defaults to “string” if the
+values can't be represented by any numeric type or if all values are None.
+
+**Syntax**
+
+```python
+chdb.utils.infer_data_type(values: List[Any]) → str
+```
+
+**Parameters**
+
+| Parameter  | Type        | Description                                                |
+|------------|-------------|------------------------------------------------------------|
+| `values`   | `List[Any]` | A list of values to analyze. The values can be of any type |
+
+**Returns**
+
+| Return Type | Description                                                                                                                                                                                                                                                 |
+|-------------|-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `str`       | A string representing the inferred data type. Possible return values are: ”int8”, “int16”, “int32”, “int64”, “int128”, “int256”, “uint8”, “uint16”,“uint32”, “uint64”, “uint128”, “uint256”, “decimal128”, “decimal256”, “float32”, “float64”, or “string”. | 
+
+:::note
+- If all values in the list are None, the function returns “string”.
+- If any value in the list is a string, the function immediately returns “string”.
+- The function assumes that numeric values can be represented as integers,
+  decimals, or floats based on their range and precision.
+:::
+
+---
+
+### `chdb.utils.infer_data_types`
+Infers data types for each column in a columnar data structure.
+
+This function analyzes the values in each column and infers the most suitable
+data type for each column, based on a sample of the data.
+
+**Syntax**
+
+```python
+chdb.utils.infer_data_types`(column_data: Dict[str, List[Any]], n_rows: int = 10000) → List[tuple]
+```
+
+**Parameters**
+
+| Parameter     | Type                   | Default    | Description                                                                    |
+|---------------|------------------------|------------|--------------------------------------------------------------------------------|
+| `column_data` | `Dict[str, List[Any]]` | *required* | A dictionary where keys are column names and values are lists of column values |
+| `n_rows`      | int                    | `10000`    | The number of rows to sample for type inference                                |
+
+**Returns**
+
+| Return Type   | Description                                                                |
+|---------------|----------------------------------------------------------------------------|
+| `List[tuple]` | A list of tuples, each containing a column name and its inferred data type |
+
+## Abstract Base Classes
+### **class** `chdb.rwabc.PyReader`(data: Any)`
+Bases: `ABC`
+
+```python
+class chdb.rwabc.PyReader(data: Any)
+```
+
+---
+
+#### **abstractmethod** `read`
+Read a specified number of rows from the given columns and return a list of objects,
+where each object is a sequence of values for a column.
+
+```python
+abstractmethod (col_names: List[str], count: int) → List[Any]
+```
+
+**Parameters**
+
+| Parameter   | Type        | Description                    |
+|-------------|-------------|--------------------------------|
+| `col_names` | `List[str]` | List of column names to read   |
+| `count`     | int         | Maximum number of rows to read |
+
+**Returns**
+
+| Return Type  | Description                            |
+|--------------|----------------------------------------|
+| `List[Any]`  | List of sequences, one for each column |
+
+### **class** `chdb.rwabc.PyWriter`
+Bases: `ABC`
+
+```python
+class chdb.rwabc.PyWriter(col_names: List[str], types: List[type], data: Any)
+```
+
+---
+
+#### **abstractmethod** finalize
+Assemble and return the final data from blocks. Must be implemented by subclasses.
+
+```python
+abstractmethod finalize() → bytes
+```
+
+**Returns**
+
+| Return Type  | Description               |
+|--------------|---------------------------|
+| `bytes`      | The final serialized data |
+
+---
+
+#### **abstractmethod** `write`
+Save columns of data to blocks. Must be implemented by subclasses.
+
+```python
+abstractmethod write(col_names: List[str], columns: List[List[Any]]) → None
+```
+
+**Parameters**
+
+| Parameter   | Type              | Description                                                |
+|-------------|-------------------|------------------------------------------------------------|
+| `col_names` | `List[str]`       | List of column names that are being written                |
+| `columns`   | `List[List[Any]]` | List of columns data, each column is represented by a list |
+
+## Exception Handling
+### **class** `chdb.ChdbError`
+Bases: `Exception`
+
+Base exception class for chDB-related errors.
+
+This exception is raised when chDB query execution fails or encounters
+an error. It inherits from the standard Python Exception class and
+provides error information from the underlying ClickHouse engine.
+
+The exception message typically contains detailed error information
+from ClickHouse, including syntax errors, type mismatches, missing
+tables/columns, and other query execution issues.
+
+**Variables**
+
+| Variable  | Type  | Description                                                     |
+|-----------|-------|-----------------------------------------------------------------|
+| `args`    | -     | Tuple containing the error message and any additional arguments |
+
+**Examples**
+
+```pycon
+>>> try:
+...     result = chdb.query("SELECT * FROM non_existent_table")
+... except chdb.ChdbError as e:
+...     print(f"Query failed: {e}")
+Query failed: Table 'non_existent_table' doesn't exist
+```
+
+```pycon
+>>> try:
+...     result = chdb.query("SELECT invalid_syntax FROM")
+... except chdb.ChdbError as e:
+...     print(f"Syntax error: {e}")
+Syntax error: Syntax error near 'FROM'
+```
+
+:::note
+This exception is automatically raised by chdb.query() and related
+functions when the underlying ClickHouse engine reports an error.
+You should catch this exception when handling potentially failing
+queries to provide appropriate error handling in your application.
+:::
+
+## Version Information
+### `chdb.chdb_version = ('3', '6', '0')`
+Built-in immutable sequence.
+
+If no argument is given, the constructor returns an empty tuple.
+If iterable is specified the tuple is initialized from iterable’s items.
+
+If the argument is a tuple, the return value is the same object.
+
+---
+
+### `chdb.engine_version = '25.5.2.1'`
+```python
+str(object=’’) -> str
+str(bytes_or_buffer[, encoding[, errors]]) -> str
+```
+
+Create a new string object from the given object. If encoding or
+errors is specified, then the object must expose a data buffer
+that will be decoded using the given encoding and error handler.
+Otherwise, returns the result of object._\_str_\_() (if defined)
+or repr(object).
+
+- encoding defaults to ‘utf-8’.
+- errors defaults to ‘strict’.
+
+---
+
+### `chdb.__version__ = '3.6.0'`
+```python
+str(object=’’) -> str
+str(bytes_or_buffer[, encoding[, errors]]) -> str
+```
+
+Create a new string object from the given object. If encoding or
+errors is specified, then the object must expose a data buffer
+that will be decoded using the given encoding and error handler.
+Otherwise, returns the result of object._\_str_\_() (if defined)
+or repr(object).
+
+- encoding defaults to ‘utf-8’.
+- errors defaults to ‘strict’.
+
+---
+
+# DataStore accessors
+
+**URL:** https://clickhouse.com/docs/chdb/datastore/accessors
+
+String, DateTime, Array, JSON, URL, IP, and Geo accessors with 185+ methods
+
+DataStore provides 7 accessor namespaces with 185+ methods for domain-specific operations.
+
+| Accessor | Methods | Description |
+|----------|---------|-------------|
+| `.str` | 56 | String operations |
+| `.dt` | 42+ | DateTime operations |
+| `.arr` | 37 | Array operations (ClickHouse-specific) |
+| `.json` | 13 | JSON parsing (ClickHouse-specific) |
+| `.url` | 15 | URL parsing (ClickHouse-specific) |
+| `.ip` | 9 | IP address operations (ClickHouse-specific) |
+| `.geo` | 14 | Geo/distance operations (ClickHouse-specific) |
+
+---
+
+## String Accessor (`.str`)
+All 56 pandas `.str` methods are supported, plus ClickHouse string functions.
+
+### Case Conversion
+| Method | ClickHouse | Description |
+|--------|------------|-------------|
+| `upper()` | `upper()` | Convert to uppercase |
+| `lower()` | `lower()` | Convert to lowercase |
+| `capitalize()` | `initcap()` | Capitalize first letter |
+| `title()` | `initcap()` | Title case |
+| `swapcase()` | - | Swap case |
+| `casefold()` | `lower()` | Case folding |
+
+```python
+ds['name_upper'] = ds['name'].str.upper()
+ds['name_title'] = ds['name'].str.title()
+```
+
+### Length and Size
+| Method | ClickHouse | Description |
+|--------|------------|-------------|
+| `len()` | `length()` | String length (bytes) |
+| `char_length()` | `char_length()` | Length in characters |
+
+```python
+ds['name_len'] = ds['name'].str.len()
+```
+
+### Substring and Slicing
+| Method | ClickHouse | Description |
+|--------|------------|-------------|
+| `slice(start, stop)` | `substring()` | Extract substring |
+| `slice_replace()` | - | Replace slice |
+| `left(n)` | `left()` | Leftmost n characters |
+| `right(n)` | `right()` | Rightmost n characters |
+| `get(i)` | - | Character at index |
+
+```python
+ds['first_3'] = ds['name'].str.slice(0, 3)
+ds['last_4'] = ds['name'].str.right(4)
+```
+
+### Trimming
+| Method | ClickHouse | Description |
+|--------|------------|-------------|
+| `strip()` | `trim()` | Remove whitespace |
+| `lstrip()` | `trimLeft()` | Remove leading whitespace |
+| `rstrip()` | `trimRight()` | Remove trailing whitespace |
+
+```python
+ds['trimmed'] = ds['text'].str.strip()
+```
+
+### Search and Match
+| Method | ClickHouse | Description |
+|--------|------------|-------------|
+| `contains(pat)` | `position()` | Contains substring |
+| `startswith(pat)` | `startsWith()` | Starts with prefix |
+| `endswith(pat)` | `endsWith()` | Ends with suffix |
+| `find(sub)` | `position()` | Find position |
+| `rfind(sub)` | - | Find from right |
+| `index(sub)` | `position()` | Find or raise |
+| `rindex(sub)` | - | Find from right or raise |
+| `match(pat)` | `match()` | Regex match |
+| `fullmatch(pat)` | - | Full regex match |
+| `count(pat)` | - | Count occurrences |
+
+```python
+# Contains substring
+ds['has_john'] = ds['name'].str.contains('John')
+
+# Regex match
+ds['valid_email'] = ds['email'].str.match(r'^[\w.-]+@[\w.-]+\.\w+$')
+```
+
+### Replace
+| Method | ClickHouse | Description |
+|--------|------------|-------------|
+| `replace(pat, repl)` | `replace()` | Replace occurrences |
+| `replace(pat, repl, regex=True)` | `replaceRegexpAll()` | Regex replace |
+| `removeprefix(prefix)` | - | Remove prefix |
+| `removesuffix(suffix)` | - | Remove suffix |
+| `translate(table)` | - | Translate characters |
+
+```python
+ds['cleaned'] = ds['text'].str.replace('\n', ' ')
+ds['digits_only'] = ds['phone'].str.replace(r'\D', '', regex=True)
+```
+
+### Splitting
+| Method | ClickHouse | Description |
+|--------|------------|-------------|
+| `split(sep)` | `splitByString()` | Split into array |
+| `rsplit(sep)` | - | Split from right |
+| `partition(sep)` | - | Split into 3 parts |
+| `rpartition(sep)` | - | Split from right into 3 |
+
+```python
+ds['parts'] = ds['path'].str.split('/')
+```
+
+### Padding
+| Method | ClickHouse | Description |
+|--------|------------|-------------|
+| `pad(width)` | `leftPad()` | Left pad |
+| `ljust(width)` | `rightPad()` | Right justify |
+| `rjust(width)` | `leftPad()` | Left justify |
+| `center(width)` | - | Center |
+| `zfill(width)` | `leftPad(..., '0')` | Zero fill |
+
+```python
+ds['padded_id'] = ds['id'].astype(str).str.zfill(6)
+```
+
+### Character Tests
+| Method | Description |
+|--------|-------------|
+| `isalpha()` | All alphabetic |
+| `isdigit()` | All digits |
+| `isalnum()` | Alphanumeric |
+| `isspace()` | All whitespace |
+| `isupper()` | All uppercase |
+| `islower()` | All lowercase |
+| `istitle()` | Title case |
+| `isnumeric()` | Numeric characters |
+| `isdecimal()` | Decimal characters |
+
+```python
+ds['is_numeric'] = ds['code'].str.isdigit()
+```
+
+### Other
+| Method | Description |
+|--------|-------------|
+| `repeat(n)` | Repeat n times |
+| `reverse()` | Reverse string |
+| `wrap(width)` | Wrap text |
+| `encode(enc)` | Encode |
+| `decode(enc)` | Decode |
+| `normalize(form)` | Unicode normalize |
+| `extract(pat)` | Extract regex groups |
+| `extractall(pat)` | Extract all matches |
+| `cat(sep)` | Concatenate all |
+| `get_dummies(sep)` | Dummy variables |
+
+---
+
+## DateTime Accessor (`.dt`)
+All 42+ pandas `.dt` methods plus ClickHouse datetime functions.
+
+### Date Components
+| Property | ClickHouse | Description |
+|----------|------------|-------------|
+| `year` | `toYear()` | Year |
+| `month` | `toMonth()` | Month (1-12) |
+| `day` | `toDayOfMonth()` | Day (1-31) |
+| `hour` | `toHour()` | Hour (0-23) |
+| `minute` | `toMinute()` | Minute (0-59) |
+| `second` | `toSecond()` | Second (0-59) |
+| `millisecond` | `toMillisecond()` | Millisecond |
+| `microsecond` | `toMicrosecond()` | Microsecond |
+| `quarter` | `toQuarter()` | Quarter (1-4) |
+| `dayofweek` | `toDayOfWeek()` | Day of week (0=Mon) |
+| `dayofyear` | `toDayOfYear()` | Day of year |
+| `week` | `toWeek()` | Week number |
+| `days_in_month` | - | Days in month |
+
+```python
+ds['year'] = ds['date'].dt.year
+ds['month'] = ds['date'].dt.month
+ds['day_of_week'] = ds['date'].dt.dayofweek
+```
+
+### Truncation
+| Method | ClickHouse | Description |
+|--------|------------|-------------|
+| `to_start_of_day()` | `toStartOfDay()` | Start of day |
+| `to_start_of_week()` | `toStartOfWeek()` | Start of week |
+| `to_start_of_month()` | `toStartOfMonth()` | Start of month |
+| `to_start_of_quarter()` | `toStartOfQuarter()` | Start of quarter |
+| `to_start_of_year()` | `toStartOfYear()` | Start of year |
+| `to_start_of_hour()` | `toStartOfHour()` | Start of hour |
+| `to_start_of_minute()` | `toStartOfMinute()` | Start of minute |
+
+```python
+ds['month_start'] = ds['date'].dt.to_start_of_month()
+```
+
+### Arithmetic
+| Method | ClickHouse | Description |
+|--------|------------|-------------|
+| `add_years(n)` | `addYears()` | Add years |
+| `add_months(n)` | `addMonths()` | Add months |
+| `add_weeks(n)` | `addWeeks()` | Add weeks |
+| `add_days(n)` | `addDays()` | Add days |
+| `add_hours(n)` | `addHours()` | Add hours |
+| `add_minutes(n)` | `addMinutes()` | Add minutes |
+| `add_seconds(n)` | `addSeconds()` | Add seconds |
+| `subtract_years(n)` | `subtractYears()` | Subtract years |
+| `subtract_months(n)` | `subtractMonths()` | Subtract months |
+| `subtract_days(n)` | `subtractDays()` | Subtract days |
+
+```python
+ds['next_month'] = ds['date'].dt.add_months(1)
+ds['last_week'] = ds['date'].dt.subtract_weeks(1)
+```
+
+### Boolean Checks
+| Method | Description |
+|--------|-------------|
+| `is_month_start()` | First day of month |
+| `is_month_end()` | Last day of month |
+| `is_quarter_start()` | First day of quarter |
+| `is_quarter_end()` | Last day of quarter |
+| `is_year_start()` | First day of year |
+| `is_year_end()` | Last day of year |
+| `is_leap_year()` | Leap year |
+
+```python
+ds['is_eom'] = ds['date'].dt.is_month_end()
+```
+
+### Formatting
+| Method | ClickHouse | Description |
+|--------|------------|-------------|
+| `strftime(fmt)` | `formatDateTime()` | Format as string |
+| `day_name()` | - | Day name |
+| `month_name()` | - | Month name |
+
+```python
+ds['date_str'] = ds['date'].dt.strftime('%Y-%m-%d')
+ds['day_name'] = ds['date'].dt.day_name()
+```
+
+### Timezone
+| Method | ClickHouse | Description |
+|--------|------------|-------------|
+| `tz_convert(tz)` | `toTimezone()` | Convert timezone |
+| `tz_localize(tz)` | - | Localize timezone |
+
+```python
+ds['utc_time'] = ds['timestamp'].dt.tz_convert('UTC')
+```
+
+---
+
+## Array Accessor (`.arr`)
+ClickHouse-specific array operations (37 methods).
+
+### Properties
+| Property | ClickHouse | Description |
+|----------|------------|-------------|
+| `length` | `length()` | Array length |
+| `size` | `length()` | Alias for length |
+| `empty` | `empty()` | Is empty |
+| `not_empty` | `notEmpty()` | Is not empty |
+
+```python
+ds['tag_count'] = ds['tags'].arr.length
+ds['has_tags'] = ds['tags'].arr.not_empty
+```
+
+### Element Access
+| Method | ClickHouse | Description |
+|--------|------------|-------------|
+| `array_first()` | `arrayElement(..., 1)` | First element |
+| `array_last()` | `arrayElement(..., -1)` | Last element |
+| `array_element(n)` | `arrayElement()` | Nth element |
+| `array_slice(off, len)` | `arraySlice()` | Slice array |
+
+```python
+ds['first_tag'] = ds['tags'].arr.array_first()
+ds['last_tag'] = ds['tags'].arr.array_last()
+```
+
+### Aggregations
+| Method | ClickHouse | Description |
+|--------|------------|-------------|
+| `array_sum()` | `arraySum()` | Sum of elements |
+| `array_avg()` | `arrayAvg()` | Average |
+| `array_min()` | `arrayMin()` | Minimum |
+| `array_max()` | `arrayMax()` | Maximum |
+| `array_product()` | `arrayProduct()` | Product |
+| `array_uniq()` | `arrayUniq()` | Count unique |
+
+```python
+ds['total'] = ds['values'].arr.array_sum()
+ds['average'] = ds['values'].arr.array_avg()
+```
+
+### Transformations
+| Method | ClickHouse | Description |
+|--------|------------|-------------|
+| `array_sort()` | `arraySort()` | Sort ascending |
+| `array_reverse_sort()` | `arrayReverseSort()` | Sort descending |
+| `array_reverse()` | `arrayReverse()` | Reverse order |
+| `array_distinct()` | `arrayDistinct()` | Unique elements |
+| `array_compact()` | `arrayCompact()` | Remove consecutive dupes |
+| `array_flatten()` | `arrayFlatten()` | Flatten nested |
+
+```python
+ds['sorted_tags'] = ds['tags'].arr.array_sort()
+ds['unique_tags'] = ds['tags'].arr.array_distinct()
+```
+
+### Modifications
+| Method | ClickHouse | Description |
+|--------|------------|-------------|
+| `array_push_back(elem)` | `arrayPushBack()` | Add to end |
+| `array_push_front(elem)` | `arrayPushFront()` | Add to front |
+| `array_pop_back()` | `arrayPopBack()` | Remove last |
+| `array_pop_front()` | `arrayPopFront()` | Remove first |
+| `array_concat(other)` | `arrayConcat()` | Concatenate |
+
+### Search
+| Method | ClickHouse | Description |
+|--------|------------|-------------|
+| `has(elem)` | `has()` | Contains element |
+| `index_of(elem)` | `indexOf()` | Find index |
+| `count_equal(elem)` | `countEqual()` | Count occurrences |
+
+```python
+ds['has_python'] = ds['skills'].arr.has('Python')
+```
+
+### String Operations
+| Method | ClickHouse | Description |
+|--------|------------|-------------|
+| `array_string_concat(sep)` | `arrayStringConcat()` | Join to string |
+
+```python
+ds['tags_str'] = ds['tags'].arr.array_string_concat(', ')
+```
+
+---
+
+## JSON Accessor (`.json`)
+ClickHouse-specific JSON parsing (13 methods).
+
+| Method | ClickHouse | Description |
+|--------|------------|-------------|
+| `get_string(path)` | `JSONExtractString()` | Extract string |
+| `get_int(path)` | `JSONExtractInt()` | Extract integer |
+| `get_float(path)` | `JSONExtractFloat()` | Extract float |
+| `get_bool(path)` | `JSONExtractBool()` | Extract boolean |
+| `get_raw(path)` | `JSONExtractRaw()` | Extract raw JSON |
+| `get_keys()` | `JSONExtractKeys()` | Get keys |
+| `get_type(path)` | `JSONType()` | Get type |
+| `get_length(path)` | `JSONLength()` | Get length |
+| `has_key(key)` | `JSONHas()` | Check key exists |
+| `is_valid()` | `isValidJSON()` | Validate JSON |
+| `to_json_string()` | `toJSONString()` | Convert to JSON |
+
+```python
+# Parse JSON columns
+ds['user_name'] = ds['json_data'].json.get_string('user.name')
+ds['user_age'] = ds['json_data'].json.get_int('user.age')
+ds['is_active'] = ds['json_data'].json.get_bool('user.active')
+ds['has_email'] = ds['json_data'].json.has_key('user.email')
+```
+
+---
+
+## URL Accessor (`.url`)
+ClickHouse-specific URL parsing (15 methods).
+
+| Method | ClickHouse | Description |
+|--------|------------|-------------|
+| `domain()` | `domain()` | Extract domain |
+| `domain_without_www()` | `domainWithoutWWW()` | Domain without www |
+| `top_level_domain()` | `topLevelDomain()` | TLD |
+| `protocol()` | `protocol()` | Protocol (http/https) |
+| `path()` | `path()` | URL path |
+| `path_full()` | `pathFull()` | Path with query |
+| `query_string()` | `queryString()` | Query string |
+| `fragment()` | `fragment()` | Fragment (#...) |
+| `port()` | `port()` | Port number |
+| `extract_url_parameter(name)` | `extractURLParameter()` | Get query param |
+| `extract_url_parameters()` | `extractURLParameters()` | All params |
+| `cut_url_parameter(name)` | `cutURLParameter()` | Remove param |
+| `decode_url_component()` | `decodeURLComponent()` | URL decode |
+| `encode_url_component()` | `encodeURLComponent()` | URL encode |
+
+```python
+# Parse URLs
+ds['domain'] = ds['url'].url.domain()
+ds['path'] = ds['url'].url.path()
+ds['utm_source'] = ds['url'].url.extract_url_parameter('utm_source')
+```
+
+---
+
+## IP Accessor (`.ip`)
+ClickHouse-specific IP address operations (9 methods).
+
+| Method | ClickHouse | Description |
+|--------|------------|-------------|
+| `to_ipv4()` | `toIPv4()` | Convert to IPv4 |
+| `to_ipv6()` | `toIPv6()` | Convert to IPv6 |
+| `ipv4_num_to_string()` | `IPv4NumToString()` | Number to string |
+| `ipv4_string_to_num()` | `IPv4StringToNum()` | String to number |
+| `ipv6_num_to_string()` | `IPv6NumToString()` | IPv6 num to string |
+| `ipv4_to_ipv6()` | `IPv4ToIPv6()` | Convert to IPv6 |
+| `is_ipv4_string()` | `isIPv4String()` | Validate IPv4 |
+| `is_ipv6_string()` | `isIPv6String()` | Validate IPv6 |
+| `ipv4_cidr_to_range(cidr)` | `IPv4CIDRToRange()` | CIDR to range |
+
+```python
+# IP operations
+ds['is_valid_ip'] = ds['ip'].ip.is_ipv4_string()
+ds['ip_num'] = ds['ip'].ip.ipv4_string_to_num()
+```
+
+---
+
+## Geo Accessor (`.geo`)
+ClickHouse-specific geo/distance operations (14 methods).
+
+### Distance Functions
+| Method | ClickHouse | Description |
+|--------|------------|-------------|
+| `great_circle_distance(...)` | `greatCircleDistance()` | Great circle distance |
+| `geo_distance(...)` | `geoDistance()` | WGS-84 distance |
+| `l1_distance(v1, v2)` | `L1Distance()` | Manhattan distance |
+| `l2_distance(v1, v2)` | `L2Distance()` | Euclidean distance |
+| `l2_squared_distance(v1, v2)` | `L2SquaredDistance()` | Squared Euclidean |
+| `linf_distance(v1, v2)` | `LinfDistance()` | Chebyshev distance |
+| `cosine_distance(v1, v2)` | `cosineDistance()` | Cosine distance |
+
+### Vector Operations
+| Method | ClickHouse | Description |
+|--------|------------|-------------|
+| `dot_product(v1, v2)` | `dotProduct()` | Dot product |
+| `l2_norm(vec)` | `L2Norm()` | Vector norm |
+| `l2_normalize(vec)` | `L2Normalize()` | Normalize |
+
+### H3 Functions
+| Method | ClickHouse | Description |
+|--------|------------|-------------|
+| `geo_to_h3(lon, lat, res)` | `geoToH3()` | Geo to H3 index |
+| `h3_to_geo(h3)` | `h3ToGeo()` | H3 to geo coords |
+
+### Point Operations
+| Method | ClickHouse | Description |
+|--------|------------|-------------|
+| `point_in_polygon(pt, poly)` | `pointInPolygon()` | Point in polygon |
+| `point_in_ellipses(...)` | `pointInEllipses()` | Point in ellipses |
+
+```python
+from chdb.datastore import F
+
+# Calculate distances
+ds['distance'] = F.great_circle_distance(
+    ds['lon1'], ds['lat1'],
+    ds['lon2'], ds['lat2']
+)
+
+# Vector similarity
+ds['similarity'] = F.cosine_distance(ds['embedding1'], ds['embedding2'])
+```
+
+---
+
+## Using Accessors
+### Lazy Evaluation
+Most accessor methods are lazy - they return expressions that are evaluated later:
+
+```python
+# All these are lazy
+ds['name_upper'] = ds['name'].str.upper()  # Not executed yet
+ds['year'] = ds['date'].dt.year            # Not executed yet
+ds['domain'] = ds['url'].url.domain()      # Not executed yet
+
+# Execution happens when you access results
+df = ds.to_df()  # Now everything executes
+```
+
+### Methods That Execute Immediately
+Some `.str` methods must execute because they change the structure:
+
+| Method | Returns | Why |
+|--------|---------|-----|
+| `partition(sep)` | DataStore (3 columns) | Creates multiple columns |
+| `rpartition(sep)` | DataStore (3 columns) | Creates multiple columns |
+| `get_dummies(sep)` | DataStore (N columns) | Dynamic column count |
+| `extractall(pat)` | DataStore | MultiIndex result |
+| `cat(sep)` | str | Aggregation (N rows → 1) |
+
+### Chaining Accessors
+Accessor methods can be chained:
+
+```python
+ds['clean_name'] = (ds['name']
+    .str.strip()
+    .str.lower()
+    .str.replace(' ', '_')
+)
+
+ds['next_month_start'] = (ds['date']
+    .dt.add_months(1)
+    .dt.to_start_of_month()
+)
+```
+
+---
+
+# DataStore aggregation functions
+
+**URL:** https://clickhouse.com/docs/chdb/datastore/aggregation
+
+Aggregate functions, window functions, and the F namespace in DataStore
+
+DataStore provides comprehensive aggregation and window function support, leveraging ClickHouse's powerful SQL aggregation capabilities.
+
+## Basic Aggregations
+### Built-in Methods
+| Method | SQL Equivalent | Description |
+|--------|---------------|-------------|
+| `sum()` | `SUM()` | Sum of values |
+| `mean()` | `AVG()` | Average/mean |
+| `count()` | `COUNT()` | Count non-null values |
+| `min()` | `MIN()` | Minimum value |
+| `max()` | `MAX()` | Maximum value |
+| `median()` | `MEDIAN()` | Median value |
+| `std()` | `stddevPop()` | Standard deviation |
+| `var()` | `varPop()` | Variance |
+| `nunique()` | `COUNT(DISTINCT)` | Count unique values |
+
+**Examples:**
+
+```python
+from pathlib import Path
+Path("sales.csv").write_text("""\
+region,product,category,amount,quantity,price,date,order_id
+East,Widget,Electronics,5200,10,120,2024-01-15,1001
+West,Gadget,Electronics,800,5,160,2024-02-20,1002
+East,Gizmo,Home,6500,3,100,2024-03-10,1003
+North,Widget,Electronics,4500,6,150,2024-06-18,1004
+West,Gadget,Electronics,2000,8,250,2024-09-14,1005
+""")
+
+from chdb import datastore as pd
+
+ds = pd.read_csv("sales.csv")
+
+# Single column aggregation
+total = ds['amount'].sum()
+average = ds['amount'].mean()
+count = ds['amount'].count()
+
+# All aggregations
+print(ds['amount'].sum())    # Total
+print(ds['amount'].mean())   # Average
+print(ds['amount'].std())    # Standard deviation
+print(ds['amount'].median()) # Median
+print(ds['amount'].nunique()) # Unique count
+```
+
+---
+
+## GroupBy Aggregations
+### Single Aggregation
+```python
+# Group by and aggregate
+result = ds.groupby('category')['amount'].sum()
+result = ds.groupby('region')['sales'].mean()
+```
+
+### Multiple Aggregations
+```python
+# Dictionary syntax
+result = ds.groupby('category').agg({
+    'amount': 'sum',
+    'quantity': 'mean',
+    'order_id': 'count'
+})
+
+# List of aggregations per column
+result = ds.groupby('category').agg({
+    'amount': ['sum', 'mean', 'max'],
+    'quantity': ['sum', 'count']
+})
+```
+
+### Named Aggregations
+```python
+# Named aggregation (pandas style)
+result = ds.groupby('region').agg(
+    total_amount=('amount', 'sum'),
+    avg_quantity=('quantity', 'mean'),
+    order_count=('order_id', 'count'),
+    max_price=('price', 'max')
+)
+```
+
+### Multiple GroupBy Keys
+```python
+# Group by multiple columns
+result = ds.groupby(['region', 'category']).agg({
+    'amount': 'sum',
+    'quantity': 'sum'
+})
+```
+
+---
+
+## Statistical Aggregations
+| Method | SQL Equivalent | Description |
+|--------|---------------|-------------|
+| `quantile(q)` | `quantile(q)` | q-th quantile (0-1) |
+| `skew()` | `skewPop()` | Skewness |
+| `kurt()` | `kurtPop()` | Kurtosis |
+| `corr()` | `corr()` | Correlation |
+| `cov()` | `covar()` | Covariance |
+| `sem()` | - | Standard error of mean |
+
+**Examples:**
+
+```python
+# Quantiles
+q50 = ds['amount'].quantile(0.5)  # Median
+q95 = ds['amount'].quantile(0.95) # 95th percentile
+
+# Multiple quantiles
+quantiles = ds['amount'].quantile([0.25, 0.5, 0.75])
+
+# Correlation between columns
+correlation = ds[['sales', 'marketing_spend']].corr()
+```
+
+---
+
+## Conditional Aggregations
+ClickHouse-specific conditional aggregation functions.
+
+| Function | ClickHouse | Description |
+|----------|------------|-------------|
+| `sum_if(cond)` | `sumIf()` | Sum where condition |
+| `count_if(cond)` | `countIf()` | Count where condition |
+| `avg_if(cond)` | `avgIf()` | Average where condition |
+| `min_if(cond)` | `minIf()` | Min where condition |
+| `max_if(cond)` | `maxIf()` | Max where condition |
+
+**Examples:**
+
+```python
+from chdb.datastore import F, Field
+
+# Sum only high value orders
+high_value_sum = F.sum_if(Field('amount'), Field('amount') > 1000)
+
+# Count active users
+active_count = F.count_if(Field('status') == 'active')
+
+# In groupby context
+result = ds.groupby('region').agg({
+    'total': ('amount', 'sum'),
+    'high_value': ('amount', F.sum_if(Field('amount') > 1000)),
+})
+```
+
+---
+
+## Collection Aggregations
+ClickHouse-specific functions that collect values.
+
+| Function | ClickHouse | Description |
+|----------|------------|-------------|
+| `group_array()` | `groupArray()` | Collect into array |
+| `group_uniq_array()` | `groupUniqArray()` | Collect unique into array |
+| `group_concat(sep)` | `groupConcat()` | Concatenate strings |
+| `top_k(n)` | `topK(n)` | Top K frequent values |
+| `any()` | `any()` | Any value |
+| `any_last()` | `anyLast()` | Last value |
+| `first_value()` | `first_value()` | First value in order |
+| `last_value()` | `last_value()` | Last value in order |
+
+**Examples:**
+
+```python
+from chdb.datastore import F, Field
+
+# Collect all tags per category
+result = ds.groupby('category').agg({
+    'all_tags': ('tag', F.group_array()),
+    'unique_tags': ('tag', F.group_uniq_array())
+})
+
+# Get top 5 products per region
+result = ds.groupby('region').agg({
+    'top_products': ('product_id', F.top_k(5))
+})
+```
+
+---
+
+## Window Functions
+### Ranking Functions
+| Function | SQL | Description |
+|----------|-----|-------------|
+| `row_number()` | `ROW_NUMBER()` | Sequential row number |
+| `rank()` | `RANK()` | Rank with gaps |
+| `dense_rank()` | `DENSE_RANK()` | Rank without gaps |
+| `ntile(n)` | `NTILE(n)` | Divide into n buckets |
+| `percent_rank()` | `PERCENT_RANK()` | Percentile rank (0-1) |
+| `cume_dist()` | `CUME_DIST()` | Cumulative distribution |
+
+**Examples:**
+
+```python
+from chdb.datastore import F, Field
+
+# Add row number
+ds['row_num'] = F.row_number().over(order_by='date')
+
+# Rank within groups
+ds['rank'] = F.rank().over(
+    partition_by='category',
+    order_by='sales'
+)
+
+# Dense rank (no gaps)
+ds['dense_rank'] = F.dense_rank().over(
+    partition_by='region',
+    order_by=('revenue', 'desc')
+)
+
+# Divide into quartiles
+ds['quartile'] = F.ntile(4).over(order_by='score')
+```
+
+### Value Functions
+| Function | SQL | Description |
+|----------|-----|-------------|
+| `lag(n)` | `LAG(col, n)` | Previous row value |
+| `lead(n)` | `LEAD(col, n)` | Next row value |
+| `first_value()` | `FIRST_VALUE()` | First value in window |
+| `last_value()` | `LAST_VALUE()` | Last value in window |
+| `nth_value(n)` | `NTH_VALUE(col, n)` | Nth value in window |
+
+**Examples:**
+
+```python
+# Previous and next value
+ds['prev_price'] = F.lag('price', 1).over(order_by='date')
+ds['next_price'] = F.lead('price', 1).over(order_by='date')
+
+# First and last in partition
+ds['first_order'] = F.first_value('amount').over(
+    partition_by='customer_id',
+    order_by='date'
+)
+```
+
+### Cumulative Functions
+| Method | Description |
+|--------|-------------|
+| `cumsum()` | Cumulative sum |
+| `cummax()` | Cumulative maximum |
+| `cummin()` | Cumulative minimum |
+| `cumprod()` | Cumulative product |
+| `diff(n)` | Difference from n rows back |
+| `pct_change(n)` | Percent change from n rows back |
+
+**Examples:**
+
+```python
+# Cumulative calculations
+ds['running_total'] = ds['amount'].cumsum()
+ds['running_max'] = ds['amount'].cummax()
+
+# With grouping
+ds['group_cumsum'] = ds.groupby('category')['amount'].cumsum()
+
+# Period over period
+ds['daily_diff'] = ds['sales'].diff(1)
+ds['pct_change'] = ds['sales'].pct_change(1)
+```
+
+### Rolling Windows
+```python
+# Rolling window aggregations
+ds['rolling_avg'] = ds['price'].rolling(window=7).mean()
+ds['rolling_sum'] = ds['amount'].rolling(window=30).sum()
+ds['rolling_std'] = ds['value'].rolling(window=10).std()
+
+# Expanding windows
+ds['expanding_max'] = ds['price'].expanding().max()
+ds['expanding_sum'] = ds['amount'].expanding().sum()
+```
+
+---
+
+## F Namespace
+The `F` namespace provides access to ClickHouse functions.
+
+### Import
+```python
+from chdb.datastore import F, Field
+```
+
+### Using F Functions
+```python
+# Aggregations
+F.sum(Field('amount'))
+F.avg(Field('price'))
+F.count(Field('id'))
+
+# Statistical
+F.quantile(Field('value'), 0.95)
+F.stddev_pop(Field('score'))
+F.corr(Field('x'), Field('y'))
+
+# Conditional
+F.sum_if(Field('amount'), Field('status') == 'completed')
+F.count_if(Field('is_active'))
+
+# String
+F.length(Field('name'))
+F.upper(Field('text'))
+
+# Date/Time
+F.to_year(Field('date'))
+F.date_diff('day', Field('start'), Field('end'))
+
+# Array
+F.array_sum(Field('values'))
+F.array_avg(Field('scores'))
+
+# Math
+F.abs(Field('delta'))
+F.round(Field('price'), 2)
+F.floor(Field('value'))
+F.ceil(Field('value'))
+```
+
+### F with Window Functions
+```python
+# Define window frame
+window = F.window(
+    partition_by='category',
+    order_by='date',
+    rows_between=(-7, 0)  # Current row and 7 preceding
+)
+
+ds['rolling_avg'] = F.avg(Field('price')).over(window)
+```
+
+---
+
+## Common Aggregation Patterns
+### Top N per Group
+```python
+# Top 3 products per category by sales
+result = (ds
+    .assign(rank=F.row_number().over(
+        partition_by='category',
+        order_by=('sales', 'desc')
+    ))
+    .filter(ds['rank'] <= 3)
+)
+```
+
+### Running Total
+```python
+# Running total of sales
+ds['running_total'] = F.sum('amount').over(
+    order_by='date',
+    rows_between=(None, 0)  # All rows up to current
+)
+```
+
+### Moving Average
+```python
+# 7-day moving average
+ds['ma_7'] = F.avg('price').over(
+    order_by='date',
+    rows_between=(-6, 0)
+)
+```
+
+### Year-over-Year Comparison
+```python
+# YoY comparison
+ds['prev_year_sales'] = F.lag('sales', 12).over(
+    partition_by='product_id',
+    order_by='month'
+)
+ds['yoy_growth'] = (ds['sales'] - ds['prev_year_sales']) / ds['prev_year_sales']
+```
+
+### Percentile Ranking
+```python
+# Rank customers by total spend
+ds['spend_percentile'] = F.percent_rank().over(order_by='total_spend')
+```
+
+---
+
+## Aggregation Methods Summary
+| Category | Methods |
+|----------|---------|
+| **Basic** | `sum`, `mean`, `count`, `min`, `max`, `median` |
+| **Statistical** | `std`, `var`, `quantile`, `skew`, `kurt`, `corr`, `cov` |
+| **Conditional** | `sum_if`, `count_if`, `avg_if`, `min_if`, `max_if` |
+| **Collection** | `group_array`, `group_uniq_array`, `group_concat`, `top_k` |
+| **Ranking** | `row_number`, `rank`, `dense_rank`, `ntile`, `percent_rank` |
+| **Value** | `lag`, `lead`, `first_value`, `last_value`, `nth_value` |
+| **Cumulative** | `cumsum`, `cummax`, `cummin`, `cumprod`, `diff`, `pct_change` |
+| **Rolling** | `rolling().mean/sum/std/...`, `expanding().mean/sum/...` |
+
+---
+
+# DataStore class reference
+
+**URL:** https://clickhouse.com/docs/chdb/datastore/class-reference
+
+Complete API reference for DataStore, ColumnExpr, LazyGroupBy, and LazySeries classes
+
+This reference documents the core classes in the DataStore API.
+
+## DataStore
+The main DataFrame-like class for data manipulation.
+
+```python
+from chdb.datastore import DataStore
+```
+
+### Constructor
+```python
+DataStore(data=None, columns=None, index=None, dtype=None, copy=None)
+```
+
+**Parameters:**
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `data` | dict/list/DataFrame/DataStore | Input data |
+| `columns` | list | Column names |
+| `index` | Index | Row index |
+| `dtype` | dict | Column data types |
+| `copy` | bool | Copy data |
+
+**Examples:**
+
+```python
+# From dictionary
+ds = DataStore({'a': [1, 2, 3], 'b': ['x', 'y', 'z']})
+
+# From pandas DataFrame
+
+ds = DataStore(pd.DataFrame({'a': [1, 2, 3]}))
+
+# Empty DataStore
+ds = DataStore()
+```
+
+### Properties
+| Property | Type | Description |
+|----------|------|-------------|
+| `columns` | Index | Column names |
+| `dtypes` | Series | Column data types |
+| `shape` | tuple | (rows, columns) |
+| `size` | int | Total elements |
+| `ndim` | int | Number of dimensions (2) |
+| `empty` | bool | Is DataFrame empty |
+| `values` | ndarray | Underlying data as NumPy array |
+| `index` | Index | Row index |
+| `T` | DataStore | Transpose |
+| `axes` | list | List of axes |
+
+### Factory Methods
+| Method | Description |
+|--------|-------------|
+| `uri(uri)` | Universal factory from URI |
+| `from_file(path, ...)` | Create from file |
+| `from_df(df)` | Create from pandas DataFrame |
+| `from_s3(url, ...)` | Create from S3 |
+| `from_gcs(url, ...)` | Create from Google Cloud Storage |
+| `from_azure(url, ...)` | Create from Azure Blob |
+| `from_mysql(...)` | Create from MySQL |
+| `from_postgresql(...)` | Create from PostgreSQL |
+| `from_clickhouse(...)` | Create from ClickHouse |
+| `from_mongodb(...)` | Create from MongoDB |
+| `from_sqlite(...)` | Create from SQLite |
+| `from_iceberg(path)` | Create from Iceberg table |
+| `from_delta(path)` | Create from Delta Lake |
+| `from_numbers(n)` | Create with sequential numbers |
+| `from_random(rows, cols)` | Create with random data |
+| `run_sql(query)` | Create from SQL query |
+
+See [Factory Methods](factory-methods.md) for details.
+
+### Query Methods
+| Method | Returns | Description |
+|--------|---------|-------------|
+| `select(*cols)` | DataStore | Select columns |
+| `filter(condition)` | DataStore | Filter rows |
+| `where(condition)` | DataStore | Alias for filter |
+| `sort(*cols, ascending=True)` | DataStore | Sort rows |
+| `orderby(*cols)` | DataStore | Alias for sort |
+| `limit(n)` | DataStore | Limit rows |
+| `offset(n)` | DataStore | Skip rows |
+| `distinct(subset=None)` | DataStore | Remove duplicates |
+| `groupby(*cols)` | LazyGroupBy | Group rows |
+| `having(condition)` | DataStore | Filter groups |
+| `join(right, ...)` | DataStore | Join DataStores |
+| `union(other, all=False)` | DataStore | Combine DataStores |
+| `when(cond, val)` | CaseWhen | CASE WHEN |
+
+See [Query Building](query-building.md) for details.
+
+### Pandas-compatible methods
+See [Pandas Compatibility](pandas-compat.md) for the complete list of 209 methods.
+
+**Indexing:**
+`head()`, `tail()`, `sample()`, `loc`, `iloc`, `at`, `iat`, `query()`, `isin()`, `where()`, `mask()`, `get()`, `xs()`, `pop()`
+
+**Aggregation:**
+`sum()`, `mean()`, `std()`, `var()`, `min()`, `max()`, `median()`, `count()`, `nunique()`, `quantile()`, `describe()`, `corr()`, `cov()`, `skew()`, `kurt()`
+
+**Manipulation:**
+`drop()`, `drop_duplicates()`, `dropna()`, `fillna()`, `replace()`, `rename()`, `assign()`, `astype()`, `copy()`
+
+**Sorting:**
+`sort_values()`, `sort_index()`, `nlargest()`, `nsmallest()`, `rank()`
+
+**Reshaping:**
+`pivot()`, `pivot_table()`, `melt()`, `stack()`, `unstack()`, `transpose()`, `explode()`, `squeeze()`
+
+**Combining:**
+`merge()`, `join()`, `concat()`, `append()`, `combine()`, `update()`, `compare()`
+
+**Apply/Transform:**
+`apply()`, `applymap()`, `map()`, `agg()`, `transform()`, `pipe()`, `groupby()`
+
+**Time Series:**
+`rolling()`, `expanding()`, `ewm()`, `shift()`, `diff()`, `pct_change()`, `resample()`
+
+### I/O Methods
+| Method | Description |
+|--------|-------------|
+| `to_csv(path, ...)` | Export to CSV |
+| `to_parquet(path, ...)` | Export to Parquet |
+| `to_json(path, ...)` | Export to JSON |
+| `to_excel(path, ...)` | Export to Excel |
+| `to_df()` | Convert to pandas DataFrame |
+| `to_pandas()` | Alias for to_df |
+| `to_arrow()` | Convert to Arrow Table |
+| `to_dict(orient)` | Convert to dictionary |
+| `to_records()` | Convert to records |
+| `to_numpy()` | Convert to NumPy array |
+| `to_sql()` | Generate SQL string |
+| `to_string()` | String representation |
+| `to_markdown()` | Markdown table |
+| `to_html()` | HTML table |
+
+See [I/O Operations](io.md) for details.
+
+### Debugging Methods
+| Method | Description |
+|--------|-------------|
+| `explain(verbose=False)` | Show execution plan |
+| `clear_cache()` | Clear cached results |
+
+See [Debugging](../debugging/index.md) for details.
+
+### Magic Methods
+| Method | Description |
+|--------|-------------|
+| `__getitem__(key)` | `ds['col']`, `ds[['a', 'b']]`, `ds[condition]` |
+| `__setitem__(key, value)` | `ds['col'] = value` |
+| `__delitem__(key)` | `del ds['col']` |
+| `__len__()` | `len(ds)` |
+| `__iter__()` | `for col in ds` |
+| `__contains__(key)` | `'col' in ds` |
+| `__repr__()` | `repr(ds)` |
+| `__str__()` | `str(ds)` |
+| `__eq__(other)` | `ds == other` |
+| `__ne__(other)` | `ds != other` |
+| `__lt__(other)` | `ds < other` |
+| `__le__(other)` | `ds <= other` |
+| `__gt__(other)` | `ds > other` |
+| `__ge__(other)` | `ds >= other` |
+| `__add__(other)` | `ds + other` |
+| `__sub__(other)` | `ds - other` |
+| `__mul__(other)` | `ds * other` |
+| `__truediv__(other)` | `ds / other` |
+| `__floordiv__(other)` | `ds // other` |
+| `__mod__(other)` | `ds % other` |
+| `__pow__(other)` | `ds ** other` |
+| `__and__(other)` | `ds & other` |
+| `__or__(other)` | `ds | other` |
+| `__invert__()` | `~ds` |
+| `__neg__()` | `-ds` |
+| `__pos__()` | `+ds` |
+| `__abs__()` | `abs(ds)` |
+
+---
+
+## ColumnExpr
+Represents a column expression for lazy evaluation. Returned when accessing a column.
+
+```python
+# ColumnExpr is returned automatically
+col = ds['name']  # Returns ColumnExpr
+```
+
+### Properties
+| Property | Type | Description |
+|----------|------|-------------|
+| `name` | str | Column name |
+| `dtype` | dtype | Data type |
+
+### Accessors
+| Accessor | Description | Methods |
+|----------|-------------|---------|
+| `.str` | String operations | 56 methods |
+| `.dt` | DateTime operations | 42+ methods |
+| `.arr` | Array operations | 37 methods |
+| `.json` | JSON parsing | 13 methods |
+| `.url` | URL parsing | 15 methods |
+| `.ip` | IP address operations | 9 methods |
+| `.geo` | Geo/distance operations | 14 methods |
+
+See [Accessors](accessors.md) for complete documentation.
+
+### Arithmetic Operations
+```python
+ds['total'] = ds['price'] * ds['quantity']
+ds['profit'] = ds['revenue'] - ds['cost']
+ds['ratio'] = ds['a'] / ds['b']
+ds['squared'] = ds['value'] ** 2
+ds['remainder'] = ds['value'] % 10
+```
+
+### Comparison Operations
+```python
+ds[ds['age'] > 25]           # Greater than
+ds[ds['age'] >= 25]          # Greater or equal
+ds[ds['age'] < 25]           # Less than
+ds[ds['age'] <= 25]          # Less or equal
+ds[ds['name'] == 'Alice']    # Equal
+ds[ds['name'] != 'Bob']      # Not equal
+```
+
+### Logical Operations
+```python
+ds[(ds['age'] > 25) & (ds['city'] == 'NYC')]    # AND
+ds[(ds['age'] > 25) | (ds['city'] == 'NYC')]    # OR
+ds[~(ds['status'] == 'inactive')]               # NOT
+```
+
+### Methods
+| Method | Description |
+|--------|-------------|
+| `as_(alias)` | Set alias name |
+| `cast(dtype)` | Cast to type |
+| `astype(dtype)` | Alias for cast |
+| `isnull()` | Is NULL |
+| `notnull()` | Is not NULL |
+| `isna()` | Alias for isnull |
+| `notna()` | Alias for notnull |
+| `isin(values)` | In list of values |
+| `between(low, high)` | Between two values |
+| `fillna(value)` | Fill NULLs |
+| `replace(to_replace, value)` | Replace values |
+| `clip(lower, upper)` | Clip values |
+| `abs()` | Absolute value |
+| `round(decimals)` | Round values |
+| `floor()` | Floor |
+| `ceil()` | Ceiling |
+| `apply(func)` | Apply function |
+| `map(mapper)` | Map values |
+
+### Aggregation Methods
+| Method | Description |
+|--------|-------------|
+| `sum()` | Sum |
+| `mean()` | Mean |
+| `avg()` | Alias for mean |
+| `min()` | Minimum |
+| `max()` | Maximum |
+| `count()` | Count non-null |
+| `nunique()` | Unique count |
+| `std()` | Standard deviation |
+| `var()` | Variance |
+| `median()` | Median |
+| `quantile(q)` | Quantile |
+| `first()` | First value |
+| `last()` | Last value |
+| `any()` | Any true |
+| `all()` | All true |
+
+---
+
+## LazyGroupBy
+Represents a grouped DataStore for aggregation operations.
+
+```python
+# LazyGroupBy is returned automatically
+grouped = ds.groupby('category')  # Returns LazyGroupBy
+```
+
+### Methods
+| Method | Returns | Description |
+|--------|---------|-------------|
+| `agg(spec)` | DataStore | Aggregate |
+| `aggregate(spec)` | DataStore | Alias for agg |
+| `sum()` | DataStore | Sum per group |
+| `mean()` | DataStore | Mean per group |
+| `count()` | DataStore | Count per group |
+| `min()` | DataStore | Min per group |
+| `max()` | DataStore | Max per group |
+| `std()` | DataStore | Std dev per group |
+| `var()` | DataStore | Variance per group |
+| `median()` | DataStore | Median per group |
+| `nunique()` | DataStore | Unique count per group |
+| `first()` | DataStore | First value per group |
+| `last()` | DataStore | Last value per group |
+| `nth(n)` | DataStore | Nth value per group |
+| `head(n)` | DataStore | First n per group |
+| `tail(n)` | DataStore | Last n per group |
+| `apply(func)` | DataStore | Apply function per group |
+| `transform(func)` | DataStore | Transform per group |
+| `filter(func)` | DataStore | Filter groups |
+
+### Column Selection
+```python
+# Select column after groupby
+grouped['amount'].sum()     # Returns DataStore
+grouped[['a', 'b']].sum()   # Returns DataStore
+```
+
+### Aggregation Specifications
+```python
+# Single aggregation
+grouped.agg({'amount': 'sum'})
+
+# Multiple aggregations per column
+grouped.agg({'amount': ['sum', 'mean', 'count']})
+
+# Named aggregations
+grouped.agg(
+    total=('amount', 'sum'),
+    average=('amount', 'mean'),
+    count=('id', 'count')
+)
+```
+
+---
+
+## LazySeries
+Represents a lazy Series (single column).
+
+### Properties
+| Property | Type | Description |
+|----------|------|-------------|
+| `name` | str | Series name |
+| `dtype` | dtype | Data type |
+
+### Methods
+Inherits most methods from `ColumnExpr`. Key methods:
+
+| Method | Description |
+|--------|-------------|
+| `value_counts()` | Value frequencies |
+| `unique()` | Unique values |
+| `nunique()` | Count unique |
+| `mode()` | Mode value |
+| `to_list()` | Convert to list |
+| `to_numpy()` | Convert to array |
+| `to_frame()` | Convert to DataStore |
+
+---
+
+## Related Classes
+### F (Functions)
+Namespace for ClickHouse functions.
+
+```python
+from chdb.datastore import F, Field
+
+# Aggregations
+F.sum(Field('amount'))
+F.avg(Field('price'))
+F.count(Field('id'))
+F.quantile(Field('value'), 0.95)
+
+# Conditional
+F.sum_if(Field('amount'), Field('status') == 'completed')
+F.count_if(Field('active'))
+
+# Window
+F.row_number().over(order_by='date')
+F.lag('price', 1).over(partition_by='product', order_by='date')
+```
+
+See [Aggregation](aggregation.md#f-namespace) for details.
+
+### Field
+Reference to a column by name.
+
+```python
+from chdb.datastore import Field
+
+# Create field reference
+amount = Field('amount')
+price = Field('price')
+
+# Use in expressions
+F.sum(Field('amount'))
+F.avg(Field('price'))
+```
+
+### CaseWhen
+Builder for CASE WHEN expressions.
+
+```python
+# Create case-when expression
+result = (ds
+    .when(ds['score'] >= 90, 'A')
+    .when(ds['score'] >= 80, 'B')
+    .when(ds['score'] >= 70, 'C')
+    .otherwise('F')
+)
+
+# Assign to column
+ds['grade'] = result
+```
+
+### Window
+Window specification for window functions.
+
+```python
+from chdb.datastore import F
+
+# Create window
+window = F.window(
+    partition_by='category',
+    order_by='date',
+    rows_between=(-7, 0)
+)
+
+# Use with aggregation
+ds['rolling_avg'] = F.avg('price').over(window)
+```
+
+---
+
+# DataStore execution model
+
+**URL:** https://clickhouse.com/docs/chdb/datastore/execution-model
+
+Understanding lazy evaluation, execution triggers, and caching in DataStore
+
+Understanding DataStore's lazy evaluation model is key to using it effectively and achieving optimal performance.
+
+## Lazy Evaluation
+DataStore uses **lazy evaluation** - operations are not executed immediately but are recorded and compiled into optimized SQL queries. Execution happens only when results are actually needed.
+
+### Example: Lazy vs Eager
+```python
+from pathlib import Path
+Path("sales.csv").write_text("""\
+region,product,category,amount,quantity,price,date,order_id
+East,Widget,Electronics,5200,10,120,2024-01-15,1001
+West,Gadget,Electronics,800,5,160,2024-02-20,1002
+East,Gizmo,Home,6500,3,100,2024-03-10,1003
+North,Widget,Electronics,4500,6,150,2024-06-18,1004
+West,Gadget,Electronics,2000,8,250,2024-09-14,1005
+""")
+
+from chdb import datastore as pd
+
+ds = pd.read_csv("sales.csv")
+
+# These operations are NOT executed yet
+result = (ds
+    .filter(ds['amount'] > 1000)    # Recorded, not executed
+    .select('region', 'amount')      # Recorded, not executed
+    .groupby('region')               # Recorded, not executed
+    .agg({'amount': 'sum'})          # Recorded, not executed
+    .sort('sum', ascending=False)    # Recorded, not executed
+)
+
+# Still no execution - just building the query plan
+print(result.to_sql())
+# SELECT region, SUM(amount) AS sum
+# FROM file('sales.csv', 'CSVWithNames')
+# WHERE amount > 1000
+# GROUP BY region
+# ORDER BY sum DESC
+
+# NOW execution happens
+df = result.to_df()  # <-- Triggers execution
+```
+
+### Benefits of Lazy Evaluation
+1. **Query Optimization**: Multiple operations compile to a single optimized SQL query
+2. **Filter Pushdown**: Filters are applied at the data source level
+3. **Column Pruning**: Only needed columns are read
+4. **Deferred Decisions**: Execution engine can be chosen at runtime
+5. **Plan Inspection**: You can view/debug the query before executing
+
+---
+
+## Execution Triggers
+Execution is triggered automatically when you need actual values:
+
+### Automatic Triggers
+| Trigger | Example | Description |
+|---------|---------|-------------|
+| `print()` / `repr()` | `print(ds)` | Display results |
+| `len()` | `len(ds)` | Get row count |
+| `.columns` | `ds.columns` | Get column names |
+| `.dtypes` | `ds.dtypes` | Get column types |
+| `.shape` | `ds.shape` | Get dimensions |
+| `.index` | `ds.index` | Get row index |
+| `.values` | `ds.values` | Get NumPy array |
+| Iteration | `for row in ds` | Iterate over rows |
+| `to_df()` | `ds.to_df()` | Convert to pandas |
+| `to_pandas()` | `ds.to_pandas()` | Alias for to_df |
+| `to_dict()` | `ds.to_dict()` | Convert to dict |
+| `to_numpy()` | `ds.to_numpy()` | Convert to array |
+| `.equals()` | `ds.equals(other)` | Compare DataStores |
+
+**Examples:**
+
+```python
+# All these trigger execution
+print(ds)              # Display
+len(ds)                # 1000
+ds.columns             # Index(['name', 'age', 'city'])
+ds.shape               # (1000, 3)
+list(ds)               # List of values
+ds.to_df()             # pandas DataFrame
+```
+
+### Operations That Stay Lazy
+| Operation | Returns | Description |
+|-----------|---------|-------------|
+| `filter()` | DataStore | Adds WHERE clause |
+| `select()` | DataStore | Adds column selection |
+| `sort()` | DataStore | Adds ORDER BY |
+| `groupby()` | LazyGroupBy | Prepares GROUP BY |
+| `join()` | DataStore | Adds JOIN |
+| `ds['col']` | ColumnExpr | Column reference |
+| `ds[['col1', 'col2']]` | DataStore | Column selection |
+
+**Examples:**
+
+```python
+# These do NOT trigger execution - they stay lazy
+result = ds.filter(ds['age'] > 25)      # Returns DataStore
+result = ds.select('name', 'age')        # Returns DataStore
+result = ds['name']                      # Returns ColumnExpr
+result = ds.groupby('city')              # Returns LazyGroupBy
+```
+
+---
+
+## Three-Phase Execution
+DataStore operations follow a three-phase execution model:
+
+### Phase 1: SQL Query Building (Lazy)
+Operations that can be expressed in SQL are accumulated:
+
+```python
+result = (ds
+    .filter(ds['status'] == 'active')   # WHERE
+    .select('user_id', 'amount')         # SELECT
+    .groupby('user_id')                  # GROUP BY
+    .agg({'amount': 'sum'})              # SUM()
+    .sort('sum', ascending=False)        # ORDER BY
+    .limit(10)                           # LIMIT
+)
+# All compiled into one SQL query
+```
+
+### Phase 2: Execution Point
+When a trigger occurs, the accumulated SQL is executed:
+
+```python
+# Execution triggered here
+df = result.to_df()  
+# The single optimized SQL query runs now
+```
+
+### Phase 3: DataFrame Operations (if any)
+If you chain pandas-only operations after execution:
+
+```python
+# Mixed operations
+result = (ds
+    .filter(ds['amount'] > 100)          # Phase 1: SQL
+    .to_df()                             # Phase 2: Execute
+    .pivot_table(...)                    # Phase 3: pandas
+)
+```
+
+---
+
+## Viewing Execution Plans
+Use `explain()` to see what will be executed:
+
+```python title="Query"
+ds = pd.read_csv("sales.csv")
+
+query = (ds
+    .filter(ds['amount'] > 1000)
+    .groupby('region')
+    .agg({'amount': ['sum', 'mean']})
+)
+
+# View execution plan
+query.explain()
+```
+
+```text title="Response"
+Pipeline:
+  1. Source: file('sales.csv', 'CSVWithNames')
+  2. Filter: amount > 1000
+  3. GroupBy: region
+  4. Aggregate: sum(amount), avg(amount)
+
+Generated SQL:
+SELECT region, SUM(amount) AS sum, AVG(amount) AS mean
+FROM file('sales.csv', 'CSVWithNames')
+WHERE amount > 1000
+GROUP BY region
+```
+
+Use `verbose=True` for more details:
+
+```python
+query.explain(verbose=True)
+```
+
+See [Debugging: explain()](../debugging/explain.md) for complete documentation.
+
+---
+
+## Caching
+DataStore caches execution results to avoid redundant queries.
+
+### How Caching Works
+```python
+from pathlib import Path
+Path("data.csv").write_text("""\
+name,age,city,salary,department
+Alice,25,NYC,55000,Engineering
+Bob,30,LA,65000,Product
+Charlie,35,NYC,80000,Engineering
+Diana,28,SF,70000,Design
+Eve,42,NYC,95000,Product
+""")
+
+ds = pd.read_csv("data.csv")
+result = ds.filter(ds['age'] > 25)
+
+# First access - executes query
+print(result.shape)  # Executes and caches
+
+# Second access - uses cache
+print(result.columns)  # Uses cached result
+
+# Third access - uses cache
+df = result.to_df()  # Uses cached result
+```
+
+### Cache Invalidation
+Cache is invalidated when operations modify the DataStore:
+
+```python
+result = ds.filter(ds['age'] > 25)
+print(result.shape)  # Executes, caches
+
+# New operation invalidates cache
+result2 = result.filter(result['city'] == 'NYC')
+print(result2.shape)  # Re-executes (different query)
+```
+
+### Manual Cache Control
+```python
+# Clear cache
+ds.clear_cache()
+
+# Disable caching
+from chdb.datastore.config import config
+config.set_cache_enabled(False)
+```
+
+---
+
+## Mixing SQL and Pandas Operations
+DataStore intelligently handles operations that mix SQL and pandas:
+
+### SQL-Compatible Operations
+These compile to SQL:
+- `filter()`, `where()`
+- `select()`
+- `groupby()`, `agg()`
+- `sort()`, `orderby()`
+- `limit()`, `offset()`
+- `join()`, `union()`
+- `distinct()`
+- Column operations (math, comparison, string methods)
+
+### Pandas-Only Operations
+These trigger execution and use pandas:
+- `apply()` with custom functions
+- `pivot_table()` with complex aggregations
+- `stack()`, `unstack()`
+- Operations on executed DataFrames
+
+### Hybrid Pipelines
+```python
+# SQL phase
+result = (ds
+    .filter(ds['amount'] > 100)      # SQL
+    .groupby('category')              # SQL
+    .agg({'amount': 'sum'})           # SQL
+)
+
+# Execution + pandas phase
+result = (result
+    .to_df()                          # Execute SQL
+    .pivot_table(...)                 # pandas operation
+)
+```
+
+---
+
+## Execution Engine Selection
+DataStore can execute operations using different engines:
+
+### Auto Mode (Default)
+```python
+from chdb.datastore.config import config
+
+config.set_execution_engine('auto')  # Default
+# Automatically selects best engine per operation
+```
+
+### Force chDB Engine
+```python
+config.set_execution_engine('chdb')
+# All operations use ClickHouse SQL
+```
+
+### Force pandas Engine
+```python
+config.set_execution_engine('pandas')
+# All operations use pandas
+```
+
+See [Configuration: Execution Engine](../configuration/execution-engine.md) for details.
+
+---
+
+## Performance Implications
+### Good: Filter Early
+```python
+# Good: Filter in SQL, then aggregate
+result = (ds
+    .filter(ds['date'] >= '2024-01-01')  # Reduces data early
+    .groupby('category')
+    .agg({'amount': 'sum'})
+)
+```
+
+### Bad: Filter Late
+```python
+# Bad: Aggregate all, then filter
+result = (ds
+    .groupby('category')
+    .agg({'amount': 'sum'})
+    .to_df()
+    .query('sum > 1000')  # Pandas filter after aggregation
+)
+```
+
+### Good: Select Columns Early
+```python
+# Good: Select columns in SQL
+result = (ds
+    .select('user_id', 'amount', 'date')
+    .filter(ds['date'] >= '2024-01-01')
+    .groupby('user_id')
+    .agg({'amount': 'sum'})
+)
+```
+
+### Good: Let SQL Do the Work
+```python
+# Good: Complex aggregation in SQL
+result = (ds
+    .groupby('category')
+    .agg({
+        'amount': ['sum', 'mean', 'count'],
+        'quantity': 'sum'
+    })
+    .sort('sum', ascending=False)
+    .limit(10)
+)
+# One SQL query does everything
+
+# Bad: Multiple separate queries
+sums = ds.groupby('category')['amount'].sum().to_df()
+means = ds.groupby('category')['amount'].mean().to_df()
+# Two queries instead of one
+```
+
+---
+
+## Best Practices Summary
+1. **Chain operations before executing** - Build the full query, then trigger once
+2. **Filter early** - Reduce data at the source
+3. **Select only needed columns** - Column pruning improves performance
+4. **Use `explain()` to understand execution** - Debug before running
+5. **Let SQL handle aggregations** - ClickHouse is optimized for this
+6. **Be aware of execution triggers** - Avoid accidental early execution
+7. **Use caching wisely** - Understand when cache is invalidated
+
+---
+
+# DataStore factory methods
+
+**URL:** https://clickhouse.com/docs/chdb/datastore/factory-methods
+
+Create DataStore instances from files, databases, cloud storage, and data lakes
+
+DataStore provides over 20 factory methods to create instances from various data sources including local files, databases, cloud storage, and data lakes.
+
+## Universal URI Interface
+The `uri()` method is the recommended universal entry point that auto-detects the source type:
+
+```python
+from chdb.datastore import DataStore
+
+# Local files
+ds = DataStore.uri("data.csv")
+ds = DataStore.uri("/path/to/data.parquet")
+
+# Cloud storage
+ds = DataStore.uri("s3://bucket/data.parquet?nosign=true")
+ds = DataStore.uri("https://example.com/data.csv")
+
+# Databases
+ds = DataStore.uri("mysql://user:pass@host:3306/db/table")
+ds = DataStore.uri("postgresql://user:pass@host:5432/db/table")
+```
+
+### URI Syntax Reference
+| Source Type | URI Format | Example |
+|-------------|------------|---------|
+| Local file | `path/to/file` | `data.csv`, `/abs/path/data.parquet` |
+| S3 | `s3://bucket/path` | `s3://mybucket/data.parquet?nosign=true` |
+| GCS | `gs://bucket/path` | `gs://mybucket/data.csv` |
+| Azure | `az://container/path` | `az://mycontainer/data.parquet` |
+| HTTP/HTTPS | `https://url` | `https://example.com/data.csv` |
+| MySQL | `mysql://user:pass@host:port/db/table` | `mysql://root:pass@localhost:3306/mydb/users` |
+| PostgreSQL | `postgresql://user:pass@host:port/db/table` | `postgresql://postgres:pass@localhost:5432/mydb/users` |
+| SQLite | `sqlite:///path?table=name` | `sqlite:///data.db?table=users` |
+| ClickHouse | `clickhouse://host:port/db/table` | `clickhouse://localhost:9000/default/hits` |
+
+---
+
+## File Sources
+### `from_file`
+Create DataStore from a local or remote file with automatic format detection.
+
+```python
+DataStore.from_file(path, format=None, compression=None, **kwargs)
+```
+
+**Parameters:**
+
+| Parameter | Type | Default | Description |
+|-----------|------|---------|-------------|
+| `path` | str | *required* | File path (local or URL) |
+| `format` | str | `None` | File format (auto-detected if None) |
+| `compression` | str | `None` | Compression type (auto-detected if None) |
+
+**Supported formats:** CSV, TSV, Parquet, JSON, JSONLines, ORC, Avro, Arrow
+
+**Examples:**
+
+```python
+from chdb.datastore import DataStore
+
+# Auto-detect format from extension
+ds = DataStore.from_file("data.csv")
+ds = DataStore.from_file("data.parquet")
+ds = DataStore.from_file("data.json")
+
+# Explicit format
+ds = DataStore.from_file("data.txt", format="CSV")
+
+# With compression
+ds = DataStore.from_file("data.csv.gz", compression="gzip")
+```
+
+### Pandas-compatible read functions
+```python
+from chdb import datastore as pd
+
+# CSV files
+ds = pd.read_csv("data.csv")
+ds = pd.read_csv("data.csv", sep=";", header=0, nrows=1000)
+
+# Parquet files (recommended for large datasets)
+ds = pd.read_parquet("data.parquet")
+ds = pd.read_parquet("data.parquet", columns=['col1', 'col2'])
+
+# JSON files
+ds = pd.read_json("data.json")
+ds = pd.read_json("data.jsonl", lines=True)
+
+# Excel files
+ds = pd.read_excel("data.xlsx", sheet_name="Sheet1")
+```
+
+---
+
+## Cloud Storage
+### `from_s3`
+Create DataStore from Amazon S3.
+
+```python
+DataStore.from_s3(url, access_key_id=None, secret_access_key=None, format=None, **kwargs)
+```
+
+**Parameters:**
+
+| Parameter | Type | Default | Description |
+|-----------|------|---------|-------------|
+| `url` | str | *required* | S3 URL (s3://bucket/path) |
+| `access_key_id` | str | `None` | AWS access key ID |
+| `secret_access_key` | str | `None` | AWS secret access key |
+| `format` | str | `None` | File format (auto-detected) |
+
+**Examples:**
+
+```python
+from chdb.datastore import DataStore
+
+# Anonymous access (public bucket)
+ds = DataStore.from_s3("s3://bucket/data.parquet")
+
+# With credentials
+ds = DataStore.from_s3(
+    "s3://bucket/data.parquet",
+    access_key_id="AKIAIOSFODNN7EXAMPLE",
+    secret_access_key="wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY"
+)
+
+# Using URI with query parameters
+ds = DataStore.uri("s3://bucket/data.parquet?nosign=true")
+ds = DataStore.uri("s3://bucket/data.parquet?access_key_id=KEY&secret_access_key=SECRET")
+```
+
+### `from_gcs`
+Create DataStore from Google Cloud Storage.
+
+```python
+DataStore.from_gcs(url, credentials_path=None, **kwargs)
+```
+
+**Examples:**
+
+```python
+ds = DataStore.from_gcs("gs://bucket/data.parquet")
+ds = DataStore.from_gcs("gs://bucket/data.parquet", credentials_path="/path/to/creds.json")
+```
+
+### `from_azure`
+Create DataStore from Azure Blob Storage.
+
+```python
+DataStore.from_azure(url, account_name=None, account_key=None, **kwargs)
+```
+
+**Examples:**
+
+```python
+ds = DataStore.from_azure(
+    "az://container/data.parquet",
+    account_name="myaccount",
+    account_key="mykey"
+)
+```
+
+### `from_hdfs`
+Create DataStore from HDFS.
+
+```python
+DataStore.from_hdfs(url, **kwargs)
+```
+
+**Examples:**
+
+```python
+ds = DataStore.from_hdfs("hdfs://namenode:8020/path/data.parquet")
+```
+
+### `from_url`
+Create DataStore from HTTP/HTTPS URL.
+
+```python
+DataStore.from_url(url, format=None, **kwargs)
+```
+
+**Examples:**
+
+```python
+ds = DataStore.from_url("https://example.com/data.csv")
+ds = DataStore.from_url("https://raw.githubusercontent.com/user/repo/main/data.parquet")
+```
+
+---
+
+## Databases
+### `from_mysql`
+Create DataStore from MySQL database.
+
+```python
+DataStore.from_mysql(host, database, table, user, password, port=3306, **kwargs)
+```
+
+**Parameters:**
+
+| Parameter | Type | Default | Description |
+|-----------|------|---------|-------------|
+| `host` | str | *required* | MySQL host |
+| `database` | str | *required* | Database name |
+| `table` | str | *required* | Table name |
+| `user` | str | *required* | Username |
+| `password` | str | *required* | Password |
+| `port` | int | `3306` | Port number |
+
+**Examples:**
+
+```python
+ds = DataStore.from_mysql(
+    host="localhost",
+    database="mydb",
+    table="users",
+    user="root",
+    password="password"
+)
+
+# Using URI
+ds = DataStore.uri("mysql://root:password@localhost:3306/mydb/users")
+```
+
+### `from_postgresql`
+Create DataStore from PostgreSQL database.
+
+```python
+DataStore.from_postgresql(host, database, table, user, password, port=5432, **kwargs)
+```
+
+**Examples:**
+
+```python
+ds = DataStore.from_postgresql(
+    host="localhost",
+    database="mydb",
+    table="users",
+    user="postgres",
+    password="password"
+)
+
+# Using URI
+ds = DataStore.uri("postgresql://postgres:password@localhost:5432/mydb/users")
+```
+
+### `from_clickhouse`
+Create DataStore from ClickHouse server.
+
+```python
+DataStore.from_clickhouse(host, database, table, user=None, password=None, port=9000, **kwargs)
+```
+
+**Examples:**
+
+```python
+ds = DataStore.from_clickhouse(
+    host="localhost",
+    database="default",
+    table="hits",
+    user="default",
+    password=""
+)
+
+# Connection-level mode (explore databases)
+ds = DataStore.from_clickhouse(
+    host="analytics.company.com",
+    user="analyst",
+    password="secret"
+)
+ds.databases()                  # List databases
+ds.tables("production")         # List tables
+result = ds.sql("SELECT * FROM production.users LIMIT 10")
+```
+
+### `from_mongodb`
+Create DataStore from MongoDB.
+
+```python
+DataStore.from_mongodb(uri, database, collection, **kwargs)
+```
+
+**Examples:**
+
+```python
+ds = DataStore.from_mongodb(
+    uri="mongodb://localhost:27017",
+    database="mydb",
+    collection="users"
+)
+```
+
+### `from_sqlite`
+Create DataStore from SQLite database.
+
+```python
+DataStore.from_sqlite(database_path, table, **kwargs)
+```
+
+**Examples:**
+
+```python
+ds = DataStore.from_sqlite("data.db", table="users")
+
+# Using URI
+ds = DataStore.uri("sqlite:///data.db?table=users")
+```
+
+---
+
+## Data Lakes
+### `from_iceberg`
+Create DataStore from Apache Iceberg table.
+
+```python
+DataStore.from_iceberg(path, **kwargs)
+```
+
+**Examples:**
+
+```python
+ds = DataStore.from_iceberg("/path/to/iceberg_table")
+ds = DataStore.uri("iceberg://catalog/namespace/table")
+```
+
+### `from_delta`
+Create DataStore from Delta Lake table.
+
+```python
+DataStore.from_delta(path, **kwargs)
+```
+
+**Examples:**
+
+```python
+ds = DataStore.from_delta("/path/to/delta_table")
+ds = DataStore.uri("deltalake:///path/to/delta_table")
+```
+
+### `from_hudi`
+Create DataStore from Apache Hudi table.
+
+```python
+DataStore.from_hudi(path, **kwargs)
+```
+
+**Examples:**
+
+```python
+ds = DataStore.from_hudi("/path/to/hudi_table")
+ds = DataStore.uri("hudi:///path/to/hudi_table")
+```
+
+---
+
+## In-Memory Sources
+### `from_df` / `from_dataframe`
+Create DataStore from pandas DataFrame.
+
+```python
+DataStore.from_df(df, name=None)
+DataStore.from_dataframe(df, name=None)  # alias
+```
+
+**Examples:**
+
+```python
+
+from chdb.datastore import DataStore
+
+pdf = pandas.DataFrame({'a': [1, 2, 3], 'b': ['x', 'y', 'z']})
+ds = DataStore.from_df(pdf)
+```
+
+### `DataFrame` Constructor
+Create DataStore using pandas-like constructor.
+
+```python
+from chdb import datastore as pd
+
+# From dictionary
+ds = pd.DataFrame({
+    'name': ['Alice', 'Bob'],
+    'age': [25, 30]
+})
+
+# From pandas DataFrame
+
+pdf = pandas.DataFrame({'a': [1, 2, 3]})
+ds = pd.DataFrame(pdf)
+```
+
+---
+
+## Special Sources
+### `from_numbers`
+Create DataStore with sequential numbers (useful for testing).
+
+```python
+DataStore.from_numbers(count, **kwargs)
+```
+
+**Examples:**
+
+```python
+ds = DataStore.from_numbers(1000000)  # 1M rows with 'number' column
+result = ds.filter(ds['number'] % 2 == 0).head(10)  # Even numbers
+```
+
+### `from_random`
+Create DataStore with random data.
+
+```python
+DataStore.from_random(rows, columns, **kwargs)
+```
+
+**Examples:**
+
+```python
+ds = DataStore.from_random(rows=1000, columns=5)
+```
+
+### `run_sql`
+Create DataStore from raw SQL query.
+
+```python
+DataStore.run_sql(query)
+```
+
+**Examples:**
+
+```python
+ds = DataStore.run_sql("""
+    SELECT number, number * 2 as doubled
+    FROM numbers(100)
+    WHERE number % 10 = 0
+""")
+```
+
+---
+
+## Summary Table
+| Method | Source Type | Example |
+|--------|-------------|---------|
+| `uri()` | Universal | `DataStore.uri("s3://bucket/data.parquet")` |
+| `from_file()` | Local/Remote files | `DataStore.from_file("data.csv")` |
+| `read_csv()` | CSV files | `pd.read_csv("data.csv")` |
+| `read_parquet()` | Parquet files | `pd.read_parquet("data.parquet")` |
+| `from_s3()` | Amazon S3 | `DataStore.from_s3("s3://bucket/path")` |
+| `from_gcs()` | Google Cloud Storage | `DataStore.from_gcs("gs://bucket/path")` |
+| `from_azure()` | Azure Blob | `DataStore.from_azure("az://container/path")` |
+| `from_hdfs()` | HDFS | `DataStore.from_hdfs("hdfs://host/path")` |
+| `from_url()` | HTTP/HTTPS | `DataStore.from_url("https://example.com/data.csv")` |
+| `from_mysql()` | MySQL | `DataStore.from_mysql(host, db, table, user, pass)` |
+| `from_postgresql()` | PostgreSQL | `DataStore.from_postgresql(host, db, table, user, pass)` |
+| `from_clickhouse()` | ClickHouse | `DataStore.from_clickhouse(host, db, table)` |
+| `from_mongodb()` | MongoDB | `DataStore.from_mongodb(uri, db, collection)` |
+| `from_sqlite()` | SQLite | `DataStore.from_sqlite("data.db", table)` |
+| `from_iceberg()` | Apache Iceberg | `DataStore.from_iceberg("/path/to/table")` |
+| `from_delta()` | Delta Lake | `DataStore.from_delta("/path/to/table")` |
+| `from_hudi()` | Apache Hudi | `DataStore.from_hudi("/path/to/table")` |
+| `from_df()` | pandas DataFrame | `DataStore.from_df(pandas_df)` |
+| `DataFrame()` | Dictionary/DataFrame | `pd.DataFrame({'a': [1, 2, 3]})` |
+| `from_numbers()` | Sequential numbers | `DataStore.from_numbers(1000000)` |
+| `from_random()` | Random data | `DataStore.from_random(rows=1000, columns=5)` |
+| `run_sql()` | Raw SQL | `DataStore.run_sql("SELECT * FROM ...")` |
+
+---
+
+# DataStore: Pandas-compatible API with SQL optimization
+
+**URL:** https://clickhouse.com/docs/chdb/datastore
+
+DataStore provides a pandas-compatible API with SQL optimization for high-performance data analysis
+
+DataStore is chDB's pandas-compatible API that combines the familiar pandas DataFrame interface with the power of SQL query optimization and allows you to write pandas-style code while getting ClickHouse performance.
+
+## Key features
+- **Pandas Compatibility**: 209 pandas DataFrame methods, 56 `.str` methods, 42+ `.dt` methods
+- **SQL Optimization**: Operations automatically compile to optimized SQL queries
+- **Lazy Evaluation**: Operations are deferred until results are needed
+- **630+ API Methods**: Comprehensive API surface for data manipulation
+- **ClickHouse Extensions**: Additional accessors (`.arr`, `.json`, `.url`, `.ip`, `.geo`) not available in pandas
+
+## Architecture
+<Image size="md" img={data_store} alt="DataStore Architecture" />
+
+DataStore uses **lazy evaluation** with **dual-engine execution**:
+
+1. **Lazy Operation Chain**: Operations are recorded, not executed immediately
+2. **Smart Engine Selection**: QueryPlanner routes each segment to optimal engine (chDB for SQL, Pandas for complex ops)
+3. **Intermediate Caching**: Results cached at each step for fast iterative exploration
+
+See [Execution Model](execution-model.md) for details.
+
+## One-Line migration from Pandas
+```python
+# Before (pandas)
+
+df = pd.read_csv("data.csv")
+result = df[df['age'] > 25].groupby('city')['salary'].mean()
+
+# After (DataStore) - just change the import!
+from chdb import datastore as pd
+df = pd.read_csv("data.csv")
+result = df[df['age'] > 25].groupby('city')['salary'].mean()
+```
+
+Your existing pandas code works unchanged, but now runs on the ClickHouse engine.
+
+## Performance comparison
+DataStore delivers significant performance improvements over pandas, especially for aggregation and complex pipelines:
+
+| Operation | Pandas | DataStore | Speedup |
+|-----------|--------|-----------|---------|
+| GroupBy count | 347ms | 17ms | **19.93x** |
+| Complex pipeline | 2,047ms | 380ms | **5.39x** |
+| Filter+Sort+Head | 1,537ms | 350ms | **4.40x** |
+| GroupBy agg | 406ms | 141ms | **2.88x** |
+
+*Benchmark on 10M rows. See [benchmark script](https://github.com/chdb-io/chdb/blob/main/refs/benchmark_datastore_vs_pandas.py) and [Performance Guide](../guides/pandas-performance.md) for details.*
+
+## When to use DataStore
+**Use DataStore when:**
+- Working with large datasets (millions of rows)
+- Performing aggregations and groupby operations
+- Querying data from files, databases, or cloud storage
+- Building complex data pipelines
+- You want pandas API with better performance
+
+**Use raw SQL API when:**
+- You prefer writing SQL directly
+- You need fine-grained control over query execution
+- Working with ClickHouse-specific features not exposed in pandas API
+
+## Feature comparison
+| Feature | Pandas | Polars  | DuckDB | DataStore |
+|---------|--------|---------|--------|-----------|
+| Pandas API compatible | -      | Partial | No | **Full** |
+| Lazy evaluation | No     | Yes     | Yes | **Yes** |
+| SQL query support | No     | Yes     | Yes | **Yes** |
+| ClickHouse functions | No     | No      | No | **Yes** |
+| String/DateTime accessors | Yes    | Yes     | No | **Yes + extras** |
+| Array/JSON/URL/IP/Geo | No     | Partial | No | **Yes** |
+| Direct file queries | No     | Yes     | Yes | **Yes** |
+| Cloud storage support | No     | Limited | Yes | **Yes** |
+
+## API statistics
+| Category | Count | Coverage |
+|----------|-------|----------|
+| DataFrame methods | 209 | 100% of pandas |
+| Series.str accessor | 56 | 100% of pandas |
+| Series.dt accessor | 42+ | 100%+ (includes ClickHouse extras) |
+| Series.arr accessor | 37 | ClickHouse-specific |
+| Series.json accessor | 13 | ClickHouse-specific |
+| Series.url accessor | 15 | ClickHouse-specific |
+| Series.ip accessor | 9 | ClickHouse-specific |
+| Series.geo accessor | 14 | ClickHouse-specific |
+| **Total API methods** | **630+** | - |
+
+## Documentation navigation
+### Getting Started
+- [Quickstart](quickstart.md) - Installation and basic usage
+- [Migration from Pandas](../guides/migration-from-pandas.md) - Step-by-step migration guide
+
+### API reference
+- [Factory Methods](factory-methods.md) - Creating DataStore from various sources
+- [Query Building](query-building.md) - SQL-style query operations
+- [Pandas Compatibility](pandas-compat.md) - All 209 pandas-compatible methods
+- [Accessors](accessors.md) - String, DateTime, Array, JSON, URL, IP, Geo accessors
+- [Aggregation](aggregation.md) - Aggregate and window functions
+- [I/O Operations](io.md) - Reading and writing data
+
+### Advanced topics
+- [Execution Model](execution-model.md) - Lazy evaluation and caching
+- [Class Reference](class-reference.md) - Complete API reference
+
+### Configuration & debugging
+- [Configuration](../configuration/index.md) - All configuration options
+- [Performance Mode](../configuration/performance-mode.md) - SQL-first mode for maximum throughput
+- [Debugging](../debugging/index.md) - Explain, profiling, and logging
+
+### Pandas user guides
+- [Pandas Cookbook](../guides/pandas-cookbook.md) - Common patterns
+- [Key Differences](../guides/pandas-differences.md) - Important differences from pandas
+- [Performance Guide](../guides/pandas-performance.md) - Optimization tips
+- [SQL for Pandas Users](../guides/pandas-to-sql.md) - Understanding the SQL behind pandas operations
+
+## Quick example
+```python
+from chdb import datastore as pd
+
+# Read data from various sources
+ds = pd.read_csv("sales.csv")
+# or: ds = pd.DataStore.uri("s3://bucket/sales.parquet")
+# or: ds = pd.DataStore.from_mysql("mysql://user:pass@host/db/table")
+
+# Familiar pandas operations - automatically optimized to SQL
+result = (ds
+    .filter(ds['amount'] > 1000)           # WHERE amount > 1000
+    .groupby('region')                      # GROUP BY region
+    .agg({'amount': ['sum', 'mean']})       # SUM(amount), AVG(amount)
+    .sort_values('sum', ascending=False)    # ORDER BY sum DESC
+    .head(10)                               # LIMIT 10
+)
+
+# View the generated SQL
+print(result.to_sql())
+
+# Execute and get results
+df = result.to_df()  # Returns pandas DataFrame
+```
+
+## Next steps
+- **New to DataStore?** Start with the [Quickstart Guide](quickstart.md)
+- **Coming from pandas?** Read the [Migration Guide](../guides/migration-from-pandas.md)
+- **Want to learn more?** Explore the [API Reference](class-reference.md)
+
+---
+
+# Datastore I/O operations
+
+**URL:** https://clickhouse.com/docs/chdb/datastore/io
+
+Reading and writing data with DataStore - all supported formats and destinations
+
+DataStore supports reading from and writing to various file formats and data sources.
+
+## Reading Data
+### CSV Files
+```python
+read_csv(filepath_or_buffer, sep=',', header='infer', names=None, 
+         usecols=None, dtype=None, nrows=None, skiprows=None,
+         compression=None, encoding=None, **kwargs)
+```
+
+**Examples:**
+
+```python
+from chdb import datastore as pd
+
+# Basic CSV read
+ds = pd.read_csv("data.csv")
+
+# With options
+ds = pd.read_csv(
+    "data.csv",
+    sep=";",                    # Custom delimiter
+    header=0,                   # Header row index
+    names=['a', 'b', 'c'],      # Custom column names
+    usecols=['a', 'b'],         # Only read specific columns
+    dtype={'a': 'Int64'},       # Specify dtypes
+    nrows=1000,                 # Read only first 1000 rows
+    skiprows=1,                 # Skip first row
+    compression='gzip',         # Compressed file
+    encoding='utf-8'            # Encoding
+)
+
+# From URL
+ds = pd.read_csv("https://example.com/data.csv")
+```
+
+### Parquet Files
+Recommended for large datasets - columnar format with better compression.
+
+```python
+read_parquet(path, columns=None, **kwargs)
+```
+
+**Examples:**
+
+```python
+# Basic Parquet read
+ds = pd.read_parquet("data.parquet")
+
+# Read specific columns only (efficient - only reads needed data)
+ds = pd.read_parquet("data.parquet", columns=['col1', 'col2', 'col3'])
+
+# From S3
+ds = pd.read_parquet("s3://bucket/data.parquet")
+```
+
+### JSON Files
+```python
+read_json(path_or_buf, orient=None, lines=False, **kwargs)
+```
+
+**Examples:**
+
+```python
+# Standard JSON
+ds = pd.read_json("data.json")
+
+# JSON Lines (newline-delimited)
+ds = pd.read_json("data.jsonl", lines=True)
+
+# JSON with specific orientation
+ds = pd.read_json("data.json", orient='records')
+```
+
+### Excel Files
+```python
+read_excel(io, sheet_name=0, header=0, names=None, **kwargs)
+```
+
+**Examples:**
+
+```python
+# Read first sheet
+ds = pd.read_excel("data.xlsx")
+
+# Read specific sheet
+ds = pd.read_excel("data.xlsx", sheet_name="Sheet1")
+ds = pd.read_excel("data.xlsx", sheet_name=2)  # Third sheet
+
+# Read multiple sheets (returns dict)
+sheets = pd.read_excel("data.xlsx", sheet_name=['Sheet1', 'Sheet2'])
+```
+
+### SQL Databases
+```python
+read_sql(sql, con, **kwargs)
+```
+
+**Examples:**
+
+```python
+# Read from SQL query
+ds = pd.read_sql("SELECT * FROM users", connection)
+ds = pd.read_sql("SELECT * FROM orders WHERE date > '2024-01-01'", connection)
+```
+
+### Other Formats
+```python
+# Feather (Arrow)
+ds = pd.read_feather("data.feather")
+
+# ORC
+ds = pd.read_orc("data.orc")
+
+# Pickle
+ds = pd.read_pickle("data.pkl")
+
+# Fixed-width formatted
+ds = pd.read_fwf("data.txt", widths=[10, 20, 15])
+
+# HTML tables
+ds = pd.read_html("https://example.com/table.html")[0]
+```
+
+---
+
+## Writing Data
+### to_csv
+Export to CSV format.
+
+```python
+to_csv(path_or_buf=None, sep=',', na_rep='', header=True, 
+       index=True, mode='w', compression=None, **kwargs)
+```
+
+**Examples:**
+
+```python
+ds = pd.read_parquet("data.parquet")
+
+# Basic export
+ds.to_csv("output.csv")
+
+# With options
+ds.to_csv(
+    "output.csv",
+    sep=";",                    # Custom delimiter
+    index=False,                # Don't include index
+    header=True,                # Include header
+    na_rep='NULL',              # Represent NaN as 'NULL'
+    compression='gzip'          # Compress output
+)
+
+# To string
+csv_string = ds.to_csv()
+```
+
+### to_parquet
+Export to Parquet format (recommended for large data).
+
+```python
+to_parquet(path, engine='pyarrow', compression='snappy', **kwargs)
+```
+
+**Examples:**
+
+```python
+# Basic export
+ds.to_parquet("output.parquet")
+
+# With compression options
+ds.to_parquet("output.parquet", compression='gzip')
+ds.to_parquet("output.parquet", compression='zstd')
+
+# Partitioned output
+ds.to_parquet(
+    "output/",
+    partition_cols=['year', 'month']
+)
+```
+
+### to_json
+Export to JSON format.
+
+```python
+to_json(path_or_buf=None, orient='records', lines=False, **kwargs)
+```
+
+**Examples:**
+
+```python
+# Standard JSON (array of records)
+ds.to_json("output.json", orient='records')
+
+# JSON Lines (one JSON object per line)
+ds.to_json("output.jsonl", lines=True)
+
+# Different orientations
+ds.to_json("output.json", orient='split')    # {columns, data, index}
+ds.to_json("output.json", orient='records')  # [{col: val}, ...]
+ds.to_json("output.json", orient='columns')  # {col: {idx: val}}
+
+# To string
+json_string = ds.to_json()
+```
+
+### to_excel
+Export to Excel format.
+
+```python
+to_excel(excel_writer, sheet_name='Sheet1', index=True, **kwargs)
+```
+
+**Examples:**
+
+```python
+# Single sheet
+ds.to_excel("output.xlsx")
+ds.to_excel("output.xlsx", sheet_name="Data", index=False)
+
+# Multiple sheets
+with pd.ExcelWriter("output.xlsx") as writer:
+    ds1.to_excel(writer, sheet_name="Sales")
+    ds2.to_excel(writer, sheet_name="Inventory")
+```
+
+### to_sql
+Export to SQL database or generate SQL string.
+
+```python
+to_sql(name=None, con=None, schema=None, if_exists='fail', **kwargs)
+```
+
+**Examples:**
+
+```python
+# Generate SQL query (no execution)
+sql = ds.to_sql()
+print(sql)
+# SELECT ...
+# FROM ...
+# WHERE ...
+
+# Write to database
+ds.to_sql("table_name", connection, if_exists='replace')
+```
+
+### Other Export Methods
+```python
+# To pandas DataFrame
+df = ds.to_df()
+df = ds.to_pandas()
+
+# To Arrow Table
+table = ds.to_arrow()
+
+# To NumPy array
+arr = ds.to_numpy()
+
+# To dictionary
+d = ds.to_dict()
+d = ds.to_dict(orient='records')  # List of dicts
+d = ds.to_dict(orient='list')     # Dict of lists
+
+# To records (list of tuples)
+records = ds.to_records()
+
+# To string
+s = ds.to_string()
+s = ds.to_string(max_rows=100)
+
+# To Markdown
+md = ds.to_markdown()
+
+# To HTML
+html = ds.to_html()
+
+# To LaTeX
+latex = ds.to_latex()
+
+# To clipboard
+ds.to_clipboard()
+
+# To pickle
+ds.to_pickle("output.pkl")
+
+# To feather
+ds.to_feather("output.feather")
+```
+
+---
+
+## File Format Comparison
+| Format | Read Speed | Write Speed | File Size | Schema | Best For |
+|--------|------------|-------------|-----------|--------|----------|
+| **Parquet** | Fast | Fast | Small | Yes | Large datasets, analytics |
+| **CSV** | Medium | Fast | Large | No | Compatibility, simple data |
+| **JSON** | Slow | Medium | Large | Partial | APIs, nested data |
+| **Excel** | Slow | Slow | Medium | Partial | Sharing with non-tech users |
+| **Feather** | Very Fast | Very Fast | Medium | Yes | Inter-process, pandas |
+
+### Recommendations
+1. **For analytics workloads:** Use Parquet
+   - Columnar format allows reading only needed columns
+   - Excellent compression
+   - Preserves data types
+
+2. **For data exchange:** Use CSV or JSON
+   - Universal compatibility
+   - Human-readable
+
+3. **For pandas interop:** Use Feather or Arrow
+   - Fastest serialization
+   - Type preservation
+
+---
+
+## Compression Support
+### Reading Compressed Files
+```python
+# Auto-detect from extension
+ds = pd.read_csv("data.csv.gz")
+ds = pd.read_csv("data.csv.bz2")
+ds = pd.read_csv("data.csv.xz")
+ds = pd.read_csv("data.csv.zst")
+
+# Explicit compression
+ds = pd.read_csv("data.csv", compression='gzip')
+```
+
+### Writing Compressed Files
+```python
+# CSV with compression
+ds.to_csv("output.csv.gz", compression='gzip')
+ds.to_csv("output.csv.bz2", compression='bz2')
+
+# Parquet (always compressed)
+ds.to_parquet("output.parquet", compression='snappy')  # Default
+ds.to_parquet("output.parquet", compression='gzip')
+ds.to_parquet("output.parquet", compression='zstd')    # Best ratio
+ds.to_parquet("output.parquet", compression='lz4')     # Fastest
+```
+
+### Compression Options
+| Compression | Speed | Ratio | Use Case |
+|-------------|-------|-------|----------|
+| `snappy` | Very Fast | Low | Default for Parquet |
+| `lz4` | Very Fast | Low | Speed priority |
+| `gzip` | Medium | High | Compatibility |
+| `zstd` | Fast | Very High | Best balance |
+| `bz2` | Slow | Very High | Maximum compression |
+
+---
+
+## Streaming I/O
+For very large files that don't fit in memory:
+
+### Chunked Reading
+```python
+# Read in chunks
+for chunk in pd.read_csv("large.csv", chunksize=100000):
+    # Process each chunk
+    process(chunk)
+
+# Using iterator
+reader = pd.read_csv("large.csv", iterator=True)
+chunk = reader.get_chunk(10000)
+```
+
+### Using ClickHouse Streaming
+```python
+from chdb.datastore import DataStore
+
+# Stream from file without loading all into memory
+ds = DataStore.from_file("huge.parquet")
+
+# Operations are lazy - only computes what's needed
+result = ds.filter(ds['amount'] > 1000).head(100)
+```
+
+---
+
+## Remote Data Sources
+### HTTP/HTTPS
+```python
+# Read from URL
+ds = pd.read_csv("https://example.com/data.csv")
+ds = pd.read_parquet("https://example.com/data.parquet")
+```
+
+### S3
+```python
+from chdb.datastore import DataStore
+
+# Anonymous access
+ds = DataStore.uri("s3://bucket/data.parquet?nosign=true")
+
+# With credentials
+ds = DataStore.from_s3(
+    "s3://bucket/data.parquet",
+    access_key_id="KEY",
+    secret_access_key="SECRET"
+)
+```
+
+### GCS, Azure, HDFS
+See [Factory Methods](factory-methods.md) for cloud storage options.
+
+---
+
+## Best Practices
+### 1. Use Parquet for Large Files
+```python
+# Convert CSV to Parquet for better performance
+ds = pd.read_csv("large.csv")
+ds.to_parquet("large.parquet")
+
+# Future reads are much faster
+ds = pd.read_parquet("large.parquet")
+```
+
+### 2. Select Only Needed Columns
+```python
+# Efficient - only reads col1 and col2
+ds = pd.read_parquet("data.parquet", columns=['col1', 'col2'])
+
+# Inefficient - reads all columns then filters
+ds = pd.read_parquet("data.parquet")[['col1', 'col2']]
+```
+
+### 3. Use Compression
+```python
+# Smaller file size, usually faster due to less I/O
+ds.to_parquet("output.parquet", compression='zstd')
+```
+
+### 4. Batch Writes
+```python
+# Write once, not in a loop
+result = process_all_data(ds)
+result.to_parquet("output.parquet")
+
+# NOT this (inefficient)
+for chunk in chunks:
+    chunk.to_parquet(f"output_{i}.parquet")
+```
+
+---
+
+# DataStore Pandas compatibility
+
+**URL:** https://clickhouse.com/docs/chdb/datastore/pandas-compat
+
+Complete list of pandas-compatible methods in DataStore (209 DataFrame methods)
+
+DataStore implements **209 pandas DataFrame methods** for full API compatibility. Your existing pandas code works with minimal changes.
+
+## Compatibility Approach
+```python
+# Typical migration - just change the import
+- import pandas as pd
++ from chdb import datastore as pd
+
+# Your code works unchanged
+df = pd.read_csv("data.csv")
+result = df[df['age'] > 25].groupby('city')['salary'].mean()
+```
+
+**Key principles:**
+- All 209 pandas DataFrame methods implemented
+- Lazy evaluation for SQL optimization
+- Automatic type wrapping (DataFrame → DataStore, Series → ColumnExpr)
+- Immutable operations (no `inplace=True`)
+
+---
+
+## Attributes and Properties
+| Property | Description | Triggers Execution |
+|----------|-------------|-------------------|
+| `shape` | (rows, columns) tuple | Yes |
+| `columns` | Column names (Index) | Yes |
+| `dtypes` | Column data types | Yes |
+| `values` | NumPy array | Yes |
+| `index` | Row index | Yes |
+| `size` | Number of elements | Yes |
+| `ndim` | Number of dimensions | No |
+| `empty` | Is DataFrame empty | Yes |
+| `T` | Transpose | Yes |
+| `axes` | List of axes | Yes |
+
+**Examples:**
+
+```python
+from chdb import datastore as pd
+
+ds = pd.read_csv("data.csv")
+
+print(ds.shape)      # (1000, 5)
+print(ds.columns)    # Index(['name', 'age', 'city', 'salary', 'dept'])
+print(ds.dtypes)     # name: object, age: int64, ...
+print(ds.empty)      # False
+```
+
+---
+
+## Indexing and Selection
+| Method | Description              | Example |
+|--------|--------------------------|---------|
+| `df['col']` | Select column            | `ds['age']` |
+| `df[['col1', 'col2']]` | Select columns           | `ds[['name', 'age']]` |
+| `df[condition]` | Boolean indexing         | `ds[ds['age'] > 25]` |
+| `df.loc[...]` | Label-based access       | `ds.loc[0:10, 'name']` |
+| `df.iloc[...]` | Integer-based access     | `ds.iloc[0:10, 0:3]` |
+| `df.at[...]` | Single value by label    | `ds.at[0, 'name']` |
+| `df.iat[...]` | Single value by position | `ds.iat[0, 0]` |
+| `df.head(n)` | First n rows             | `ds.head(10)` |
+| `df.tail(n)` | Last n rows              | `ds.tail(10)` |
+| `df.sample(n)` | Random sample            | `ds.sample(100)` |
+| `df.select_dtypes()` | Select by Dtype          | `ds.select_dtypes(include='number')` |
+| `df.query()` | Query expression         | `ds.query('age > 25')` |
+| `df.where()` | Conditional replace      | `ds.where(ds['age'] > 0, 0)` |
+| `df.mask()` | Inverse where            | `ds.mask(ds['age'] < 0, 0)` |
+| `df.isin()` | Value membership         | `ds['city'].isin(['NYC', 'LA'])` |
+| `df.get()` | Safe column access       | `ds.get('col', default=None)` |
+| `df.xs()` | Cross-section            | `ds.xs('key')` |
+| `df.pop()` | Remove column            | `ds.pop('col')` |
+
+---
+
+## Statistical Methods
+| Method | Description | SQL Equivalent |
+|--------|-------------|----------------|
+| `mean()` | Mean value | `AVG()` |
+| `median()` | Median value | `MEDIAN()` |
+| `mode()` | Mode value | - |
+| `std()` | Standard deviation | `STDDEV()` |
+| `var()` | Variance | `VAR()` |
+| `min()` | Minimum | `MIN()` |
+| `max()` | Maximum | `MAX()` |
+| `sum()` | Sum | `SUM()` |
+| `prod()` | Product | - |
+| `count()` | Non-null count | `COUNT()` |
+| `nunique()` | Unique count | `UNIQ()` |
+| `value_counts()` | Value frequencies | `GROUP BY` |
+| `quantile()` | Quantile | `QUANTILE()` |
+| `describe()` | Summary statistics | - |
+| `corr()` | Correlation matrix | `CORR()` |
+| `cov()` | Covariance matrix | `COV()` |
+| `corrwith()` | Pairwise correlation | - |
+| `rank()` | Rank values | `RANK()` |
+| `abs()` | Absolute values | `ABS()` |
+| `round()` | Round values | `ROUND()` |
+| `clip()` | Clip values | - |
+| `cumsum()` | Cumulative sum | Window function |
+| `cumprod()` | Cumulative product | Window function |
+| `cummin()` | Cumulative min | Window function |
+| `cummax()` | Cumulative max | Window function |
+| `diff()` | Difference | Window function |
+| `pct_change()` | Percent change | Window function |
+| `skew()` | Skewness | `SKEW()` |
+| `kurt()` | Kurtosis | `KURT()` |
+| `sem()` | Standard error | - |
+| `all()` | All true | - |
+| `any()` | Any true | - |
+| `idxmin()` | Index of min | - |
+| `idxmax()` | Index of max | - |
+
+**Examples:**
+
+```python
+ds = pd.read_csv("data.csv")
+
+# Basic statistics
+print(ds['salary'].mean())
+print(ds['age'].std())
+print(ds.describe())
+
+# Group statistics
+print(ds.groupby('department')['salary'].mean())
+print(ds.groupby('city').agg({'salary': ['mean', 'std'], 'age': 'count'}))
+```
+
+---
+
+## Data Manipulation
+| Method | Description |
+|--------|-------------|
+| `drop()` | Drop rows/columns |
+| `drop_duplicates()` | Remove duplicates |
+| `duplicated()` | Mark duplicates |
+| `dropna()` | Remove missing values |
+| `fillna()` | Fill missing values |
+| `ffill()` | Forward fill |
+| `bfill()` | Backward fill |
+| `interpolate()` | Interpolate values |
+| `replace()` | Replace values |
+| `rename()` | Rename columns/index |
+| `rename_axis()` | Rename axis |
+| `assign()` | Add new columns |
+| `astype()` | Convert types |
+| `convert_dtypes()` | Infer types |
+| `copy()` | Copy DataFrame |
+
+**Examples:**
+
+```python
+ds = pd.read_csv("data.csv")
+
+# Drop operations
+result = ds.drop(columns=['unused_col'])
+result = ds.drop_duplicates(subset=['user_id'])
+result = ds.dropna(subset=['email'])
+
+# Fill operations
+result = ds.fillna(0)
+result = ds.fillna({'age': 0, 'name': 'Unknown'})
+
+# Transform operations
+result = ds.rename(columns={'old_name': 'new_name'})
+result = ds.assign(
+    full_name=lambda x: x['first_name'] + ' ' + x['last_name'],
+    age_group=lambda x: pd.cut(x['age'], bins=[0, 25, 50, 100])
+)
+```
+
+---
+
+## Sorting and Ranking
+| Method | Description |
+|--------|-------------|
+| `sort_values()` | Sort by values |
+| `sort_index()` | Sort by index |
+| `nlargest()` | N largest values |
+| `nsmallest()` | N smallest values |
+
+**Examples:**
+
+```python
+# Sort by single column
+result = ds.sort_values('salary', ascending=False)
+
+# Sort by multiple columns
+result = ds.sort_values(['department', 'salary'], ascending=[True, False])
+
+# Get top/bottom N
+result = ds.nlargest(10, 'salary')
+result = ds.nsmallest(5, 'age')
+```
+
+---
+
+## Reshaping
+| Method | Description |
+|--------|-------------|
+| `pivot()` | Pivot table |
+| `pivot_table()` | Pivot with aggregation |
+| `melt()` | Unpivot |
+| `stack()` | Stack columns to index |
+| `unstack()` | Unstack index to columns |
+| `transpose()` / `T` | Transpose |
+| `explode()` | Explode lists to rows |
+| `squeeze()` | Reduce dimensions |
+| `droplevel()` | Drop index level |
+| `swaplevel()` | Swap index levels |
+| `reorder_levels()` | Reorder levels |
+
+**Examples:**
+
+```python
+# Pivot table
+result = ds.pivot_table(
+    values='amount',
+    index='region',
+    columns='product',
+    aggfunc='sum'
+)
+
+# Melt (unpivot)
+result = ds.melt(
+    id_vars=['name'],
+    value_vars=['score1', 'score2', 'score3'],
+    var_name='test',
+    value_name='score'
+)
+
+# Explode arrays
+result = ds.explode('tags')
+```
+
+---
+
+## Combining / Joining
+| Method | Description |
+|--------|-------------|
+| `merge()` | SQL-style merge |
+| `join()` | Join on index |
+| `concat()` | Concatenate |
+| `append()` | Append rows |
+| `combine()` | Combine with function |
+| `combine_first()` | Combine with priority |
+| `update()` | Update values |
+| `compare()` | Show differences |
+
+**Examples:**
+
+```python
+# Merge (join)
+result = pd.merge(df1, df2, on='id', how='left')
+result = df1.join(df2, on='id')
+
+# Concatenate
+result = pd.concat([df1, df2, df3])
+result = pd.concat([df1, df2], axis=1)
+```
+
+---
+
+## Binary Operations
+| Method | Description |
+|--------|-------------|
+| `add()` / `radd()` | Addition |
+| `sub()` / `rsub()` | Subtraction |
+| `mul()` / `rmul()` | Multiplication |
+| `div()` / `rdiv()` | Division |
+| `truediv()` / `rtruediv()` | True division |
+| `floordiv()` / `rfloordiv()` | Floor division |
+| `mod()` / `rmod()` | Modulo |
+| `pow()` / `rpow()` | Power |
+| `dot()` | Matrix multiplication |
+
+**Examples:**
+
+```python
+# Arithmetic operations
+result = ds['col1'].add(ds['col2'])
+result = ds['price'].mul(ds['quantity'])
+
+# With fill_value for missing data
+result = ds['col1'].add(ds['col2'], fill_value=0)
+```
+
+---
+
+## Comparison Operations
+| Method | Description |
+|--------|-------------|
+| `eq()` | Equal |
+| `ne()` | Not equal |
+| `lt()` | Less than |
+| `le()` | Less than or equal |
+| `gt()` | Greater than |
+| `ge()` | Greater than or equal |
+| `equals()` | Test equality |
+| `compare()` | Show differences |
+
+---
+
+## Function Application
+| Method | Description |
+|--------|-------------|
+| `apply()` | Apply function |
+| `applymap()` | Apply element-wise |
+| `map()` | Map values |
+| `agg()` / `aggregate()` | Aggregate |
+| `transform()` | Transform |
+| `pipe()` | Pipe functions |
+| `groupby()` | Group by |
+
+**Examples:**
+
+```python
+# Apply function
+result = ds['name'].apply(lambda x: x.upper())
+result = ds.apply(lambda row: row['a'] + row['b'], axis=1)
+
+# Aggregate
+result = ds.agg({'col1': 'sum', 'col2': 'mean'})
+result = ds.agg(['sum', 'mean', 'std'])
+
+# Pipe
+result = (ds
+    .pipe(filter_active)
+    .pipe(calculate_metrics)
+    .pipe(format_output)
+)
+```
+
+---
+
+## Time Series
+| Method | Description |
+|--------|-------------|
+| `rolling()` | Rolling window |
+| `expanding()` | Expanding window |
+| `ewm()` | Exponentially weighted |
+| `resample()` | Resample time series |
+| `shift()` | Shift values |
+| `asfreq()` | Convert frequency |
+| `asof()` | Latest value as of |
+| `at_time()` | Select at time |
+| `between_time()` | Select time range |
+| `first()` / `last()` | First/last periods |
+| `to_period()` | Convert to period |
+| `to_timestamp()` | Convert to timestamp |
+| `tz_convert()` | Convert timezone |
+| `tz_localize()` | Localize timezone |
+
+**Examples:**
+
+```python
+# Rolling window
+result = ds['value'].rolling(window=7).mean()
+
+# Expanding window
+result = ds['value'].expanding().sum()
+
+# Shift
+result = ds['value'].shift(1)  # Lag
+result = ds['value'].shift(-1)  # Lead
+```
+
+---
+
+## Missing Data
+| Method | Description |
+|--------|-------------|
+| `isna()` / `isnull()` | Detect missing |
+| `notna()` / `notnull()` | Detect non-missing |
+| `dropna()` | Drop missing |
+| `fillna()` | Fill missing |
+| `ffill()` | Forward fill |
+| `bfill()` | Backward fill |
+| `interpolate()` | Interpolate |
+| `replace()` | Replace values |
+
+---
+
+## I/O Methods
+| Method | Description |
+|--------|-------------|
+| `to_csv()` | Export to CSV |
+| `to_json()` | Export to JSON |
+| `to_excel()` | Export to Excel |
+| `to_parquet()` | Export to Parquet |
+| `to_feather()` | Export to Feather |
+| `to_sql()` | Export to SQL database |
+| `to_pickle()` | Pickle |
+| `to_html()` | HTML table |
+| `to_latex()` | LaTeX table |
+| `to_markdown()` | Markdown table |
+| `to_string()` | String representation |
+| `to_dict()` | Dictionary |
+| `to_records()` | Records |
+| `to_numpy()` | NumPy array |
+| `to_clipboard()` | Clipboard |
+
+See [I/O Operations](io.md) for detailed documentation.
+
+---
+
+## Iteration
+| Method | Description              |
+|--------|--------------------------|
+| `items()` | Iterate (column, Series) |
+| `iterrows()` | Iterate (index, Series)  |
+| `itertuples()` | Iterate as named tuples  |
+
+---
+
+## Key Differences from Pandas
+### 1. Return Types
+```python
+# Pandas returns Series
+pdf['col']  # → pd.Series
+
+# DataStore returns ColumnExpr (lazy)
+ds['col']   # → ColumnExpr
+```
+
+### 2. Lazy Execution
+```python
+# DataStore operations are lazy
+result = ds.filter(ds['age'] > 25)  # Not executed yet
+df = result.to_df()  # Executed here
+```
+
+### 3. No inplace Parameter
+```python
+# Pandas
+df.drop(columns=['col'], inplace=True)
+
+# DataStore (always returns new object)
+ds = ds.drop(columns=['col'])
+```
+
+### 4. Comparing Results
+```python
+# Use to_pandas() for comparison
+pd.testing.assert_frame_equal(
+    ds.to_pandas(),
+    expected_df
+)
+```
+
+See [Key Differences](../guides/pandas-differences.md) for complete details.
+
+---
+
+# DataStore Query building
+
+**URL:** https://clickhouse.com/docs/chdb/datastore/query-building
+
+Build SQL-style queries with DataStore using fluent method chaining
+
+DataStore provides SQL-style query building methods that compile to optimized SQL queries. All operations are lazy until results are needed.
+
+## Query Methods Overview
+| Method | SQL Equivalent | Description |
+|--------|---------------|-------------|
+| `select(*cols)` | `SELECT cols` | Select columns |
+| `filter(cond)` | `WHERE cond` | Filter rows |
+| `where(cond)` | `WHERE cond` | Alias for filter |
+| `sort(*cols)` | `ORDER BY cols` | Sort rows |
+| `orderby(*cols)` | `ORDER BY cols` | Alias for sort |
+| `limit(n)` | `LIMIT n` | Limit rows |
+| `offset(n)` | `OFFSET n` | Skip rows |
+| `distinct()` | `DISTINCT` | Remove duplicates |
+| `groupby(*cols)` | `GROUP BY cols` | Group rows |
+| `having(cond)` | `HAVING cond` | Filter groups |
+| `join(right, ...)` | `JOIN` | Join DataStores |
+| `union(other)` | `UNION` | Combine results |
+
+---
+
+## Selection
+### `select`
+Select specific columns from the DataStore.
+
+```python
+select(*fields: Union[str, Expression]) -> DataStore
+```
+
+**Examples:**
+
+```python
+from chdb.datastore import DataStore
+from pathlib import Path
+Path("employees.csv").write_text("""\
+name,age,city,salary,department,dept_id,status,email,manager_id,bonus
+Alice,28,NYC,75000,Engineering,1,active,alice@company.com,3,5000
+Bob,35,LA,85000,Engineering,1,active,bob@company.com,3,
+Charlie,52,NYC,95000,Product,2,active,charlie@company.com,,10000
+Diana,32,SF,70000,Design,3,active,diana@company.com,3,3000
+Eve,23,LA,48000,Product,2,inactive,eve@company.com,2,
+""")
+
+ds = DataStore.from_file("employees.csv")
+
+# Select by column names
+result = ds.select('name', 'age', 'salary')
+
+# Select all columns
+result = ds.select('*')
+
+# Select with expressions
+result = ds.select(
+    'name',
+    (ds['salary'] * 12).as_('annual_salary'),
+    ds['age'].as_('employee_age')
+)
+
+# Equivalent pandas style
+result = ds[['name', 'age', 'salary']]
+```
+
+---
+
+## Filtering
+### `filter` / `where`
+Filter rows based on conditions. Both methods are equivalent.
+
+```python
+filter(condition) -> DataStore
+where(condition) -> DataStore  # alias
+```
+
+**Examples:**
+
+```python
+ds = DataStore.from_file("employees.csv")
+
+# Single condition
+result = ds.filter(ds['age'] > 30)
+result = ds.where(ds['salary'] >= 50000)
+
+# Multiple conditions (AND)
+result = ds.filter((ds['age'] > 30) & (ds['department'] == 'Engineering'))
+
+# Multiple conditions (OR)
+result = ds.filter((ds['city'] == 'NYC') | (ds['city'] == 'LA'))
+
+# NOT condition
+result = ds.filter(~(ds['status'] == 'inactive'))
+
+# String conditions
+result = ds.filter(ds['name'].str.contains('John'))
+result = ds.filter(ds['email'].str.endswith('@company.com'))
+
+# NULL checks
+result = ds.filter(ds['manager_id'].notnull())
+result = ds.filter(ds['bonus'].isnull())
+
+# IN condition
+result = ds.filter(ds['department'].isin(['Engineering', 'Product', 'Design']))
+
+# BETWEEN condition
+result = ds.filter(ds['salary'].between(50000, 100000))
+
+# Chained filters (AND)
+result = (ds
+    .filter(ds['age'] > 25)
+    .filter(ds['salary'] > 50000)
+    .filter(ds['city'] == 'NYC')
+)
+```
+
+### Pandas-Style Filtering
+```python
+# Boolean indexing (equivalent to filter)
+result = ds[ds['age'] > 30]
+result = ds[(ds['age'] > 30) & (ds['salary'] > 50000)]
+
+# Query method
+result = ds.query('age > 30 and salary > 50000')
+```
+
+---
+
+## Sorting
+### `sort` / `orderby`
+Sort rows by one or more columns.
+
+```python
+sort(*fields, ascending=True) -> DataStore
+orderby(*fields, ascending=True) -> DataStore  # alias
+```
+
+**Examples:**
+
+```python
+ds = DataStore.from_file("employees.csv")
+
+# Single column ascending
+result = ds.sort('name')
+
+# Single column descending
+result = ds.sort('salary', ascending=False)
+
+# Multiple columns
+result = ds.sort('department', 'salary')
+
+# Mixed order (use list for ascending parameter)
+result = ds.sort('department', 'salary', ascending=[True, False])
+
+# Pandas style
+result = ds.sort_values('salary', ascending=False)
+result = ds.sort_values(['department', 'salary'], ascending=[True, False])
+```
+
+---
+
+## Limiting and Pagination
+### `limit`
+Limit the number of rows returned.
+
+```python
+limit(n: int) -> DataStore
+```
+
+### `offset`
+Skip the first n rows.
+
+```python
+offset(n: int) -> DataStore
+```
+
+**Examples:**
+
+```python
+ds = DataStore.from_file("employees.csv")
+
+# First 10 rows
+result = ds.limit(10)
+
+# Skip first 100, take next 50
+result = ds.offset(100).limit(50)
+
+# Pandas style
+result = ds.head(10)
+result = ds.tail(10)
+result = ds.iloc[100:150]
+```
+
+---
+
+## Distinct
+### `distinct`
+Remove duplicate rows.
+
+```python
+distinct(subset=None, keep='first') -> DataStore
+```
+
+**Examples:**
+
+```python
+from pathlib import Path
+Path("events.csv").write_text("""\
+user_id,event_type,timestamp
+1,click,2024-01-15 10:30:00
+2,view,2024-01-15 11:00:00
+1,purchase,2024-01-15 11:30:00
+3,click,2024-01-16 09:00:00
+2,click,2024-01-16 10:00:00
+""")
+
+ds = DataStore.from_file("events.csv")
+
+# Remove all duplicate rows
+result = ds.distinct()
+
+# Remove duplicates based on specific columns
+result = ds.distinct(subset=['user_id', 'event_type'])
+
+# Pandas style
+result = ds.drop_duplicates()
+result = ds.drop_duplicates(subset=['user_id'])
+```
+
+---
+
+## Grouping
+### `groupby`
+Group rows by one or more columns. Returns a `LazyGroupBy` object.
+
+```python
+groupby(*fields, sort=True, as_index=True, dropna=True) -> LazyGroupBy
+```
+
+**Examples:**
+
+```python
+from pathlib import Path
+Path("sales.csv").write_text("""\
+region,product,category,amount,quantity,price,date,order_id
+East,Widget,Electronics,5200,10,120,2024-01-15,1001
+West,Gadget,Electronics,800,5,160,2024-02-20,1002
+East,Gizmo,Home,6500,3,100,2024-03-10,1003
+North,Widget,Electronics,4500,6,150,2024-06-18,1004
+West,Gadget,Electronics,2000,8,250,2024-09-14,1005
+""")
+
+ds = DataStore.from_file("sales.csv")
+
+# Group by single column
+by_region = ds.groupby('region')
+
+# Group by multiple columns
+by_region_product = ds.groupby('region', 'product')
+
+# Aggregation after groupby
+result = ds.groupby('region')['amount'].sum()
+result = ds.groupby('region').agg({'amount': 'sum', 'quantity': 'mean'})
+
+# Multiple aggregations
+result = ds.groupby('category').agg({
+    'price': ['min', 'max', 'mean'],
+    'quantity': 'sum'
+})
+
+# Named aggregation
+result = ds.groupby('region').agg(
+    total_amount=('amount', 'sum'),
+    avg_quantity=('quantity', 'mean'),
+    order_count=('order_id', 'count')
+)
+```
+
+### `having`
+Filter groups after aggregation.
+
+```python
+having(condition: Union[Condition, str]) -> DataStore
+```
+
+**Examples:**
+
+```python
+# Filter groups with total > 10000
+result = (ds
+    .groupby('region')
+    .agg({'amount': 'sum'})
+    .having(ds['sum'] > 10000)
+)
+
+# Using SQL-style having
+result = (ds
+    .select('region', 'SUM(amount) as total')
+    .groupby('region')
+    .having('total > 10000')
+)
+```
+
+---
+
+## Joining
+### `join`
+Join two DataStores.
+
+```python
+join(right, on=None, how='inner', left_on=None, right_on=None) -> DataStore
+```
+
+**Parameters:**
+
+| Parameter | Type | Default | Description |
+|-----------|------|---------|-------------|
+| `right` | DataStore | *required* | Right DataStore to join |
+| `on` | str/list | `None` | Columns to join on |
+| `how` | str | `'inner'` | Join type: 'inner', 'left', 'right', 'outer' |
+| `left_on` | str/list | `None` | Left join columns |
+| `right_on` | str/list | `None` | Right join columns |
+
+**Examples:**
+
+```python
+from pathlib import Path
+Path("departments.csv").write_text("""\
+dept_id,department_name
+1,Engineering
+2,Product
+3,Design
+""")
+
+employees = DataStore.from_file("employees.csv")
+departments = DataStore.from_file("departments.csv")
+
+# Inner join on single column
+result = employees.join(departments, on='dept_id')
+
+# Left join
+result = employees.join(departments, on='dept_id', how='left')
+
+# Join on different column names
+result = employees.join(
+    departments,
+    left_on='department_id',
+    right_on='id',
+    how='inner'
+)
+
+# Pandas style merge
+from chdb import datastore as pd
+result = pd.merge(employees, departments, on='dept_id')
+result = pd.merge(employees, departments, left_on='department_id', right_on='id')
+```
+
+### `union`
+Combine results from two DataStores.
+
+```python
+union(other, all=False) -> DataStore
+```
+
+**Examples:**
+
+```python
+from pathlib import Path
+Path("sales_2023.csv").write_text("""\
+region,product,amount,date
+East,Widget,1200,2023-06-15
+West,Gadget,800,2023-09-20
+North,Gizmo,600,2023-11-10
+""")
+Path("sales_2024.csv").write_text("""\
+region,product,amount,date
+East,Widget,1500,2024-03-10
+North,Gizmo,900,2024-07-22
+West,Gadget,1100,2024-05-05
+""")
+
+ds1 = DataStore.from_file("sales_2023.csv")
+ds2 = DataStore.from_file("sales_2024.csv")
+
+# UNION (removes duplicates)
+result = ds1.union(ds2)
+
+# UNION ALL (keeps duplicates)
+result = ds1.union(ds2, all=True)
+
+# Pandas style
+from chdb import datastore as pd
+result = pd.concat([ds1, ds2])
+```
+
+---
+
+## Conditional Expressions
+### `when`
+Create CASE WHEN expressions.
+
+```python
+when(condition, value) -> CaseWhenBuilder
+```
+
+**Examples:**
+
+```python
+ds = DataStore.from_file("employees.csv")
+
+# Simple case-when
+result = ds.select(
+    'name',
+    ds.when(ds['salary'] > 100000, 'High')
+      .when(ds['salary'] > 50000, 'Medium')
+      .otherwise('Low')
+      .as_('salary_tier')
+)
+
+# With column assignment
+ds['salary_tier'] = (
+    ds.when(ds['salary'] > 100000, 'High')
+      .when(ds['salary'] > 50000, 'Medium')
+      .otherwise('Low')
+)
+```
+
+---
+
+## Raw SQL
+### `run_sql` / `sql`
+Execute raw SQL queries.
+
+```python
+run_sql(query: str) -> DataStore
+sql(query: str) -> DataStore  # alias
+```
+
+**Examples:**
+
+```python
+from chdb.datastore import DataStore
+
+# Execute raw SQL
+result = DataStore().sql("""
+    SELECT 
+        department,
+        COUNT(*) as count,
+        AVG(salary) as avg_salary
+    FROM file('employees.csv', 'CSVWithNames')
+    WHERE status = 'active'
+    GROUP BY department
+    HAVING count > 5
+    ORDER BY avg_salary DESC
+    LIMIT 10
+""")
+
+# SQL on existing DataStore
+ds = DataStore.from_file("employees.csv")
+result = ds.sql("SELECT * FROM __table__ WHERE age > 30")
+```
+
+### `to_sql`
+View the generated SQL without executing.
+
+```python
+to_sql(**kwargs) -> str
+```
+
+**Examples:**
+
+```python
+ds = DataStore.from_file("employees.csv")
+
+query = (ds
+    .filter(ds['age'] > 30)
+    .groupby('department')
+    .agg({'salary': 'mean'})
+    .sort('mean', ascending=False)
+)
+
+print(query.to_sql())
+# Output:
+# SELECT department, AVG(salary) AS mean
+# FROM file('employees.csv', 'CSVWithNames')
+# WHERE age > 30
+# GROUP BY department
+# ORDER BY mean DESC
+```
+
+---
+
+## Method Chaining
+All query methods support fluent chaining:
+
+```python
+from chdb.datastore import DataStore
+
+ds = DataStore.from_file("sales.csv")
+
+result = (ds
+    .select('region', 'product', 'amount', 'date')
+    .filter(ds['date'] >= '2024-01-01')
+    .filter(ds['amount'] > 100)
+    .groupby('region', 'product')
+    .agg({
+        'amount': ['sum', 'mean'],
+        'date': 'count'
+    })
+    .having(ds['sum'] > 10000)
+    .sort('sum', ascending=False)
+    .limit(20)
+)
+
+# View SQL
+print(result.to_sql())
+
+# Execute
+df = result.to_df()
+```
+
+---
+
+## Aliasing
+### `as_`
+Set an alias for a column or subquery.
+
+```python
+as_(alias: str) -> DataStore
+```
+
+**Examples:**
+
+```python
+# Column alias
+result = ds.select(
+    ds['name'].as_('employee_name'),
+    (ds['salary'] * 12).as_('annual_salary')
+)
+
+# Subquery alias
+subquery = ds.filter(ds['age'] > 30).as_('senior_employees')
+```
+
+---
+
+# DataStore quickstart
+
+**URL:** https://clickhouse.com/docs/chdb/datastore/quickstart
+
+Get started with DataStore - installation, one-line migration from pandas, and basic usage
+
+Get up and running with DataStore in minutes. This guide covers installation, migrating from pandas, and basic usage patterns.
+
+## Installation
+Install chDB with pip:
+
+```bash
+pip install "chdb>=4.0"
+```
+
+For optional dependencies:
+
+```bash
+# For pandas DataFrame support
+pip install "chdb[pandas]>=4.0"
+
+# For PyArrow support
+pip install "chdb[arrow]>=4.0"
+
+# All optional dependencies
+pip install "chdb[all]>=4.0"
+```
+
+### Verify Installation
+```python
+
+print(chdb.__version__)  # Should print 4.x.x or higher
+
+from chdb import datastore as pd
+print("DataStore ready!")
+```
+
+## One-Line Migration from Pandas
+The simplest way to start using DataStore is to change your import statement:
+
+```python
+# Before (pandas)
+
+# After (DataStore)
+from chdb import datastore as pd
+```
+
+That's it! Your existing pandas code will now use DataStore and benefit from SQL optimization.
+
+### Migration Example
+```python
+from pathlib import Path
+Path("employees.csv").write_text("""\
+name,age,city,salary,department,dept_id,status,email
+Alice,28,NYC,75000,Engineering,1,active,alice@company.com
+Bob,35,LA,85000,Engineering,1,active,bob@company.com
+Charlie,52,NYC,95000,Product,2,active,charlie@company.com
+Diana,32,SF,70000,Design,3,active,diana@company.com
+Eve,23,LA,48000,Product,2,inactive,eve@company.com
+""")
+
+# Original pandas code
+
+df = pd.read_csv("employees.csv")
+result = (df[df['salary'] > 50000]
+          .groupby('department')['salary']
+          .agg(['mean', 'count'])
+          .sort_values('mean', ascending=False))
+print(result)
+
+# DataStore version - just change the import!
+from chdb import datastore as pd
+
+df = pd.read_csv("employees.csv")
+result = (df[df['salary'] > 50000]
+          .groupby('department')['salary']
+          .agg(['mean', 'count'])
+          .sort_values('mean', ascending=False))
+print(result)  # Same result, faster execution!
+```
+
+## Basic Usage
+### Creating a DataStore
+```python
+from chdb import datastore as pd
+
+# From a dictionary
+ds = pd.DataFrame({
+    'name': ['Alice', 'Bob', 'Charlie'],
+    'age': [25, 30, 35],
+    'city': ['NYC', 'LA', 'NYC']
+})
+
+# From a pandas DataFrame
+
+pdf = pandas.DataFrame({'a': [1, 2, 3], 'b': [4, 5, 6]})
+ds = pd.DataFrame(pdf)
+
+# From a CSV file
+ds = pd.read_csv("data.csv")
+
+# From a Parquet file (recommended for large datasets)
+ds = pd.read_parquet("data.parquet")
+```
+
+### Filtering Data
+```python
+from chdb import datastore as pd
+
+ds = pd.read_csv("employees.csv")
+
+# Single condition
+senior = ds[ds['age'] > 30]
+
+# Multiple conditions (AND)
+senior_nyc = ds[(ds['age'] > 30) & (ds['city'] == 'NYC')]
+
+# Multiple conditions (OR)
+young_or_senior = ds[(ds['age'] < 25) | (ds['age'] > 50)]
+
+# Using filter method (SQL-style)
+result = ds.filter(ds['salary'] > 50000)
+```
+
+### Selecting Columns
+```python
+# Pandas style
+subset = ds[['name', 'age']]
+
+# SQL style
+subset = ds.select('name', 'age')
+```
+
+### Sorting
+```python
+# Pandas style
+sorted_ds = ds.sort_values('salary', ascending=False)
+
+# SQL style
+sorted_ds = ds.sort('salary', ascending=False)
+```
+
+### Grouping and Aggregation
+```python
+from pathlib import Path
+Path("sales.csv").write_text("""\
+region,product,category,amount,quantity,price,date,order_id
+East,Widget,Electronics,5200,10,120,2024-01-15,1001
+West,Gadget,Electronics,800,5,160,2024-02-20,1002
+East,Gizmo,Home,6500,3,100,2024-03-10,1003
+North,Widget,Electronics,4500,6,150,2024-06-18,1004
+West,Gadget,Electronics,2000,8,250,2024-09-14,1005
+""")
+
+from chdb import datastore as pd
+
+ds = pd.read_csv("sales.csv")
+
+# Group by single column
+by_region = ds.groupby('region')['amount'].sum()
+
+# Group by multiple columns
+by_region_product = ds.groupby(['region', 'product']).agg({
+    'amount': ['sum', 'mean'],
+    'quantity': 'sum'
+})
+
+# Multiple aggregations
+summary = ds.groupby('category').agg({
+    'price': ['min', 'max', 'mean'],
+    'quantity': 'sum'
+})
+```
+
+### Joining DataStores
+```python
+from pathlib import Path
+Path("departments.csv").write_text("""\
+dept_id,department_name
+1,Engineering
+2,Product
+3,Design
+""")
+
+from chdb import datastore as pd
+
+employees = pd.read_csv("employees.csv")
+departments = pd.read_csv("departments.csv")
+
+# Inner join
+result = employees.join(departments, on='dept_id', how='inner')
+
+# Left join
+result = employees.join(departments, on='dept_id', how='left')
+
+# Using merge (pandas style)
+result = pd.merge(employees, departments, on='dept_id')
+```
+
+## Getting Results
+DataStore uses lazy evaluation - operations are not executed until you need the results.
+
+### Triggering Execution
+```python
+# Automatic triggers
+print(ds)           # Displaying results
+len(ds)             # Getting row count
+ds.columns          # Accessing properties
+list(ds)            # Converting to list
+
+# Explicit conversion
+df = ds.to_df()     # Convert to pandas DataFrame
+df = ds.to_pandas() # Same as to_df()
+```
+
+### Viewing Generated SQL
+```python title="Query"
+# See what SQL DataStore will execute
+query = ds.filter(ds['age'] > 25).groupby('city').agg({'salary': 'mean'})
+print(query.to_sql())
+```
+
+```sql title="Response"
+SELECT city, AVG(salary) AS mean
+FROM file('data.csv', 'CSVWithNames')
+WHERE age > 25
+GROUP BY city
+```
+
+## Working with Different Data Sources
+### Local Files
+```python
+from chdb import datastore as pd
+
+# CSV
+ds = pd.read_csv("data.csv")
+
+# Parquet (best performance)
+ds = pd.read_parquet("data.parquet")
+
+# JSON
+ds = pd.read_json("data.json")
+```
+
+### Cloud Storage
+```python
+from chdb.datastore import DataStore
+
+# S3 (anonymous)
+ds = DataStore.uri("s3://bucket/data.parquet?nosign=true")
+
+# S3 (with credentials)
+ds = DataStore.from_s3(
+    "s3://bucket/data.parquet",
+    access_key_id="KEY",
+    secret_access_key="SECRET"
+)
+
+# HTTP/HTTPS
+ds = DataStore.uri("https://example.com/data.csv")
+```
+
+### Databases
+```python
+from chdb.datastore import DataStore
+
+# MySQL
+ds = DataStore.from_mysql(
+    host="localhost",
+    database="mydb",
+    table="users",
+    user="root",
+    password="pass"
+)
+
+# PostgreSQL
+ds = DataStore.from_postgresql(
+    host="localhost",
+    database="mydb",
+    table="users",
+    user="postgres",
+    password="pass"
+)
+
+# Using URI
+ds = DataStore.uri("mysql://user:pass@localhost:3306/mydb/users")
+```
+
+## String and DateTime Operations
+### String Operations
+```python
+# All pandas .str methods work
+ds['name_upper'] = ds['name'].str.upper()
+ds['name_len'] = ds['name'].str.len()
+ds['has_a'] = ds['name'].str.contains('a')
+```
+
+### DateTime Operations
+```python
+# All pandas .dt methods work
+ds['year'] = ds['date'].dt.year
+ds['month'] = ds['date'].dt.month
+ds['day_of_week'] = ds['date'].dt.dayofweek
+```
+
+### ClickHouse Extensions
+```python
+# URL parsing (not available in pandas!)
+ds['domain'] = ds['url'].url.domain()
+
+# JSON extraction
+ds['user_name'] = ds['json_data'].json.get_string('name')
+
+# IP address operations
+ds['is_ipv4'] = ds['ip_addr'].ip.is_ipv4_string()
+```
+
+## Best Practices
+### 1. Use Parquet for Large Files
+```python
+# CSV - slower, reads entire file
+ds = pd.read_csv("large_data.csv")
+
+# Parquet - faster, columnar format, reads only needed columns
+ds = pd.read_parquet("large_data.parquet")
+```
+
+### 2. Filter Early
+```python
+# Good - filter first, then aggregate
+result = (ds
+    .filter(ds['date'] >= '2024-01-01')
+    .groupby('category')['amount'].sum()
+)
+
+# Less optimal - aggregate first
+result = ds.groupby('category')['amount'].sum()
+```
+
+### 3. Select Only Needed Columns
+```python
+# Good - select specific columns
+result = ds.select('name', 'age', 'city').filter(ds['age'] > 25)
+
+# Less optimal - work with all columns
+result = ds.filter(ds['age'] > 25)
+```
+
+### 4. Use SQL for Complex Operations
+```python
+# For complex queries, use SQL directly
+ds = DataStore()
+result = ds.sql("""
+    SELECT category, 
+           SUM(amount) as total,
+           COUNT(*) as count,
+           AVG(amount) as avg
+    FROM file('sales.csv', 'CSVWithNames')
+    WHERE date >= '2024-01-01'
+    GROUP BY category
+    HAVING total > 10000
+    ORDER BY total DESC
+    LIMIT 10
+""")
+```
+
+## Next Steps
+- Learn about all [Factory Methods](factory-methods.md) for creating DataStore
+- Explore [Query Building](query-building.md) for SQL-style operations
+- Check out [Accessors](accessors.md) for string, datetime, and more
+- Read the [Performance Guide](../guides/pandas-performance.md) for optimization tips
+
+---
+
+# Using a clickhouse-local database
+
+**URL:** https://clickhouse.com/docs/chdb/guides/clickhouse-local
+
+Learn how to use a clickhouse-local database with chDB
+
+[clickhouse-local](/operations/utilities/clickhouse-local) is a CLI with an embedded version of ClickHouse.
+It gives users the power of ClickHouse without having to install a server.
+In this guide, we will learn how to use a clickhouse-local database from chDB.
+
+## Setup
+Let's first create a virtual environment:
+
+```bash
+python -m venv .venv
+source .venv/bin/activate
+```
+
+And now we'll install chDB.
+Make sure you have version 2.0.2 or higher:
+
+```bash
+pip install "chdb>=2.0.2"
+```
+
+And now we're going to install [ipython](https://ipython.org/):
+
+```bash
+pip install ipython
+```
+
+We're going to use `ipython` to run the commands in the rest of the guide, which you can launch by running:
+
+```bash
+ipython
+```
+
+## Installing clickhouse-local
+Downloading and installing clickhouse-local is the same as [downloading and installing ClickHouse](/install).
+We can do this by running the following command:
+
+```bash
+curl https://clickhouse.com/ | sh
+```
+
+To launch clickhouse-local with the data being persisted to a directory, we need to pass in a `--path`:
+
+```bash
+./clickhouse -m --path demo.chdb
+```
+
+## Ingesting data into clickhouse-local
+The default database only stores data in memory, so we'll need to create a named database to make sure any data we ingest is persisted to disk.
+
+```sql
+CREATE DATABASE foo;
+```
+
+Let's create a table and insert some random numbers:
+
+```sql
+CREATE TABLE foo.randomNumbers
+ORDER BY number AS
+SELECT rand() AS number
+FROM numbers(10_000_000);
+```
+
+Let's write a query to see what data we've got:
+
+```sql
+SELECT quantilesExact(0, 0.5, 0.75, 0.99)(number) AS quants
+FROM foo.randomNumbers
+```
+
+```response
+┌─quants────────────────────────────────┐
+│ [69,2147776478,3221525118,4252096960] │
+└───────────────────────────────────────┘
+```
+
+Once you've done that, make sure you `exit;` from the CLI as only one process can hold a lock on this directory.
+If we don't do that, we'll get the following error when we try to connect to the database from chDB:
+
+```text
+ChdbError: Code: 76. DB::Exception: Cannot lock file demo.chdb/status. Another server instance in same directory is already running. (CANNOT_OPEN_FILE)
+```
+
+## Connecting to a clickhouse-local database
+Go back to the `ipython` shell and import the `session` module from chDB:
+
+```python
+from chdb import session as chs
+```
+
+Initialize a session pointing to `demo.chdb`:
+
+```python
+sess = chs.Session("demo.chdb")
+```
+
+We can then run the same query that returns the quantiles of numbers:
+
+```python
+sess.query("""
+SELECT quantilesExact(0, 0.5, 0.75, 0.99)(number) AS quants
+FROM foo.randomNumbers
+""", "Vertical")
+
+Row 1:
+──────
+quants: [0,9976599,2147776478,4209286886]
+```
+
+We can also insert data into this database from chDB:
+
+```python
+sess.query("""
+INSERT INTO foo.randomNumbers
+SELECT rand() AS number FROM numbers(10_000_000)
+""")
+
+Row 1:
+──────
+quants: [0,9976599,2147776478,4209286886]
+```
+
+We can then re-run the quantiles query from chDB or clickhouse-local.
+
+---
+
+# chDB guides
+
+**URL:** https://clickhouse.com/docs/chdb/guides
+
+Index page for chDB guides
+
+Take a look at our chDB developer guides below:
+
+<!-- 
+The following table of contents is autogenerated by https://github.com/ClickHouse/clickhouse-docs/blob/main/scripts/autogenerate-table-of-contents.sh
+from YAML frontmatter fields title, slug, description. If you've found an error 
+in the table of contents, please edit the frontmatter of the files directly.
+-->
+
+<!--AUTOGENERATED_START-->
+| Page | Description |
+|-----|-----|
+| [How to query a remote ClickHouse server](/chdb/guides/query-remote-clickhouse) | In this guide, we will learn how to query a remote ClickHouse server from chDB. |
+| [How to query Apache Arrow with chDB](/chdb/guides/apache-arrow) | In this guide, we will learn how to query Apache Arrow tables with chDB |
+| [How to query data in an S3 bucket](/chdb/guides/querying-s3) | Learn how to query data in an S3 bucket with chDB. |
+| [How to query Pandas DataFrames with chDB](/chdb/guides/pandas) | Learn how to query Pandas DataFrames with chDB |
+| [How to query Parquet files](/chdb/guides/querying-parquet) | Learn how to query Parquet files with chDB. |
+| [JupySQL and chDB](/chdb/guides/jupysql) | How to install chDB for Bun |
+| [Key differences from pandas](/chdb/guides/pandas-differences) | Important differences between DataStore and pandas |
+| [Migration from pandas](/chdb/guides/migration-from-pandas) | Step-by-step guide to migrate from pandas to DataStore |
+| [Pandas cookbook](/chdb/guides/pandas-cookbook) | Common pandas patterns and their DataStore equivalents |
+| [Performance guide](/chdb/guides/pandas-performance) | Performance optimization tips for DataStore vs pandas |
+| [SQL for pandas users](/chdb/guides/pandas-to-sql) | Understanding how pandas operations map to SQL in DataStore |
+| [Using a clickhouse-local database](/chdb/guides/clickhouse-local) | Learn how to use a clickhouse-local database with chDB |
+<!--AUTOGENERATED_END-->
+
+---
+
+# JupySQL and chDB
+
+**URL:** https://clickhouse.com/docs/chdb/guides/jupysql
+
+How to install chDB for Bun
+
+[JupySQL](https://jupysql.ploomber.io/en/latest/quick-start.html) is a Python library that lets you run SQL in Jupyter notebooks and the IPython shell.
+In this guide, we're going to learn how to query data using chDB and JupySQL.
+
+<div class='vimeo-container'>
+<iframe width="560" height="315" src="https://www.youtube.com/embed/2wjl3OijCto?si=EVf2JhjS5fe4j6Cy" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" referrerpolicy="strict-origin-when-cross-origin" allowfullscreen></iframe>
+</div>
+
+## Setup
+Let's first create a virtual environment:
+
+```bash
+python -m venv .venv
+source .venv/bin/activate
+```
+
+And then, we'll install JupySQL, IPython, and Jupyter Lab:
+
+```bash
+pip install jupysql ipython jupyterlab
+```
+
+We can use JupySQL in IPython, which we can launch by running:
+
+```bash
+ipython
+```
+
+Or in Jupyter Lab, by running:
+
+```bash
+jupyter lab
+```
+
+:::note
+If you're using Jupyter Lab, you'll need to create a notebook before following the rest of the guide.
+:::
+
+## Downloading a dataset
+We're going to use one of [Jeff Sackmann's tennis_atp](https://github.com/JeffSackmann/tennis_atp) dataset, which contains metadata about players and their rankings over time.
+Let's start by downloading the rankings files:
+
+```python
+from urllib.request import urlretrieve
+```
+
+```python
+files = ['00s', '10s', '20s', '70s', '80s', '90s', 'current']
+base = "https://raw.githubusercontent.com/JeffSackmann/tennis_atp/master"
+for file in files:
+  _ = urlretrieve(
+    f"{base}/atp_rankings_{file}.csv",
+    f"atp_rankings_{file}.csv",
+  )
+```
+
+## Configuring chDB and JupySQL
+Next, let's import the `dbapi` module for chDB:
+
+```python
+from chdb import dbapi
+```
+
+And we'll create a chDB connection.
+Any data that we persist will be saved to the `atp.chdb` directory:
+
+```python
+conn = dbapi.connect(path="atp.chdb")
+```
+
+Let's now load the `sql` magic and create a connection to chDB:
+
+```python
+%load_ext sql
+%sql conn --alias chdb
+```
+
+Next, we'll display the display limit so that results of queries won't be truncated:
+
+```python
+%config SqlMagic.displaylimit = None
+```
+
+## Querying data in CSV files
+We've downloaded a bunch of files with the `atp_rankings` prefix.
+Let's use the `DESCRIBE` clause to understand the schema:
+
+```python
+%%sql
+DESCRIBE file('atp_rankings*.csv')
+SETTINGS describe_compact_output=1,
+         schema_inference_make_columns_nullable=0
+```
+
+```text
++--------------+-------+
+|     name     |  type |
++--------------+-------+
+| ranking_date | Int64 |
+|     rank     | Int64 |
+|    player    | Int64 |
+|    points    | Int64 |
++--------------+-------+
+```
+
+We can also write a `SELECT` query directly against these files to see what the data looks like:
+
+```python
+%sql SELECT * FROM file('atp_rankings*.csv') LIMIT 1
+```
+
+```text
++--------------+------+--------+--------+
+| ranking_date | rank | player | points |
++--------------+------+--------+--------+
+|   20000110   |  1   | 101736 |  4135  |
++--------------+------+--------+--------+
+```
+
+The format of the data is a bit weird.
+Let's clean that date up and use the `REPLACE` clause to return the cleaned up `ranking_date`:
+
+```python
+%%sql
+SELECT * REPLACE (
+  toDate(parseDateTime32BestEffort(toString(ranking_date))) AS ranking_date
+)
+FROM file('atp_rankings*.csv')
+LIMIT 10
+SETTINGS schema_inference_make_columns_nullable=0
+```
+
+```text
++--------------+------+--------+--------+
+| ranking_date | rank | player | points |
++--------------+------+--------+--------+
+|  2000-01-10  |  1   | 101736 |  4135  |
+|  2000-01-10  |  2   | 102338 |  2915  |
+|  2000-01-10  |  3   | 101948 |  2419  |
+|  2000-01-10  |  4   | 103017 |  2184  |
+|  2000-01-10  |  5   | 102856 |  2169  |
+|  2000-01-10  |  6   | 102358 |  2107  |
+|  2000-01-10  |  7   | 102839 |  1966  |
+|  2000-01-10  |  8   | 101774 |  1929  |
+|  2000-01-10  |  9   | 102701 |  1846  |
+|  2000-01-10  |  10  | 101990 |  1739  |
++--------------+------+--------+--------+
+```
+
+## Importing CSV files into chDB
+Now we're going to store the data from these CSV files in a table.
+The default database doesn't persist data on disk, so we need to create another database first:
+
+```python
+%sql CREATE DATABASE atp
+```
+
+And now we're going to create a table called `rankings` whose schema will be derived from the structure of the data in the CSV files:
+
+```python
+%%sql
+CREATE TABLE atp.rankings
+ENGINE=MergeTree
+ORDER BY ranking_date AS
+SELECT * REPLACE (
+  toDate(parseDateTime32BestEffort(toString(ranking_date))) AS ranking_date
+)
+FROM file('atp_rankings*.csv')
+SETTINGS schema_inference_make_columns_nullable=0
+```
+
+Let's do a quick check on the data in our table:
+
+```python
+%sql SELECT * FROM atp.rankings LIMIT 10
+```
+
+```text
++--------------+------+--------+--------+
+| ranking_date | rank | player | points |
++--------------+------+--------+--------+
+|  2000-01-10  |  1   | 101736 |  4135  |
+|  2000-01-10  |  2   | 102338 |  2915  |
+|  2000-01-10  |  3   | 101948 |  2419  |
+|  2000-01-10  |  4   | 103017 |  2184  |
+|  2000-01-10  |  5   | 102856 |  2169  |
+|  2000-01-10  |  6   | 102358 |  2107  |
+|  2000-01-10  |  7   | 102839 |  1966  |
+|  2000-01-10  |  8   | 101774 |  1929  |
+|  2000-01-10  |  9   | 102701 |  1846  |
+|  2000-01-10  |  10  | 101990 |  1739  |
++--------------+------+--------+--------+
+```
+
+Looks good - the output, as expected, is the same as when querying the CSV files directly.
+
+We're going to follow the same process for the player metadata.
+This time the data is all in a single CSV file, so let's download that file:
+
+```python
+_ = urlretrieve(
+    f"{base}/atp_players.csv",
+    "atp_players.csv",
+)
+```
+
+And then create a table called `players` based on the content of the CSV file.
+We'll also clean up the `dob` field so that its a `Date32` type.
+
+> In ClickHouse, the `Date` type only supports dates from 1970 onwards. Since the `dob` column contains dates from before 1970, we'll use the `Date32` type instead.
+
+```python
+%%sql
+CREATE TABLE atp.players
+Engine=MergeTree
+ORDER BY player_id AS
+SELECT * REPLACE (
+  makeDate32(
+    toInt32OrNull(substring(toString(dob), 1, 4)),
+    toInt32OrNull(substring(toString(dob), 5, 2)),
+    toInt32OrNull(substring(toString(dob), 7, 2))
+  )::Nullable(Date32) AS dob
+)
+FROM file('atp_players.csv')
+SETTINGS schema_inference_make_columns_nullable=0
+```
+
+Once that's finished running, we can have a look at the data we've ingested:
+
+```python
+%sql SELECT * FROM atp.players LIMIT 10
+```
+
+```text
++-----------+------------+-----------+------+------------+-----+--------+-------------+
+| player_id | name_first | name_last | hand |    dob     | ioc | height | wikidata_id |
++-----------+------------+-----------+------+------------+-----+--------+-------------+
+|   100001  |  Gardnar   |   Mulloy  |  R   | 1913-11-22 | USA |  185   |    Q54544   |
+|   100002  |   Pancho   |   Segura  |  R   | 1921-06-20 | ECU |  168   |    Q54581   |
+|   100003  |   Frank    |  Sedgman  |  R   | 1927-10-02 | AUS |  180   |   Q962049   |
+|   100004  |  Giuseppe  |   Merlo   |  R   | 1927-10-11 | ITA |   0    |   Q1258752  |
+|   100005  |  Richard   |  Gonzalez |  R   | 1928-05-09 | USA |  188   |    Q53554   |
+|   100006  |   Grant    |   Golden  |  R   | 1929-08-21 | USA |  175   |   Q3115390  |
+|   100007  |    Abe     |   Segal   |  L   | 1930-10-23 | RSA |   0    |   Q1258527  |
+|   100008  |    Kurt    |  Nielsen  |  R   | 1930-11-19 | DEN |   0    |   Q552261   |
+|   100009  |   Istvan   |   Gulyas  |  R   | 1931-10-14 | HUN |   0    |    Q51066   |
+|   100010  |    Luis    |   Ayala   |  R   | 1932-09-18 | CHI |  170   |   Q1275397  |
++-----------+------------+-----------+------+------------+-----+--------+-------------+
+```
+
+## Querying chDB
+Data ingestion is done, now it's time for the fun part - querying the data!
+
+Tennis players receive points based on how well they perform in the tournaments they play.
+The points for each player over a 52 week rolling period.
+We're going to write a query that finds the maximum points accumulate by each player along with their ranking at the time:
+
+```python
+%%sql
+SELECT name_first, name_last,
+       max(points) as maxPoints,
+       argMax(rank, points) as rank,
+       argMax(ranking_date, points) as date
+FROM atp.players
+JOIN atp.rankings ON rankings.player = players.player_id
+GROUP BY ALL
+ORDER BY maxPoints DESC
+LIMIT 10
+```
+
+```text
++------------+-----------+-----------+------+------------+
+| name_first | name_last | maxPoints | rank |    date    |
++------------+-----------+-----------+------+------------+
+|   Novak    |  Djokovic |   16950   |  1   | 2016-06-06 |
+|   Rafael   |   Nadal   |   15390   |  1   | 2009-04-20 |
+|    Andy    |   Murray  |   12685   |  1   | 2016-11-21 |
+|   Roger    |  Federer  |   12315   |  1   | 2012-10-29 |
+|   Daniil   |  Medvedev |   10780   |  2   | 2021-09-13 |
+|   Carlos   |  Alcaraz  |    9815   |  1   | 2023-08-21 |
+|  Dominic   |   Thiem   |    9125   |  3   | 2021-01-18 |
+|   Jannik   |   Sinner  |    8860   |  2   | 2024-05-06 |
+|  Stefanos  | Tsitsipas |    8350   |  3   | 2021-09-20 |
+| Alexander  |   Zverev  |    8240   |  4   | 2021-08-23 |
++------------+-----------+-----------+------+------------+
+```
+
+It's quite interesting that some of the players in this list accumulated a lot of points without being number 1 with that points total.
+
+## Saving queries
+We can save queries using the `--save` parameter on the same line as the `%%sql` magic.
+The `--no-execute` parameter means that query execution will be skipped.
+
+```python
+%%sql --save best_points --no-execute
+SELECT name_first, name_last,
+       max(points) as maxPoints,
+       argMax(rank, points) as rank,
+       argMax(ranking_date, points) as date
+FROM atp.players
+JOIN atp.rankings ON rankings.player = players.player_id
+GROUP BY ALL
+ORDER BY maxPoints DESC
+```
+
+When we run a saved query it will be converted into a Common Table Expression (CTE) before executing.
+In the following query we compute the maximum points achieved by players when they were ranked 1:
+
+```python
+%sql select * FROM best_points WHERE rank=1
+```
+
+```text
++-------------+-----------+-----------+------+------------+
+|  name_first | name_last | maxPoints | rank |    date    |
++-------------+-----------+-----------+------+------------+
+|    Novak    |  Djokovic |   16950   |  1   | 2016-06-06 |
+|    Rafael   |   Nadal   |   15390   |  1   | 2009-04-20 |
+|     Andy    |   Murray  |   12685   |  1   | 2016-11-21 |
+|    Roger    |  Federer  |   12315   |  1   | 2012-10-29 |
+|    Carlos   |  Alcaraz  |    9815   |  1   | 2023-08-21 |
+|     Pete    |  Sampras  |    5792   |  1   | 1997-08-11 |
+|    Andre    |   Agassi  |    5652   |  1   | 1995-08-21 |
+|   Lleyton   |   Hewitt  |    5205   |  1   | 2002-08-12 |
+|   Gustavo   |  Kuerten  |    4750   |  1   | 2001-09-10 |
+| Juan Carlos |  Ferrero  |    4570   |  1   | 2003-10-20 |
+|    Stefan   |   Edberg  |    3997   |  1   | 1991-02-25 |
+|     Jim     |  Courier  |    3973   |  1   | 1993-08-23 |
+|     Ivan    |   Lendl   |    3420   |  1   | 1990-02-26 |
+|     Ilie    |  Nastase  |     0     |  1   | 1973-08-27 |
++-------------+-----------+-----------+------+------------+
+```
+
+## Querying with parameters
+We can also use parameters in our queries.
+Parameters are just normal variables:
+
+```python
+rank = 10
+```
+
+And then we can use the `{{variable}}` syntax in our query.
+The following query finds the players who had the least number of days between when they first had a ranking in the top 10 and last had a ranking in the top 10:
+
+```python
+%%sql
+SELECT name_first, name_last,
+       MIN(ranking_date) AS earliest_date,
+       MAX(ranking_date) AS most_recent_date,
+       most_recent_date - earliest_date AS days,
+       1 + (days/7) AS weeks
+FROM atp.rankings
+JOIN atp.players ON players.player_id = rankings.player
+WHERE rank <= {{rank}}
+GROUP BY ALL
+ORDER BY days
+LIMIT 10
+```
+
+```text
++------------+-----------+---------------+------------------+------+-------+
+| name_first | name_last | earliest_date | most_recent_date | days | weeks |
++------------+-----------+---------------+------------------+------+-------+
+|    Alex    | Metreveli |   1974-06-03  |    1974-06-03    |  0   |   1   |
+|   Mikael   |  Pernfors |   1986-09-22  |    1986-09-22    |  0   |   1   |
+|   Felix    |  Mantilla |   1998-06-08  |    1998-06-08    |  0   |   1   |
+|   Wojtek   |   Fibak   |   1977-07-25  |    1977-07-25    |  0   |   1   |
+|  Thierry   |  Tulasne  |   1986-08-04  |    1986-08-04    |  0   |   1   |
+|   Lucas    |  Pouille  |   2018-03-19  |    2018-03-19    |  0   |   1   |
+|    John    | Alexander |   1975-12-15  |    1975-12-15    |  0   |   1   |
+|  Nicolas   |   Massu   |   2004-09-13  |    2004-09-20    |  7   |   2   |
+|   Arnaud   |  Clement  |   2001-04-02  |    2001-04-09    |  7   |   2   |
+|  Ernests   |   Gulbis  |   2014-06-09  |    2014-06-23    |  14  |   3   |
++------------+-----------+---------------+------------------+------+-------+
+```
+
+## Plotting histograms
+JupySQL also has limited charting functionality.
+We can create box plots or histograms.
+
+We're going to create a histogram, but first let's write (and save) a query that computes the rankings within the top 100 that each player has achieved.
+We'll be able to use this to create a histogram that counts how many players achieved each ranking:
+
+```python
+%%sql --save players_per_rank --no-execute
+select distinct player, rank
+FROM atp.rankings
+WHERE rank <= 100
+```
+
+We can then create a histogram by running the following:
+
+```python
+from sql.ggplot import ggplot, geom_histogram, aes
+
+plot = (
+  ggplot(
+    table="players_per_rank",
+    with_="players_per_rank",
+    mapping=aes(x="rank", fill="#69f0ae", color="#fff"),
+  ) + geom_histogram(bins=100)
+)
+```
+
+<Image img={PlayersPerRank} size="md" alt="Histogram of player rankings in ATP dataset" />
+
+---
+
+# Migration from pandas
+
+**URL:** https://clickhouse.com/docs/chdb/guides/migration-from-pandas
+
+Step-by-step guide to migrate from pandas to DataStore
+
+This guide helps you migrate existing pandas code to DataStore for better performance while maintaining compatibility.
+
+## The One-Line Migration
+The simplest migration is changing your import:
+
+```python
+# Before (pandas)
+
+# After (DataStore)
+from chdb import datastore as pd
+```
+
+That's it! Most pandas code works unchanged.
+
+## Step-by-Step Migration
+<VerticalStepper headerLevel="h3">
+
+### Install chDB
+```bash
+pip install "chdb>=4.0"
+```
+
+### Change the Import
+```python
+# Change this:
+
+# To this:
+from chdb import datastore as pd
+```
+
+### Test Your Code
+Run your existing code. Most operations work unchanged:
+
+```python
+from chdb import datastore as pd
+
+# These all work the same
+df = pd.read_csv("data.csv")
+result = df[df['age'] > 25]
+grouped = df.groupby('city')['salary'].mean()
+df.to_csv("output.csv")
+```
+
+### Handle Any Differences
+A few operations behave differently. See [Key Differences](#differences) below.
+
+</VerticalStepper>
+
+---
+
+## What Works Unchanged
+### Data Loading
+```python
+# All these work the same
+df = pd.read_csv("data.csv")
+df = pd.read_parquet("data.parquet")
+df = pd.read_json("data.json")
+df = pd.read_excel("data.xlsx")
+```
+
+### Filtering
+```python
+# Boolean indexing
+df[df['age'] > 25]
+df[(df['age'] > 25) & (df['city'] == 'NYC')]
+
+# query() method
+df.query('age > 25 and salary > 50000')
+```
+
+### Selection
+```python
+# Column selection
+df['name']
+df[['name', 'age']]
+
+# Row selection
+df.head(10)
+df.tail(10)
+df.iloc[0:100]
+```
+
+### GroupBy and Aggregation
+```python
+# GroupBy
+df.groupby('city')['salary'].mean()
+df.groupby(['city', 'dept']).agg({'salary': ['sum', 'mean']})
+```
+
+### Sorting
+```python
+df.sort_values('salary', ascending=False)
+df.sort_values(['city', 'age'])
+```
+
+### String Operations
+```python
+df['name'].str.upper()
+df['name'].str.contains('John')
+df['name'].str.len()
+```
+
+### DateTime Operations
+```python
+df['date'].dt.year
+df['date'].dt.month
+df['date'].dt.dayofweek
+```
+
+### I/O Operations
+```python
+df.to_csv("output.csv")
+df.to_parquet("output.parquet")
+df.to_json("output.json")
+```
+
+---
+
+## Key Differences
+### 1. Lazy Evaluation
+DataStore operations are lazy - they don't execute until results are needed.
+
+**pandas:**
+```python
+# Executes immediately
+result = df[df['age'] > 25]
+print(type(result))  # pandas.DataFrame
+```
+
+**DataStore:**
+```python
+# Builds query, doesn't execute yet
+result = ds[ds['age'] > 25]
+print(type(result))  # DataStore (lazy)
+
+# Executes when you need the data
+print(result)        # Triggers execution
+df = result.to_df()  # Triggers execution
+```
+
+### 2. Return Types
+| Operation | pandas Returns | DataStore Returns |
+|-----------|---------------|-------------------|
+| `df['col']` | Series | ColumnExpr (lazy) |
+| `df[['a', 'b']]` | DataFrame | DataStore (lazy) |
+| `df[condition]` | DataFrame | DataStore (lazy) |
+| `df.groupby('x')` | GroupBy | LazyGroupBy |
+
+### 3. No inplace Parameter
+DataStore doesn't support `inplace=True`. Always use the return value:
+
+**pandas:**
+```python
+df.drop(columns=['col'], inplace=True)
+```
+
+**DataStore:**
+```python
+ds = ds.drop(columns=['col'])  # Assign the result
+```
+
+### 4. Comparing DataStores
+pandas doesn't recognize DataStore objects, so use `to_pandas()` for comparison:
+
+```python
+# This may not work as expected
+df == ds  # pandas doesn't know DataStore
+
+# Do this instead
+df.equals(ds.to_pandas())
+```
+
+### 5. Row Order
+DataStore may not preserve row order for file sources (like SQL databases). Use explicit sorting:
+
+```python
+# pandas preserves order
+df = pd.read_csv("data.csv")
+
+# DataStore - use sort for guaranteed order
+ds = pd.read_csv("data.csv")
+ds = ds.sort('id')  # Explicit ordering
+```
+
+---
+
+## Migration Patterns
+### Pattern 1: Read-Analyze-Write
+```python
+# pandas
+
+df = pd.read_csv("data.csv")
+result = df[df['amount'] > 100].groupby('category')['amount'].sum()
+result.to_csv("output.csv")
+
+# DataStore - same code works!
+from chdb import datastore as pd
+df = pd.read_csv("data.csv")
+result = df[df['amount'] > 100].groupby('category')['amount'].sum()
+result.to_csv("output.csv")
+```
+
+### Pattern 2: DataFrame with pandas Operations
+If you need pandas-specific features, convert at the end:
+
+```python
+from chdb import datastore as pd
+
+# Fast DataStore operations
+ds = pd.read_csv("large_data.csv")
+ds = ds.filter(ds['date'] >= '2024-01-01')
+ds = ds.filter(ds['amount'] > 100)
+
+# Convert to pandas for specific features
+df = ds.to_df()
+df_pivoted = df.pivot_table(...)  # pandas-specific
+```
+
+### Pattern 3: Mixed Workflow
+```python
+from chdb import datastore as pd
+
+# Start with DataStore for fast filtering
+ds = pd.read_csv("huge_file.csv")  # 10M rows
+ds = ds.filter(ds['year'] == 2024)  # Fast SQL filter
+ds = ds.select('col1', 'col2', 'col3')  # Column pruning
+
+# Convert for pandas-specific operations
+df = ds.to_df()  # Now only ~100K rows
+result = df.apply(complex_custom_function)  # pandas
+```
+
+---
+
+## Performance Comparison
+DataStore is significantly faster for large datasets:
+
+| Operation | pandas | DataStore | Speedup |
+|-----------|--------|-----------|---------|
+| GroupBy count | 347ms | 17ms | **19.93x** |
+| Complex pipeline | 2,047ms | 380ms | **5.39x** |
+| Filter+Sort+Head | 1,537ms | 350ms | **4.40x** |
+| GroupBy agg | 406ms | 141ms | **2.88x** |
+
+*Benchmark on 10M rows*
+
+---
+
+## Troubleshooting Migration
+### Issue: Operation Not Working
+Some pandas operations may not be supported. Check:
+
+1. Is the operation in the [compatibility list](../datastore/pandas-compat.md)?
+2. Try converting to pandas first: `ds.to_df().operation()`
+
+### Issue: Different Results
+Enable debug logging to understand what's happening:
+
+```python
+from chdb.datastore.config import config
+config.enable_debug()
+
+# View the SQL being generated
+ds.filter(ds['x'] > 10).explain()
+```
+
+### Issue: Slow Performance
+Check your execution pattern:
+
+```python
+# Bad: Multiple small executions
+for i in range(1000):
+    result = ds.filter(ds['id'] == i).to_df()
+
+# Good: Single execution
+result = ds.filter(ds['id'].isin(ids)).to_df()
+```
+
+### Issue: Type Mismatches
+DataStore may infer types differently:
+
+```python
+# Check types
+print(ds.dtypes)
+
+# Force conversion
+ds['col'] = ds['col'].astype('int64')
+```
+
+---
+
+## Gradual Migration Strategy
+### Week 1: Test Compatibility
+```python
+# Keep both imports
+
+from chdb import datastore as ds
+
+# Compare results
+pdf = pd.read_csv("data.csv")
+dsf = ds.read_csv("data.csv")
+
+# Verify they match
+assert pdf.equals(dsf.to_pandas())
+```
+
+### Week 2: Switch Simple Scripts
+Start with scripts that:
+- Read large files
+- Do filtering and aggregation
+- Don't use custom apply functions
+
+### Week 3: Handle Complex Cases
+For scripts with custom functions:
+
+```python
+from chdb import datastore as pd
+
+# Let DataStore handle the heavy lifting
+ds = pd.read_csv("data.csv")
+ds = ds.filter(ds['year'] == 2024)  # SQL
+
+# Convert for custom work
+df = ds.to_df()
+result = df.apply(my_custom_function)
+```
+
+### Week 4: Full Migration
+Switch all scripts to DataStore import.
+
+---
+
+## FAQ
+### Can I use both pandas and DataStore?
+Yes! Convert between them freely:
+
+```python
+from chdb import datastore as ds
+
+# DataStore to pandas
+df = ds_result.to_pandas()
+
+# pandas to DataStore  
+ds = ds.DataFrame(pd_result)
+```
+
+### Will my tests still pass?
+Most tests should pass. For comparison tests, convert to pandas:
+
+```python
+def test_my_function():
+    result = my_function()
+    expected = pd.DataFrame(...)
+    pd.testing.assert_frame_equal(result.to_pandas(), expected)
+```
+
+### Can I use DataStore in Jupyter?
+Yes! DataStore works in Jupyter notebooks:
+
+```python
+from chdb import datastore as pd
+
+ds = pd.read_csv("data.csv")
+ds.head()  # Displays nicely in Jupyter
+```
+
+### How do I report issues?
+If you find compatibility issues, report them at:
+https://github.com/chdb-io/chdb/issues
+
+---
+
+# Pandas cookbook
+
+**URL:** https://clickhouse.com/docs/chdb/guides/pandas-cookbook
+
+Common pandas patterns and their DataStore equivalents
+
+Common pandas patterns and their DataStore equivalents. Most code works unchanged!
+
+## Data Loading
+### Read CSV
+```python
+# Pandas
+
+df = pd.read_csv("data.csv")
+
+# DataStore - same!
+from chdb import datastore as pd
+df = pd.read_csv("data.csv")
+```
+
+### Read Multiple Files
+```python
+# Pandas
+
+dfs = [pd.read_csv(f) for f in glob.glob("data/*.csv")]
+df = pd.concat(dfs)
+
+# DataStore - more efficient with glob pattern
+df = pd.read_csv("data/*.csv")
+```
+
+---
+
+## Filtering
+### Single Condition
+```python
+# Pandas and DataStore - identical
+df[df['age'] > 25]
+df[df['city'] == 'NYC']
+df[df['name'].str.contains('John')]
+```
+
+### Multiple Conditions
+```python
+# AND
+df[(df['age'] > 25) & (df['city'] == 'NYC')]
+
+# OR
+df[(df['age'] < 18) | (df['age'] > 65)]
+
+# NOT
+df[~(df['status'] == 'inactive')]
+```
+
+### Using query()
+```python
+# Pandas and DataStore - identical
+df.query('age > 25 and city == "NYC"')
+df.query('salary > 50000')
+```
+
+### isin()
+```python
+# Pandas and DataStore - identical
+df[df['city'].isin(['NYC', 'LA', 'SF'])]
+```
+
+### between()
+```python
+# Pandas and DataStore - identical
+df[df['age'].between(18, 65)]
+```
+
+---
+
+## Selecting Columns
+### Single Column
+```python
+# Pandas and DataStore - identical
+df['name']
+df.name  # attribute access
+```
+
+### Multiple Columns
+```python
+# Pandas and DataStore - identical
+df[['name', 'age', 'city']]
+```
+
+### Select and Filter
+```python
+# Pandas and DataStore - identical
+df[df['age'] > 25][['name', 'salary']]
+
+# DataStore also supports SQL-style
+df.filter(df['age'] > 25).select('name', 'salary')
+```
+
+---
+
+## Sorting
+### Single Column
+```python
+# Pandas and DataStore - identical
+df.sort_values('salary')
+df.sort_values('salary', ascending=False)
+```
+
+### Multiple Columns
+```python
+# Pandas and DataStore - identical
+df.sort_values(['city', 'salary'], ascending=[True, False])
+```
+
+### Get Top/Bottom N
+```python
+# Pandas and DataStore - identical
+df.nlargest(10, 'salary')
+df.nsmallest(5, 'age')
+```
+
+---
+
+## GroupBy and Aggregation
+### Simple GroupBy
+```python
+# Pandas and DataStore - identical
+df.groupby('city')['salary'].mean()
+df.groupby('city')['salary'].sum()
+df.groupby('city').size()  # count
+```
+
+### Multiple Aggregations
+```python
+# Pandas and DataStore - identical
+df.groupby('city')['salary'].agg(['sum', 'mean', 'count'])
+
+df.groupby('city').agg({
+    'salary': ['sum', 'mean'],
+    'age': ['min', 'max']
+})
+```
+
+### Named Aggregations
+```python
+# Pandas and DataStore - identical
+df.groupby('city').agg(
+    total_salary=('salary', 'sum'),
+    avg_salary=('salary', 'mean'),
+    employee_count=('id', 'count')
+)
+```
+
+### Multiple GroupBy Keys
+```python
+# Pandas and DataStore - identical
+df.groupby(['city', 'department'])['salary'].mean()
+```
+
+---
+
+## Joining Data
+### Inner Join
+```python
+# Pandas
+pd.merge(df1, df2, on='id')
+
+# DataStore - same API
+pd.merge(df1, df2, on='id')
+
+# DataStore also supports
+df1.join(df2, on='id')
+```
+
+### Left Join
+```python
+# Pandas and DataStore - identical
+pd.merge(df1, df2, on='id', how='left')
+```
+
+### Join on Different Columns
+```python
+# Pandas and DataStore - identical
+pd.merge(df1, df2, left_on='emp_id', right_on='id')
+```
+
+### Concat
+```python
+# Pandas and DataStore - identical
+pd.concat([df1, df2, df3])
+pd.concat([df1, df2], axis=1)
+```
+
+---
+
+## String Operations
+### Case Conversion
+```python
+# Pandas and DataStore - identical
+df['name'].str.upper()
+df['name'].str.lower()
+df['name'].str.title()
+```
+
+### Substring
+```python
+# Pandas and DataStore - identical
+df['name'].str[:3]        # First 3 characters
+df['name'].str.slice(0, 3)
+```
+
+### Search
+```python
+# Pandas and DataStore - identical
+df['name'].str.contains('John')
+df['name'].str.startswith('A')
+df['name'].str.endswith('son')
+```
+
+### Replace
+```python
+# Pandas and DataStore - identical
+df['text'].str.replace('old', 'new')
+df['text'].str.replace(r'\d+', '', regex=True)  # Remove digits
+```
+
+### Split
+```python
+# Pandas and DataStore - identical
+df['name'].str.split(' ')
+df['name'].str.split(' ', expand=True)
+```
+
+### Length
+```python
+# Pandas and DataStore - identical
+df['name'].str.len()
+```
+
+---
+
+## DateTime Operations
+### Extract Components
+```python
+# Pandas and DataStore - identical
+df['date'].dt.year
+df['date'].dt.month
+df['date'].dt.day
+df['date'].dt.dayofweek
+df['date'].dt.hour
+```
+
+### Formatting
+```python
+# Pandas and DataStore - identical
+df['date'].dt.strftime('%Y-%m-%d')
+```
+
+---
+
+## Missing Data
+### Check Missing
+```python
+# Pandas and DataStore - identical
+df['col'].isna()
+df['col'].notna()
+df.isna().sum()
+```
+
+### Drop Missing
+```python
+# Pandas and DataStore - identical
+df.dropna()
+df.dropna(subset=['col1', 'col2'])
+```
+
+### Fill Missing
+```python
+# Pandas and DataStore - identical
+df.fillna(0)
+df.fillna({'col1': 0, 'col2': 'Unknown'})
+df.fillna(method='ffill')
+```
+
+---
+
+## Creating New Columns
+### Simple Assignment
+```python
+# Pandas and DataStore - identical
+df['total'] = df['price'] * df['quantity']
+df['age_group'] = df['age'] // 10 * 10
+```
+
+### Using assign()
+```python
+# Pandas and DataStore - identical
+df = df.assign(
+    total=df['price'] * df['quantity'],
+    is_adult=df['age'] >= 18
+)
+```
+
+### Conditional (where/mask)
+```python
+# Pandas and DataStore - identical
+df['status'] = df['age'].where(df['age'] >= 18, 'minor')
+```
+
+### apply() for Custom Logic
+```python
+# Works, but triggers pandas execution
+df['category'] = df['amount'].apply(lambda x: 'high' if x > 1000 else 'low')
+
+# DataStore alternative (stays lazy)
+df['category'] = (
+    df.when(df['amount'] > 1000, 'high')
+      .otherwise('low')
+)
+```
+
+---
+
+## Reshaping
+### Pivot Table
+```python
+# Pandas and DataStore - identical
+df.pivot_table(
+    values='amount',
+    index='region',
+    columns='product',
+    aggfunc='sum'
+)
+```
+
+### Melt (Unpivot)
+```python
+# Pandas and DataStore - identical
+df.melt(
+    id_vars=['name'],
+    value_vars=['score1', 'score2', 'score3'],
+    var_name='test',
+    value_name='score'
+)
+```
+
+### Explode
+```python
+# Pandas and DataStore - identical
+df.explode('tags')  # Expand array column
+```
+
+---
+
+## Window Functions
+### Rolling
+```python
+# Pandas and DataStore - identical
+df['rolling_avg'] = df['price'].rolling(window=7).mean()
+df['rolling_sum'] = df['amount'].rolling(window=30).sum()
+```
+
+### Expanding
+```python
+# Pandas and DataStore - identical
+df['cumsum'] = df['amount'].expanding().sum()
+df['cummax'] = df['amount'].expanding().max()
+```
+
+### Shift
+```python
+# Pandas and DataStore - identical
+df['prev_value'] = df['value'].shift(1)   # Lag
+df['next_value'] = df['value'].shift(-1)  # Lead
+```
+
+### Diff
+```python
+# Pandas and DataStore - identical
+df['change'] = df['value'].diff()
+df['pct_change'] = df['value'].pct_change()
+```
+
+---
+
+## Output
+### To CSV
+```python
+# Pandas and DataStore - identical
+df.to_csv("output.csv", index=False)
+```
+
+### To Parquet
+```python
+# Pandas and DataStore - identical
+df.to_parquet("output.parquet")
+```
+
+### To pandas DataFrame
+```python
+# DataStore specific
+pandas_df = ds.to_df()
+pandas_df = ds.to_pandas()
+```
+
+---
+
+## DataStore Extras
+### View SQL
+```python
+# DataStore only
+print(ds.to_sql())
+```
+
+### Explain Plan
+```python
+# DataStore only
+ds.explain()
+```
+
+### ClickHouse Functions
+```python
+# DataStore only - extra accessors
+df['domain'] = df['url'].url.domain()
+df['json_value'] = df['data'].json.get_string('key')
+df['ip_valid'] = df['ip'].ip.is_ipv4_string()
+```
+
+### Universal URI
+```python
+# DataStore only - read from anywhere
+ds = DataStore.uri("s3://bucket/data.parquet")
+ds = DataStore.uri("mysql://user:pass@host/db/table")
+```
+
+---
+
+# Key differences from pandas
+
+**URL:** https://clickhouse.com/docs/chdb/guides/pandas-differences
+
+Important differences between DataStore and pandas
+
+While DataStore is highly compatible with pandas, there are important differences to understand.
+
+## Summary Table
+| Aspect | pandas | DataStore |
+|--------|--------|-----------|
+| **Execution** | Eager (immediate) | Lazy (deferred) |
+| **Return types** | DataFrame/Series | DataStore/ColumnExpr |
+| **Row order** | Preserved | Preserved (automatic); not guaranteed in [performance mode](../configuration/performance-mode.md) |
+| **inplace** | Supported | Not supported |
+| **Index** | Full support | Simplified |
+| **Memory** | All data in memory | Data at source |
+
+---
+
+## 1. Lazy vs Eager Execution
+### pandas (Eager)
+Operations execute immediately:
+
+```python
+
+df = pd.read_csv("data.csv")  # Loads entire file NOW
+result = df[df['age'] > 25]   # Filters NOW
+grouped = result.groupby('city')['salary'].mean()  # Aggregates NOW
+```
+
+### DataStore (Lazy)
+Operations are deferred until results are needed:
+
+```python
+from chdb import datastore as pd
+
+ds = pd.read_csv("data.csv")  # Just records the source
+result = ds[ds['age'] > 25]   # Just records the filter
+grouped = result.groupby('city')['salary'].mean()  # Just records
+
+# Execution happens here:
+print(grouped)        # Executes when displaying
+df = grouped.to_df()  # Or when converting to pandas
+```
+
+### Why It Matters
+Lazy execution enables:
+- **Query optimization**: Multiple operations compile to one SQL query
+- **Column pruning**: Only needed columns are read
+- **Filter pushdown**: Filters apply at the source
+- **Memory efficiency**: Don't load data you don't need
+
+---
+
+## 2. Return Types
+### pandas
+```python
+df['col']           # Returns pd.Series
+df[['a', 'b']]      # Returns pd.DataFrame
+df[df['x'] > 10]    # Returns pd.DataFrame
+df.groupby('x')     # Returns DataFrameGroupBy
+```
+
+### DataStore
+```python
+ds['col']           # Returns ColumnExpr (lazy)
+ds[['a', 'b']]      # Returns DataStore (lazy)
+ds[ds['x'] > 10]    # Returns DataStore (lazy)
+ds.groupby('x')     # Returns LazyGroupBy
+```
+
+### Converting to pandas Types
+```python
+# Get pandas DataFrame
+df = ds.to_df()
+df = ds.to_pandas()
+
+# Get pandas Series from column
+series = ds['col'].to_pandas()
+
+# Or trigger execution
+print(ds)  # Automatically converts for display
+```
+
+---
+
+## 3. Execution Triggers
+DataStore executes when you need actual values:
+
+| Trigger | Example | Notes |
+|---------|---------|-------|
+| `print()` / `repr()` | `print(ds)` | Display needs data |
+| `len()` | `len(ds)` | Need row count |
+| `.columns` | `ds.columns` | Need column names |
+| `.dtypes` | `ds.dtypes` | Need type info |
+| `.shape` | `ds.shape` | Need dimensions |
+| `.values` | `ds.values` | Need actual data |
+| `.index` | `ds.index` | Need index |
+| `to_df()` | `ds.to_df()` | Explicit conversion |
+| Iteration | `for row in ds` | Need to iterate |
+| `equals()` | `ds.equals(other)` | Need comparison |
+
+### Operations That Stay Lazy
+| Operation | Returns |
+|-----------|---------|
+| `filter()` | DataStore |
+| `select()` | DataStore |
+| `sort()` | DataStore |
+| `groupby()` | LazyGroupBy |
+| `join()` | DataStore |
+| `ds['col']` | ColumnExpr |
+| `ds[['a', 'b']]` | DataStore |
+| `ds[condition]` | DataStore |
+
+---
+
+## 4. Row Order
+### pandas
+Row order is always preserved:
+
+```python
+df = pd.read_csv("data.csv")
+print(df.head())  # Always same order as file
+```
+
+### DataStore
+Row order is **automatically preserved** for most operations:
+
+```python
+ds = pd.read_csv("data.csv")
+print(ds.head())  # Matches file order
+
+# Filter preserves order
+ds_filtered = ds[ds['age'] > 25]  # Same order as pandas
+```
+
+DataStore automatically tracks original row positions internally (using `rowNumberInAllBlocks()`) to ensure order consistency with pandas.
+
+### When Order Is Preserved
+- File sources (CSV, Parquet, JSON, etc.)
+- pandas DataFrame sources
+- Filter operations
+- Column selection
+- After explicit `sort()` or `sort_values()`
+- Operations that define order (`nlargest()`, `nsmallest()`, `head()`, `tail()`)
+
+### When Order May Differ
+- After `groupby()` aggregations (use `sort_values()` to ensure consistent order)
+- After `merge()` / `join()` with certain join types
+- In **performance mode** (`config.use_performance_mode()`): row order is not guaranteed for any operation. See [Performance Mode](../configuration/performance-mode.md).
+
+---
+
+## 5. No inplace Parameter
+### pandas
+```python
+df.drop(columns=['col'], inplace=True)  # Modifies df
+df.fillna(0, inplace=True)              # Modifies df
+df.rename(columns={'old': 'new'}, inplace=True)
+```
+
+### DataStore
+`inplace=True` is not supported. Always assign the result:
+
+```python
+ds = ds.drop(columns=['col'])           # Returns new DataStore
+ds = ds.fillna(0)                       # Returns new DataStore
+ds = ds.rename(columns={'old': 'new'})  # Returns new DataStore
+```
+
+### Why No inplace?
+DataStore uses immutable operations to enable:
+- Query building (lazy evaluation)
+- Thread safety
+- Easier debugging
+- Cleaner code
+
+---
+
+## 6. Index Support
+### pandas
+Full index support:
+
+```python
+df = df.set_index('id')
+df.loc['user123']           # Label-based access
+df.loc['a':'z']             # Label-based slicing
+df.reset_index()
+df.index.name = 'user_id'
+```
+
+### DataStore
+Simplified index support:
+
+```python
+# Basic operations work
+ds.loc[0:10]               # Integer position
+ds.iloc[0:10]              # Same as loc for DataStore
+
+# For pandas-style index operations, convert first
+df = ds.to_df()
+df = df.set_index('id')
+df.loc['user123']
+```
+
+### DataStore Source Matters
+- **DataFrame source**: Preserves pandas index
+- **File source**: Uses simple integer index
+
+---
+
+## 7. Comparison Behavior
+### Comparing with pandas
+pandas doesn't recognize DataStore objects:
+
+```python
+
+from chdb import datastore as ds
+
+pdf = pd.DataFrame({'a': [1, 2, 3]})
+dsf = ds.DataFrame({'a': [1, 2, 3]})
+
+# This doesn't work as expected
+pdf == dsf  # pandas doesn't know DataStore
+
+# Solution: convert DataStore to pandas
+pdf.equals(dsf.to_pandas())  # True
+```
+
+### Using equals()
+```python
+# DataStore.equals() also works
+dsf.equals(pdf)  # Compares with pandas DataFrame
+```
+
+---
+
+## 8. Type Inference
+### pandas
+Uses numpy/pandas types:
+
+```python
+df['col'].dtype  # int64, float64, object, datetime64, etc.
+```
+
+### DataStore
+May use ClickHouse types:
+
+```python
+ds['col'].dtype  # Int64, Float64, String, DateTime, etc.
+
+# Types are converted when going to pandas
+df = ds.to_df()
+df['col'].dtype  # Now pandas type
+```
+
+### Explicit Casting
+```python
+# Force specific type
+ds['col'] = ds['col'].astype('int64')
+```
+
+---
+
+## 9. Memory Model
+### pandas
+All data lives in memory:
+
+```python
+df = pd.read_csv("huge.csv")  # 10GB in memory!
+```
+
+### DataStore
+Data stays at source until needed:
+
+```python
+ds = pd.read_csv("huge.csv")  # Just metadata
+ds = ds.filter(ds['year'] == 2024)  # Still just metadata
+
+# Only filtered result is loaded
+df = ds.to_df()  # Maybe only 1GB now
+```
+
+---
+
+## 10. Error Messages
+### Different Error Sources
+- **pandas errors**: From pandas library
+- **DataStore errors**: From chDB or ClickHouse
+
+```python
+# May see ClickHouse-style errors
+# "Code: 62. DB::Exception: Syntax error..."
+```
+
+### Debugging Tips
+```python
+# View the SQL to debug
+print(ds.to_sql())
+
+# See execution plan
+ds.explain()
+
+# Enable debug logging
+from chdb.datastore.config import config
+config.enable_debug()
+```
+
+---
+
+## Migration Checklist
+When migrating from pandas:
+
+- [ ] Change import statement
+- [ ] Remove `inplace=True` parameters
+- [ ] Add explicit `to_df()` where pandas DataFrame is required
+- [ ] Add sorting if row order matters
+- [ ] Use `to_pandas()` for comparison tests
+- [ ] Test with representative data sizes
+
+---
+
+## Quick Reference
+| pandas | DataStore |
+|--------|-----------|
+| `df[condition]` | Same (returns DataStore) |
+| `df.groupby()` | Same (returns LazyGroupBy) |
+| `df.drop(inplace=True)` | `ds = ds.drop()` |
+| `df.equals(other)` | `ds.to_pandas().equals(other)` |
+| `df.loc['label']` | `ds.to_df().loc['label']` |
+| `print(df)` | Same (triggers execution) |
+| `len(df)` | Same (triggers execution) |
+
+---
+
+# Performance guide
+
+**URL:** https://clickhouse.com/docs/chdb/guides/pandas-performance
+
+Performance optimization tips for DataStore vs pandas
+
+DataStore delivers significant performance improvements over pandas for many operations. This guide explains why and how to optimize your workloads.
+
+## Why DataStore Is Faster
+### 1. SQL Pushdown
+Operations are pushed down to the data source:
+
+```python
+# pandas: Loads ALL data, then filters in memory
+df = pd.read_csv("huge.csv")       # Load 10GB
+df = df[df['year'] == 2024]        # Filter in Python
+
+# DataStore: Filter at source
+ds = pd.read_csv("huge.csv")       # Just metadata
+ds = ds[ds['year'] == 2024]        # Filter in SQL
+df = ds.to_df()                    # Only load filtered data
+```
+
+### 2. Column Pruning
+Only needed columns are read:
+
+```python
+# DataStore: Only reads name, age columns
+ds = pd.read_parquet("wide_table.parquet")
+result = ds.select('name', 'age').to_df()
+
+# vs pandas: Reads all 100 columns, then selects
+```
+
+### 3. Lazy Evaluation
+Multiple operations compile to one query:
+
+```python
+# DataStore: One optimized SQL query
+result = (ds
+    .filter(ds['amount'] > 100)
+    .groupby('region')
+    .agg({'amount': 'sum'})
+    .sort('sum', ascending=False)
+    .head(10)
+    .to_df()
+)
+
+# Becomes:
+# SELECT region, SUM(amount) FROM data
+# WHERE amount > 100
+# GROUP BY region ORDER BY sum DESC LIMIT 10
+```
+
+---
+
+## Benchmark: DataStore vs pandas
+### Test Environment
+- Data: 10 million rows
+- Hardware: Standard laptop
+- File format: CSV
+
+### Results
+| Operation | pandas (ms) | DataStore (ms) | Winner |
+|-----------|-------------|----------------|--------|
+| GroupBy count | 347 | 17 | **DataStore (19.93x)** |
+| Combined ops | 1,535 | 234 | **DataStore (6.56x)** |
+| Complex pipeline | 2,047 | 380 | **DataStore (5.39x)** |
+| MultiFilter+Sort+Head | 1,963 | 366 | **DataStore (5.36x)** |
+| Filter+Sort+Head | 1,537 | 350 | **DataStore (4.40x)** |
+| Head/Limit | 166 | 45 | **DataStore (3.69x)** |
+| Ultra-complex (10+ ops) | 1,070 | 338 | **DataStore (3.17x)** |
+| GroupBy agg | 406 | 141 | **DataStore (2.88x)** |
+| Select+Filter+Sort | 1,217 | 443 | **DataStore (2.75x)** |
+| Filter+GroupBy+Sort | 466 | 184 | **DataStore (2.53x)** |
+| Filter+Select+Sort | 1,285 | 533 | **DataStore (2.41x)** |
+| Sort (single) | 1,742 | 1,197 | **DataStore (1.45x)** |
+| Filter (single) | 276 | 526 | Comparable |
+| Sort (multiple) | 947 | 1,477 | Comparable |
+
+### Key Insights
+1. **GroupBy operations**: DataStore up to **19.93x faster**
+2. **Complex pipelines**: DataStore **5-6x faster** (SQL pushdown benefit)
+3. **Simple slice operations**: Performance comparable - difference negligible
+4. **Best use case**: Multi-step operations with groupby/aggregation
+5. **Zero-copy**: `to_df()` has no data conversion overhead
+
+---
+
+## When DataStore Wins
+### Heavy Aggregations
+```python
+# DataStore excels: 19.93x faster
+result = ds.groupby('category')['amount'].sum()
+```
+
+### Complex Pipelines
+```python
+# DataStore excels: 5-6x faster
+result = (ds
+    .filter(ds['date'] >= '2024-01-01')
+    .filter(ds['amount'] > 100)
+    .groupby('region')
+    .agg({'amount': ['sum', 'mean', 'count']})
+    .sort('sum', ascending=False)
+    .head(20)
+)
+```
+
+### Large File Processing
+```python
+# DataStore: Only loads what you need
+ds = pd.read_parquet("huge_file.parquet")
+result = ds.filter(ds['id'] == 12345).to_df()  # Fast!
+```
+
+### Multiple Column Operations
+```python
+# DataStore: Combines into single SQL
+ds['total'] = ds['price'] * ds['quantity']
+ds['is_large'] = ds['total'] > 1000
+ds = ds.filter(ds['is_large'])
+```
+
+---
+
+## When pandas Is Comparable
+In most scenarios, DataStore matches or exceeds pandas performance. However, pandas may be slightly faster in these specific cases:
+
+### Small Datasets (&lt;1,000 rows)
+```python
+# For very small datasets, overhead is minimal for both
+# Performance difference is negligible
+small_df = pd.DataFrame({'x': range(100)})
+```
+
+### Simple Slice Operations
+```python
+# Single slice operations without aggregation
+df = df[df['x'] > 10]  # pandas slightly faster
+ds = ds[ds['x'] > 10]  # DataStore comparable
+```
+
+### Custom Python Lambda Functions
+```python
+# pandas required for custom Python code
+def complex_function(row):
+    return custom_logic(row)
+
+df['result'] = df.apply(complex_function, axis=1)
+```
+
+:::note Important
+Even in scenarios where DataStore is "slower", performance is typically **on par with pandas** - the difference is negligible for practical use. DataStore's advantages in complex operations far outweigh these edge cases.
+
+For fine-grained control over execution, see [Execution Engine Configuration](../configuration/execution-engine.md).
+:::
+
+---
+
+## Zero-Copy DataFrame Integration
+DataStore uses **zero-copy** for reading and writing pandas DataFrames. This means:
+
+```python
+# to_df() does NOT copy data - it's a zero-copy operation
+result = ds.filter(ds['x'] > 10).to_df()  # No data conversion overhead
+
+# Same for creating DataStore from DataFrame
+ds = DataStore(existing_df)  # No data copy
+```
+
+**Key implications:**
+- `to_df()` is essentially free - no serialization or memory copying
+- Creating DataStore from pandas DataFrame is instant
+- Memory is shared between DataStore and pandas views
+
+---
+
+## Optimization Tips
+### 1. Enable Performance Mode for Heavy Workloads
+For aggregation-heavy workloads where you don't need exact pandas output format (row order, MultiIndex columns, dtype corrections), enable performance mode for maximum throughput:
+
+```python
+from chdb.datastore.config import config
+
+config.use_performance_mode()
+
+# Now all operations use SQL-first execution with no pandas overhead:
+# - Parallel Parquet reading (no preserve_order)
+# - Single-SQL aggregation (filter+groupby in one query)
+# - No row-order preservation overhead
+# - No MultiIndex, no dtype corrections
+result = (ds
+    .filter(ds['amount'] > 100)
+    .groupby('region')
+    .agg({'amount': ['sum', 'mean', 'count']})
+)
+```
+
+**Expected improvement**: Up to 2-8x faster for filter+groupby workloads, reduced memory usage for large Parquet files.
+
+See [Performance Mode](../configuration/performance-mode.md) for full details.
+
+### 2. Use Parquet Instead of CSV
+```python
+# CSV: Slower, reads entire file
+ds = pd.read_csv("data.csv")
+
+# Parquet: Faster, columnar, compressed
+ds = pd.read_parquet("data.parquet")
+
+# Convert once, benefit forever
+df = pd.read_csv("data.csv")
+df.to_parquet("data.parquet")
+```
+
+**Expected improvement**: 3-10x faster reads
+
+### 3. Filter Early
+```python
+# Good: Filter first, then aggregate
+result = (ds
+    .filter(ds['date'] >= '2024-01-01')  # Reduce data early
+    .groupby('category')['amount'].sum()
+)
+
+# Less optimal: Process all data
+result = (ds
+    .groupby('category')['amount'].sum()
+    .filter(ds['sum'] > 1000)  # Filter too late
+)
+```
+
+### 4. Select Only Needed Columns
+```python
+# Good: Column pruning
+result = ds.select('name', 'amount').filter(ds['amount'] > 100)
+
+# Less optimal: All columns loaded
+result = ds.filter(ds['amount'] > 100)  # Loads all columns
+```
+
+### 5. Leverage SQL Aggregations
+```python
+# GroupBy is where DataStore shines
+# Up to 20x speedup!
+result = ds.groupby('category').agg({
+    'amount': ['sum', 'mean', 'count', 'max'],
+    'quantity': 'sum'
+})
+```
+
+### 6. Use head() Instead of Full Queries
+```python
+# Don't load entire result if you only need a sample
+result = ds.filter(ds['type'] == 'A').head(100)  # LIMIT 100
+
+# Avoid this for large results
+# result = ds.filter(ds['type'] == 'A').to_df()  # Loads everything
+```
+
+### 7. Batch Operations
+```python
+# Good: Single execution
+result = ds.filter(ds['x'] > 10).filter(ds['y'] < 100).to_df()
+
+# Bad: Multiple executions
+result1 = ds.filter(ds['x'] > 10).to_df()  # Execute
+result2 = result1[result1['y'] < 100]       # Execute again
+```
+
+### 8. Use explain() to Optimize
+```python
+# View the query plan before executing
+query = ds.filter(...).groupby(...).agg(...)
+query.explain()  # Check if operations are pushed down
+
+# Then execute
+result = query.to_df()
+```
+
+---
+
+## Profiling Your Workload
+### Enable Profiling
+```python
+from chdb.datastore.config import config, get_profiler
+
+config.enable_profiling()
+
+# Run your workload
+result = your_pipeline()
+
+# View report
+profiler = get_profiler()
+profiler.report()
+```
+
+### Identify Bottlenecks
+```text
+Performance Report
+==================
+Step                    Duration    % Total
+----                    --------    -------
+SQL execution           2.5s        62.5%     <- Bottleneck!
+read_csv                1.2s        30.0%
+Other                   0.3s        7.5%
+```
+
+### Compare Approaches
+```python
+# Test approach 1
+profiler.reset()
+result1 = approach1()
+time1 = profiler.get_steps()[-1]['duration_ms']
+
+# Test approach 2
+profiler.reset()
+result2 = approach2()
+time2 = profiler.get_steps()[-1]['duration_ms']
+
+print(f"Approach 1: {time1:.0f}ms")
+print(f"Approach 2: {time2:.0f}ms")
+```
+
+---
+
+## Best Practices Summary
+| Practice | Impact |
+|----------|--------|
+| Enable performance mode | 2-8x faster for aggregation workloads |
+| Use Parquet files | 3-10x faster reads |
+| Filter early | Reduce data processing |
+| Select needed columns | Reduce I/O and memory |
+| Use GroupBy/aggregations | Up to 20x faster |
+| Batch operations | Avoid repeated execution |
+| Profile before optimizing | Find real bottlenecks |
+| Use explain() | Verify query optimization |
+| Use head() for samples | Avoid full table scans |
+
+---
+
+## Quick Decision Guide
+| Your Workload | Recommendation |
+|---------------|----------------|
+| GroupBy/aggregation | Use DataStore |
+| Complex multi-step pipeline | Use DataStore |
+| Large files with filters | Use DataStore |
+| Simple slice operations | Either (comparable performance) |
+| Custom Python lambda functions | Use pandas or convert late |
+| Very small data (&lt;1,000 rows) | Either (negligible difference) |
+
+:::tip
+For automatic optimal engine selection, use `config.set_execution_engine('auto')` (default).
+For maximum throughput on aggregation workloads, use `config.use_performance_mode()`.
+See [Execution Engine](../configuration/execution-engine.md) and [Performance Mode](../configuration/performance-mode.md) for details.
+:::
+
+---
+
+# SQL for pandas users
+
+**URL:** https://clickhouse.com/docs/chdb/guides/pandas-to-sql
+
+Understanding how pandas operations map to SQL in DataStore
+
+DataStore compiles pandas-style operations into optimized SQL. This guide helps pandas users understand the SQL behind their operations.
+
+## Viewing Generated SQL
+```python title="Query"
+from pathlib import Path
+Path("sales.csv").write_text("""\
+region,product,category,amount,quantity,price,date,order_id
+East,Widget,Electronics,5200,10,120,2024-01-15,1001
+West,Gadget,Electronics,800,5,160,2024-02-20,1002
+East,Gizmo,Home,6500,3,100,2024-03-10,1003
+North,Widget,Electronics,4500,6,150,2024-06-18,1004
+West,Gadget,Electronics,2000,8,250,2024-09-14,1005
+""")
+
+from chdb import datastore as pd
+
+ds = pd.read_csv("sales.csv")
+
+query = (ds
+    .filter(ds['amount'] > 1000)
+    .groupby('region')
+    .agg({'amount': ['sum', 'mean']})
+    .sort('sum', ascending=False)
+    .head(10)
+)
+
+# View the SQL
+print(query.to_sql())
+```
+
+```sql title="Response"
+SELECT region, SUM(amount) AS sum, AVG(amount) AS mean
+FROM file('sales.csv', 'CSVWithNames')
+WHERE amount > 1000
+GROUP BY region
+ORDER BY sum DESC
+LIMIT 10
+```
+
+---
+
+## Basic Operations Mapping
+### Filtering (WHERE)
+| pandas | SQL |
+|--------|-----|
+| `df[df['age'] > 25]` | `WHERE age > 25` |
+| `df[df['city'] == 'NYC']` | `WHERE city = 'NYC'` |
+| `df[(df['x'] > 10) & (df['y'] < 20)]` | `WHERE x > 10 AND y < 20` |
+| `df[(df['a'] == 1) \| (df['b'] == 2)]` | `WHERE a = 1 OR b = 2` |
+| `df[~(df['status'] == 'inactive')]` | `WHERE NOT status = 'inactive'` |
+| `df[df['col'].isin([1, 2, 3])]` | `WHERE col IN (1, 2, 3)` |
+| `df[df['val'].between(10, 20)]` | `WHERE val BETWEEN 10 AND 20` |
+| `df[df['name'].str.contains('John')]` | `WHERE position('John' IN name) > 0` |
+
+### Selection (SELECT)
+| pandas | SQL |
+|--------|-----|
+| `df['col']` | `SELECT col` |
+| `df[['a', 'b', 'c']]` | `SELECT a, b, c` |
+| `df.head(10)` | `LIMIT 10` |
+| `df.tail(10)` | Complex (ORDER BY ... DESC LIMIT 10) |
+| `df.drop_duplicates()` | `SELECT DISTINCT *` |
+
+### Sorting (ORDER BY)
+| pandas | SQL |
+|--------|-----|
+| `df.sort_values('col')` | `ORDER BY col ASC` |
+| `df.sort_values('col', ascending=False)` | `ORDER BY col DESC` |
+| `df.sort_values(['a', 'b'])` | `ORDER BY a ASC, b ASC` |
+| `df.sort_values(['a', 'b'], ascending=[True, False])` | `ORDER BY a ASC, b DESC` |
+| `df.nlargest(10, 'col')` | `ORDER BY col DESC LIMIT 10` |
+| `df.nsmallest(5, 'col')` | `ORDER BY col ASC LIMIT 5` |
+
+---
+
+## GroupBy and Aggregation
+### Basic GroupBy
+| pandas | SQL |
+|--------|-----|
+| `df.groupby('city')['sales'].sum()` | `SELECT city, SUM(sales) FROM ... GROUP BY city` |
+| `df.groupby('city')['sales'].mean()` | `SELECT city, AVG(sales) FROM ... GROUP BY city` |
+| `df.groupby('city').size()` | `SELECT city, COUNT(*) FROM ... GROUP BY city` |
+| `df.groupby(['a', 'b'])['c'].sum()` | `SELECT a, b, SUM(c) FROM ... GROUP BY a, b` |
+
+### Aggregation Functions
+| pandas | SQL |
+|--------|-----|
+| `sum()` | `SUM()` |
+| `mean()` | `AVG()` |
+| `count()` | `COUNT()` |
+| `min()` | `MIN()` |
+| `max()` | `MAX()` |
+| `std()` | `stddevPop()` |
+| `var()` | `varPop()` |
+| `median()` | `MEDIAN()` |
+| `nunique()` | `COUNT(DISTINCT col)` |
+| `first()` | `any()` |
+| `last()` | `anyLast()` |
+
+### Multiple Aggregations
+```python
+# pandas
+df.groupby('city').agg({
+    'sales': ['sum', 'mean'],
+    'quantity': 'sum'
+})
+
+# SQL
+SELECT city, 
+       SUM(sales) AS sales_sum, 
+       AVG(sales) AS sales_mean,
+       SUM(quantity) AS quantity_sum
+FROM data
+GROUP BY city
+```
+
+### HAVING Clause
+```python
+# pandas style
+df.groupby('city')['sales'].sum().query('sales > 10000')
+
+# DataStore style
+ds.groupby('city').agg({'sales': 'sum'}).having(ds['sum'] > 10000)
+
+# SQL
+SELECT city, SUM(sales) AS sum
+FROM data
+GROUP BY city
+HAVING sum > 10000
+```
+
+---
+
+## Joins
+| pandas | SQL |
+|--------|-----|
+| `pd.merge(df1, df2, on='id')` | `JOIN df2 ON df1.id = df2.id` |
+| `pd.merge(df1, df2, on='id', how='left')` | `LEFT JOIN df2 ON ...` |
+| `pd.merge(df1, df2, on='id', how='right')` | `RIGHT JOIN df2 ON ...` |
+| `pd.merge(df1, df2, on='id', how='outer')` | `FULL OUTER JOIN df2 ON ...` |
+| `pd.merge(df1, df2, left_on='a', right_on='b')` | `JOIN df2 ON df1.a = df2.b` |
+
+### Join Example
+```python
+# pandas
+result = pd.merge(employees, departments, on='dept_id', how='left')
+
+# SQL equivalent
+SELECT *
+FROM employees e
+LEFT JOIN departments d ON e.dept_id = d.dept_id
+```
+
+---
+
+## String Operations
+| pandas | SQL |
+|--------|-----|
+| `df['col'].str.upper()` | `upper(col)` |
+| `df['col'].str.lower()` | `lower(col)` |
+| `df['col'].str.len()` | `length(col)` |
+| `df['col'].str.strip()` | `trim(col)` |
+| `df['col'].str.contains('x')` | `position('x' IN col) > 0` |
+| `df['col'].str.startswith('x')` | `startsWith(col, 'x')` |
+| `df['col'].str.endswith('x')` | `endsWith(col, 'x')` |
+| `df['col'].str.replace('a', 'b')` | `replace(col, 'a', 'b')` |
+| `df['col'].str[:5]` | `substring(col, 1, 5)` |
+
+---
+
+## DateTime Operations
+| pandas | SQL |
+|--------|-----|
+| `df['date'].dt.year` | `toYear(date)` |
+| `df['date'].dt.month` | `toMonth(date)` |
+| `df['date'].dt.day` | `toDayOfMonth(date)` |
+| `df['date'].dt.hour` | `toHour(date)` |
+| `df['date'].dt.dayofweek` | `toDayOfWeek(date)` |
+| `df['date'].dt.quarter` | `toQuarter(date)` |
+
+---
+
+## Arithmetic Operations
+| pandas | SQL |
+|--------|-----|
+| `df['a'] + df['b']` | `a + b` |
+| `df['a'] - df['b']` | `a - b` |
+| `df['a'] * df['b']` | `a * b` |
+| `df['a'] / df['b']` | `a / b` |
+| `df['a'] // df['b']` | `intDiv(a, b)` |
+| `df['a'] % df['b']` | `a % b` |
+| `df['a'] ** 2` | `pow(a, 2)` |
+| `df['a'].abs()` | `abs(a)` |
+| `df['a'].round(2)` | `round(a, 2)` |
+
+---
+
+## NULL Handling
+| pandas | SQL |
+|--------|-----|
+| `df['col'].isna()` | `isNull(col)` |
+| `df['col'].notna()` | `isNotNull(col)` |
+| `df.dropna()` | `WHERE col IS NOT NULL` (for each col) |
+| `df.fillna(0)` | `ifNull(col, 0)` |
+| `df.fillna({'a': 0, 'b': 'x'})` | `ifNull(a, 0), ifNull(b, 'x')` |
+
+---
+
+## Complete Example
+### pandas Code
+```python
+
+df = pd.read_csv("sales.csv")
+
+result = (df
+    [df['date'] >= '2024-01-01']              # Filter
+    [df['amount'] > 100]                      # Filter
+    [['region', 'category', 'amount']]        # Select columns
+    .groupby(['region', 'category'])          # Group
+    .agg({
+        'amount': ['sum', 'mean', 'count']
+    })
+    .reset_index()                            # Flatten
+    .query('amount_sum > 10000')              # Having
+    .sort_values('amount_sum', ascending=False)  # Sort
+    .head(20)                                 # Limit
+)
+```
+
+### Equivalent SQL
+```sql
+SELECT 
+    region,
+    category,
+    SUM(amount) AS amount_sum,
+    AVG(amount) AS amount_mean,
+    COUNT(amount) AS amount_count
+FROM file('sales.csv', 'CSVWithNames')
+WHERE date >= '2024-01-01'
+  AND amount > 100
+GROUP BY region, category
+HAVING amount_sum > 10000
+ORDER BY amount_sum DESC
+LIMIT 20
+```
+
+### DataStore Code
+```python
+from chdb import datastore as pd
+
+ds = pd.read_csv("sales.csv")
+
+result = (ds
+    .filter(ds['date'] >= '2024-01-01')
+    .filter(ds['amount'] > 100)
+    .select('region', 'category', 'amount')
+    .groupby('region', 'category')
+    .agg({'amount': ['sum', 'mean', 'count']})
+    .having(ds['sum'] > 10000)
+    .sort('sum', ascending=False)
+    .head(20)
+)
+
+# View the generated SQL
+print(result.to_sql())
+```
+
+---
+
+## SQL Keywords Summary
+| pandas Operation | SQL Clause |
+|------------------|------------|
+| `df[condition]` | `WHERE` |
+| `df[['a', 'b']]` | `SELECT a, b` |
+| `df.groupby('x')` | `GROUP BY x` |
+| `.agg({'col': 'sum'})` | `SUM(col)` |
+| `.sort_values('x')` | `ORDER BY x` |
+| `.head(n)` | `LIMIT n` |
+| `pd.merge()` | `JOIN` |
+| `.drop_duplicates()` | `DISTINCT` |
+| `.having()` | `HAVING` |
+
+---
+
+## Tips for pandas Users
+### 1. Think in SQL Operations
+When writing DataStore code, think about what SQL you'd want:
+
+```python
+# If you want: SELECT ... WHERE ... GROUP BY ... ORDER BY ... LIMIT
+# Write:
+ds.filter(...).groupby(...).agg(...).sort(...).head(...)
+```
+
+### 2. Use to_sql() to Learn
+```python
+# See how your pandas code becomes SQL
+query = ds.filter(ds['x'] > 10).groupby('y').sum()
+print(query.to_sql())
+```
+
+### 3. Leverage SQL Features
+DataStore gives you SQL power with pandas syntax:
+
+```python
+# Window functions
+ds['rank'] = F.row_number().over(partition_by='category', order_by='score')
+
+# Conditional aggregation
+ds.groupby('region').agg({
+    'high_value': ('amount', F.sum_if(Field('amount') > 1000))
+})
+```
+
+---
+
+# How to query a remote ClickHouse server
+
+**URL:** https://clickhouse.com/docs/chdb/guides/query-remote-clickhouse
+
+In this guide, we will learn how to query a remote ClickHouse server from chDB.
+
+In this guide, we're going to learn how to query a remote ClickHouse server from chDB.
+
+## Setup
+Let's first create a virtual environment:
+
+```bash
+python -m venv .venv
+source .venv/bin/activate
+```
+
+And now we'll install chDB.
+Make sure you have version 2.0.2 or higher:
+
+```bash
+pip install "chdb>=2.0.2"
+```
+
+And now we're going to install pandas, and ipython:
+
+```bash
+pip install pandas ipython
+```
+
+We're going to use `ipython` to run the commands in the rest of the guide, which you can launch by running:
+
+```bash
+ipython
+```
+
+You can also use the code in a Python script or in your favorite notebook.
+
+## An intro to ClickPy
+The remote ClickHouse server that we're going to query is [ClickPy](https://clickpy.clickhouse.com).
+ClickPy keeps track of all the downloads of PyPI packages and lets you explore the stats of packages via a UI.
+The underlying database is available to query using the `play` user.
+
+You can learn more about ClickPy in [its GitHub repository](https://github.com/ClickHouse/clickpy).
+
+## Querying the ClickPy ClickHouse service
+Let's import chDB:
+
+```python
+
+```
+
+We're going to query ClickPy using the `remoteSecure` function.
+This function takes in a host name, table name, and username at a minimum.
+
+We can write the following query to return the number of downloads per day of the [`openai` package](https://clickpy.clickhouse.com/dashboard/openai) as a Pandas DataFrame:
+ 
+```python
+query = """
+SELECT
+    toStartOfDay(date)::Date32 AS x,
+    sum(count) AS y
+FROM remoteSecure(
+  'clickpy-clickhouse.clickhouse.com', 
+  'pypi.pypi_downloads_per_day', 
+  'play'
+)
+WHERE project = 'openai'
+GROUP BY x
+ORDER BY x ASC
+"""
+
+openai_df = chdb.query(query, "DataFrame")
+openai_df.sort_values(by=["x"], ascending=False).head(n=10)
+```
+
+```text
+               x        y
+2392  2024-10-02  1793502
+2391  2024-10-01  1924901
+2390  2024-09-30  1749045
+2389  2024-09-29  1177131
+2388  2024-09-28  1157323
+2387  2024-09-27  1688094
+2386  2024-09-26  1862712
+2385  2024-09-25  2032923
+2384  2024-09-24  1901965
+2383  2024-09-23  1777554
+```
+
+Now let's do the same to return the downloads for [`scikit-learn`](https://clickpy.clickhouse.com/dashboard/scikit-learn):
+
+```python
+query = """
+SELECT
+    toStartOfDay(date)::Date32 AS x,
+    sum(count) AS y
+FROM remoteSecure(
+  'clickpy-clickhouse.clickhouse.com', 
+  'pypi.pypi_downloads_per_day', 
+  'play'
+)
+WHERE project = 'scikit-learn'
+GROUP BY x
+ORDER BY x ASC
+"""
+
+sklearn_df = chdb.query(query, "DataFrame")
+sklearn_df.sort_values(by=["x"], ascending=False).head(n=10)
+```
+
+```text
+               x        y
+2392  2024-10-02  1793502
+2391  2024-10-01  1924901
+2390  2024-09-30  1749045
+2389  2024-09-29  1177131
+2388  2024-09-28  1157323
+2387  2024-09-27  1688094
+2386  2024-09-26  1862712
+2385  2024-09-25  2032923
+2384  2024-09-24  1901965
+2383  2024-09-23  1777554
+```
+
+## Merging Pandas DataFrames
+We now have two DataFrames, which we can merge together based on date (which is the `x` column) like this:
+
+```python
+df = openai_df.merge(
+  sklearn_df, 
+  on="x", 
+  suffixes=("_openai", "_sklearn")
+)
+df.head(n=5)
+```
+
+```text
+            x  y_openai  y_sklearn
+0  2018-02-26        83      33971
+1  2018-02-27        31      25211
+2  2018-02-28         8      26023
+3  2018-03-01         8      20912
+4  2018-03-02         5      23842
+```
+
+We can then compute the ratio of Open AI downloads to `scikit-learn` downloads like this:
+
+```python
+df['ratio'] = df['y_openai'] / df['y_sklearn']
+df.head(n=5)
+```
+
+```text
+            x  y_openai  y_sklearn     ratio
+0  2018-02-26        83      33971  0.002443
+1  2018-02-27        31      25211  0.001230
+2  2018-02-28         8      26023  0.000307
+3  2018-03-01         8      20912  0.000383
+4  2018-03-02         5      23842  0.000210
+```
+
+## Querying Pandas DataFrames
+Next, let's say we want to find the dates with the best and worst ratios. 
+We can go back to chDB and compute those values:
+
+```python
+chdb.query("""
+SELECT max(ratio) AS bestRatio,
+       argMax(x, ratio) AS bestDate,
+       min(ratio) AS worstRatio,
+       argMin(x, ratio) AS worstDate
+FROM Python(df)
+""", "DataFrame")
+```
+
+```text
+   bestRatio    bestDate  worstRatio   worstDate
+0   0.693855  2024-09-19    0.000003  2020-02-09
+```
+
+If you want to learn more about querying Pandas DataFrames, see the [Pandas DataFrames developer guide](querying-pandas.md).
+
+---
+
+# How to query Apache Arrow with chDB
+
+**URL:** https://clickhouse.com/docs/chdb/guides/apache-arrow
+
+In this guide, we will learn how to query Apache Arrow tables with chDB
+
+[Apache Arrow](https://arrow.apache.org/) is a standardized column-oriented memory format that's gained popularity in the data community.
+In this guide, we will learn how to query Apache Arrow using the `Python` table function.
+
+## Setup
+Let's first create a virtual environment:
+
+```bash
+python -m venv .venv
+source .venv/bin/activate
+```
+
+And now we'll install chDB.
+Make sure you have version 2.0.2 or higher:
+
+```bash
+pip install "chdb>=2.0.2"
+```
+
+And now we're going to install PyArrow, pandas, and ipython:
+
+```bash
+pip install pyarrow pandas ipython
+```
+
+We're going to use `ipython` to run the commands in the rest of the guide, which you can launch by running:
+
+```bash
+ipython
+```
+
+You can also use the code in a Python script or in your favorite notebook.
+
+## Creating an Apache Arrow table from a file
+Let's first download one of the Parquet files for the [Ookla dataset](https://github.com/teamookla/ookla-open-data), using the [AWS CLI tool](https://aws.amazon.com/cli/):
+
+```bash
+aws s3 cp \
+  --no-sign \
+  s3://ookla-open-data/parquet/performance/type=mobile/year=2023/quarter=2/2023-04-01_performance_mobile_tiles.parquet .
+```
+
+:::note
+If you want to download more files, use `aws s3 ls` to get a list of all the files and then update the above command.
+:::
+
+Next, we'll import the Parquet module from the `pyarrow` package:
+
+```python
+
+```
+
+And then we can read the Parquet file into an Apache Arrow table:
+
+```python
+arrow_table = pq.read_table("./2023-04-01_performance_mobile_tiles.parquet")
+```
+
+The schema is shown below:
+
+```python
+arrow_table.schema
+```
+
+```text
+quadkey: string
+tile: string
+tile_x: double
+tile_y: double
+avg_d_kbps: int64
+avg_u_kbps: int64
+avg_lat_ms: int64
+avg_lat_down_ms: int32
+avg_lat_up_ms: int32
+tests: int64
+devices: int64
+```
+
+And we can get the row and column count by calling the `shape` attribute:
+
+```python
+arrow_table.shape
+```
+
+```text
+(3864546, 11)
+```
+
+## Querying Apache Arrow
+Now let's query the Arrow table from chDB.
+First, let's import chDB:
+
+```python
+
+```
+
+And then we can describe the table:
+
+```python
+chdb.query("""
+DESCRIBE Python(arrow_table)
+SETTINGS describe_compact_output=1
+""", "DataFrame")
+```
+
+```text
+               name     type
+0           quadkey   String
+1              tile   String
+2            tile_x  Float64
+3            tile_y  Float64
+4        avg_d_kbps    Int64
+5        avg_u_kbps    Int64
+6        avg_lat_ms    Int64
+7   avg_lat_down_ms    Int32
+8     avg_lat_up_ms    Int32
+9             tests    Int64
+10          devices    Int64
+```
+
+We can also count the number of rows:
+
+```python
+chdb.query("SELECT count() FROM Python(arrow_table)", "DataFrame")
+```
+
+```text
+   count()
+0  3864546
+```
+
+Now, let's do something a bit more interesting. 
+The following query excludes the `quadkey` and `tile.*` columns and then computes the average and max values for all remaining column:
+
+```python
+chdb.query("""
+WITH numericColumns AS (
+  SELECT * EXCEPT ('tile.*') EXCEPT(quadkey)
+  FROM Python(arrow_table)
+)
+SELECT * APPLY(max), * APPLY(avg) APPLY(x -> round(x, 2))
+FROM numericColumns
+""", "Vertical")
+```
+
+```text
+Row 1:
+──────
+max(avg_d_kbps):                4155282
+max(avg_u_kbps):                1036628
+max(avg_lat_ms):                2911
+max(avg_lat_down_ms):           2146959360
+max(avg_lat_up_ms):             2146959360
+max(tests):                     111266
+max(devices):                   1226
+round(avg(avg_d_kbps), 2):      84393.52
+round(avg(avg_u_kbps), 2):      15540.4
+round(avg(avg_lat_ms), 2):      41.25
+round(avg(avg_lat_down_ms), 2): 554355225.76
+round(avg(avg_lat_up_ms), 2):   552843178.3
+round(avg(tests), 2):           6.31
+round(avg(devices), 2):         2.88
+```
+
+---
+
+# How to query Pandas DataFrames with chDB
+
+**URL:** https://clickhouse.com/docs/chdb/guides/pandas
+
+Learn how to query Pandas DataFrames with chDB
+
+[Pandas](https://pandas.pydata.org/) is a popular library for data manipulation and analysis in Python.
+In version 2 of chDB, we've improved the performance of querying Pandas DataFrames and introduced the `Python` table function.
+In this guide, we will learn how to query Pandas using the `Python` table function.
+
+## Setup
+Let's first create a virtual environment:
+
+```bash
+python -m venv .venv
+source .venv/bin/activate
+```
+
+And now we'll install chDB.
+Make sure you have version 2.0.2 or higher:
+
+```bash
+pip install "chdb>=2.0.2"
+```
+
+And now we're going to install Pandas and a couple of other libraries:
+
+```bash
+pip install pandas requests ipython
+```
+
+We're going to use `ipython` to run the commands in the rest of the guide, which you can launch by running:
+
+```bash
+ipython
+```
+
+You can also use the code in a Python script or in your favorite notebook.
+
+## Creating a Pandas DataFrame from a URL
+We're going to query some data from the [StatsBomb GitHub repository](https://github.com/statsbomb/open-data/tree/master?tab=readme-ov-file).
+Let's first import requests and pandas:
+
+```python
+
+```
+
+Then, we'll load one of the matches JSON files into a DataFrame:
+
+```python
+response = requests.get(
+  "https://raw.githubusercontent.com/statsbomb/open-data/master/data/matches/223/282.json"
+)
+matches_df = pd.json_normalize(response.json(), sep='_')
+```
+
+Let's have a look what data we'll be working with:
+
+```python
+matches_df.iloc[0]
+```
+
+```text
+match_id                                                                  3943077
+match_date                                                             2024-07-15
+kick_off                                                             04:15:00.000
+home_score                                                                      1
+away_score                                                                      0
+match_status                                                            available
+match_status_360                                                      unscheduled
+last_updated                                           2024-07-15T15:50:08.671355
+last_updated_360                                                             None
+match_week                                                                      6
+competition_competition_id                                                    223
+competition_country_name                                            South America
+competition_competition_name                                         Copa America
+season_season_id                                                              282
+season_season_name                                                           2024
+home_team_home_team_id                                                        779
+home_team_home_team_name                                                Argentina
+home_team_home_team_gender                                                   male
+home_team_home_team_group                                                    None
+home_team_country_id                                                           11
+home_team_country_name                                                  Argentina
+home_team_managers              [{'id': 5677, 'name': 'Lionel Sebastián Scalon...
+away_team_away_team_id                                                        769
+away_team_away_team_name                                                 Colombia
+away_team_away_team_gender                                                   male
+away_team_away_team_group                                                    None
+away_team_country_id                                                           49
+away_team_country_name                                                   Colombia
+away_team_managers              [{'id': 5905, 'name': 'Néstor Gabriel Lorenzo'...
+metadata_data_version                                                       1.1.0
+metadata_shot_fidelity_version                                                  2
+metadata_xy_fidelity_version                                                    2
+competition_stage_id                                                           26
+competition_stage_name                                                      Final
+stadium_id                                                                   5337
+stadium_name                                                    Hard Rock Stadium
+stadium_country_id                                                            241
+stadium_country_name                                     United States of America
+referee_id                                                                   2638
+referee_name                                                        Raphael Claus
+referee_country_id                                                             31
+referee_country_name                                                       Brazil
+Name: 0, dtype: object
+```
+
+Next, we'll load one of the events JSON files and also add a column called `match_id` to that DataFrame:
+
+```python
+response = requests.get(
+  "https://raw.githubusercontent.com/statsbomb/open-data/master/data/events/3943077.json"
+)
+events_df = pd.json_normalize(response.json(), sep='_')
+events_df["match_id"] = 3943077
+```
+
+And again, let's have a look at the first row:
+
+```python
+with pd.option_context("display.max_rows", None):
+    first_row = events_df.iloc[0]
+    non_nan_columns = first_row[first_row.notna()].T
+    display(non_nan_columns)
+```
+
+```text
+id                                   279b7d66-92b5-4daa-8ff6-cba8fce271d9
+index                                                                   1
+period                                                                  1
+timestamp                                                    00:00:00.000
+minute                                                                  0
+second                                                                  0
+possession                                                              1
+duration                                                              0.0
+type_id                                                                35
+type_name                                                     Starting XI
+possession_team_id                                                    779
+possession_team_name                                            Argentina
+play_pattern_id                                                         1
+play_pattern_name                                            Regular Play
+team_id                                                               779
+team_name                                                       Argentina
+tactics_formation                                                   442.0
+tactics_lineup          [{'player': {'id': 6909, 'name': 'Damián Emili...
+match_id                                                          3943077
+Name: 0, dtype: object
+```
+
+## Querying Pandas DataFrames
+Next, let's see how to query these DataFrames using chDB. 
+We'll import the library:
+
+```python
+
+```
+
+We can query Pandas DataFrames by using the `Python` table function:
+
+```sql
+SELECT *
+FROM Python(<name-of-variable>)
+```
+
+So, if we wanted to list the columns in `matches_df`, we could write the following:
+
+```python
+chdb.query("""
+DESCRIBE Python(matches_df)
+SETTINGS describe_compact_output=1
+""", "DataFrame")
+```
+
+```text
+                              name    type
+0                         match_id   Int64
+1                       match_date  String
+2                         kick_off  String
+3                       home_score   Int64
+4                       away_score   Int64
+5                     match_status  String
+6                 match_status_360  String
+7                     last_updated  String
+8                 last_updated_360  String
+9                       match_week   Int64
+10      competition_competition_id   Int64
+11        competition_country_name  String
+12    competition_competition_name  String
+13                season_season_id   Int64
+14              season_season_name  String
+15          home_team_home_team_id   Int64
+16        home_team_home_team_name  String
+17      home_team_home_team_gender  String
+18       home_team_home_team_group  String
+19            home_team_country_id   Int64
+20          home_team_country_name  String
+21              home_team_managers  String
+22          away_team_away_team_id   Int64
+23        away_team_away_team_name  String
+24      away_team_away_team_gender  String
+25       away_team_away_team_group  String
+26            away_team_country_id   Int64
+27          away_team_country_name  String
+28              away_team_managers  String
+29           metadata_data_version  String
+30  metadata_shot_fidelity_version  String
+31    metadata_xy_fidelity_version  String
+32            competition_stage_id   Int64
+33          competition_stage_name  String
+34                      stadium_id   Int64
+35                    stadium_name  String
+36              stadium_country_id   Int64
+37            stadium_country_name  String
+38                      referee_id   Int64
+39                    referee_name  String
+40              referee_country_id   Int64
+41            referee_country_name  String
+```
+
+We could then find out which referees have officiated more than one match by writing the following query:
+
+```python
+chdb.query("""
+SELECT referee_name, count() AS count
+FROM Python(matches_df)
+GROUP BY ALL
+HAVING count > 1
+ORDER BY count DESC
+""", "DataFrame")
+```
+
+```text
+                    referee_name  count
+0  César Arturo Ramos Palazuelos      3
+1               Maurizio Mariani      3
+2               Piero Maza Gomez      3
+3     Mario Alberto Escobar Toca      2
+4  Wilmar Alexander Roldán Pérez      2
+5          Jesús Valenzuela Sáez      2
+6         Wilton Pereira Sampaio      2
+7                  Darío Herrera      2
+8                 Andrés Matonte      2
+9                  Raphael Claus      2
+```
+
+Now, let's explore `events_df`.
+
+```python
+chdb.query("""
+SELECT pass_recipient_name, count()
+FROM Python(events_df)
+WHERE type_name = 'Pass' AND pass_recipient_name <> ''
+GROUP BY ALL
+ORDER BY count() DESC
+LIMIT 10
+""", "DataFrame")
+```
+
+```text
+               pass_recipient_name  count()
+0            Davinson Sánchez Mina       76
+1  Ángel Fabián Di María Hernández       64
+2              Alexis Mac Allister       62
+3                   Enzo Fernandez       57
+4      James David Rodríguez Rubio       56
+5      Johan Andrés Mojica Palacio       55
+6           Rodrigo Javier De Paul       54
+7     Jefferson Andrés Lerma Solís       53
+8        Jhon Adolfo Arias Andrade       52
+9  Carlos Eccehomo Cuesta Figueroa       50
+```
+
+## Joining Pandas DataFrames
+We can also join DataFrames together in a query.
+For example, to get an overview of the match, we could write the following query:
+
+```python
+chdb.query("""
+SELECT home_team_home_team_name, away_team_away_team_name, home_score, away_score,
+       countIf(type_name = 'Pass' AND possession_team_id=home_team_home_team_id) AS home_passes,
+       countIf(type_name = 'Pass' AND possession_team_id=away_team_away_team_id) AS away_passes,
+       countIf(type_name = 'Shot' AND possession_team_id=home_team_home_team_id) AS home_shots,
+       countIf(type_name = 'Shot' AND possession_team_id=away_team_away_team_id) AS away_shots
+FROM Python(matches_df) AS matches
+JOIN Python(events_df) AS events ON events.match_id = matches.match_id
+GROUP BY ALL
+LIMIT 5
+""", "DataFrame").iloc[0]
+```
+
+```text
+home_team_home_team_name    Argentina
+away_team_away_team_name     Colombia
+home_score                          1
+away_score                          0
+home_passes                       527
+away_passes                       669
+home_shots                         11
+away_shots                         19
+Name: 0, dtype: object
+```
+
+## Populating a table from a DataFrame
+We can also create and populate ClickHouse tables from DataFrames.
+If we want to create a table in chDB, we need to use the Stateful Session API.
+
+Let's import the session module:
+
+```python
+from chdb import session as chs
+```
+
+Initialize a session:
+
+```python
+sess = chs.Session()
+```
+
+Next, we'll create a database:
+
+```python
+sess.query("CREATE DATABASE statsbomb")
+```
+
+Then, create an `events` table based on `events_df`:
+
+```python
+sess.query("""
+CREATE TABLE statsbomb.events ORDER BY id AS
+SELECT * 
+FROM Python(events_df)
+""")
+```
+
+We can then run the query that returns the top pass recipient:
+
+```python
+sess.query("""
+SELECT pass_recipient_name, count()
+FROM statsbomb.events
+WHERE type_name = 'Pass' AND pass_recipient_name <> ''
+GROUP BY ALL
+ORDER BY count() DESC
+LIMIT 10
+""", "DataFrame")
+```
+
+```text
+               pass_recipient_name  count()
+0            Davinson Sánchez Mina       76
+1  Ángel Fabián Di María Hernández       64
+2              Alexis Mac Allister       62
+3                   Enzo Fernandez       57
+4      James David Rodríguez Rubio       56
+5      Johan Andrés Mojica Palacio       55
+6           Rodrigo Javier De Paul       54
+7     Jefferson Andrés Lerma Solís       53
+8        Jhon Adolfo Arias Andrade       52
+9  Carlos Eccehomo Cuesta Figueroa       50
+```
+
+## Joining a Pandas DataFrame and table
+Finally, we can also update our join query to join the `matches_df` DataFrame with the `statsbomb.events` table:
+
+```python
+sess.query("""
+SELECT home_team_home_team_name, away_team_away_team_name, home_score, away_score,
+       countIf(type_name = 'Pass' AND possession_team_id=home_team_home_team_id) AS home_passes,
+       countIf(type_name = 'Pass' AND possession_team_id=away_team_away_team_id) AS away_passes,
+       countIf(type_name = 'Shot' AND possession_team_id=home_team_home_team_id) AS home_shots,
+       countIf(type_name = 'Shot' AND possession_team_id=away_team_away_team_id) AS away_shots
+FROM Python(matches_df) AS matches
+JOIN statsbomb.events AS events ON events.match_id = matches.match_id
+GROUP BY ALL
+LIMIT 5
+""", "DataFrame").iloc[0]
+```
+
+```text
+home_team_home_team_name    Argentina
+away_team_away_team_name     Colombia
+home_score                          1
+away_score                          0
+home_passes                       527
+away_passes                       669
+home_shots                         11
+away_shots                         19
+Name: 0, dtype: object
+```
+
+---
+
+# How to query Parquet files
+
+**URL:** https://clickhouse.com/docs/chdb/guides/querying-parquet
+
+Learn how to query Parquet files with chDB.
+
+A lot of the world's data lives in Amazon S3 buckets.
+In this guide, we'll learn how to query that data using chDB.
+
+## Setup
+Let's first create a virtual environment:
+
+```bash
+python -m venv .venv
+source .venv/bin/activate
+```
+
+And now we'll install chDB.
+Make sure you have version 2.0.2 or higher:
+
+```bash
+pip install "chdb>=2.0.2"
+```
+
+And now we're going to install IPython:
+
+```bash
+pip install ipython
+```
+
+We're going to use `ipython` to run the commands in the rest of the guide, which you can launch by running:
+
+```bash
+ipython
+```
+
+You can also use the code in a Python script or in your favorite notebook.
+
+## Exploring Parquet metadata
+We're going to explore a Parquet file from the [Amazon reviews](/getting-started/example-datasets/amazon-reviews) dataset.
+But first, let's install `chDB`:
+
+```python
+
+```
+
+When querying Parquet files, we can use the [`ParquetMetadata`](/interfaces/formats/ParquetMetadata) input format to have it return Parquet metadata rather than the content of the file.
+Let's use the `DESCRIBE` clause to see the fields returned when we use this format:
+
+```python
+query = """
+DESCRIBE s3(
+  'https://datasets-documentation.s3.eu-west-3.amazonaws.com/amazon_reviews/amazon_reviews_2015.snappy.parquet', 
+  ParquetMetadata
+)
+SETTINGS describe_compact_output=1
+"""
+
+chdb.query(query, 'TabSeparated')
+```
+
+```text
+num_columns     UInt64
+num_rows        UInt64
+num_row_groups  UInt64
+format_version  String
+metadata_size   UInt64
+total_uncompressed_size UInt64
+total_compressed_size   UInt64
+columns Array(Tuple(name String, path String, max_definition_level UInt64, max_repetition_level UInt64, physical_type String, logical_type String, compression String, total_uncompressed_size UInt64, total_compressed_size UInt64, space_saved String, encodings Array(String)))
+row_groups      Array(Tuple(num_columns UInt64, num_rows UInt64, total_uncompressed_size UInt64, total_compressed_size UInt64, columns Array(Tuple(name String, path String, total_compressed_size UInt64, total_uncompressed_size UInt64, have_statistics Bool, statistics Tuple(num_values Nullable(UInt64), null_count Nullable(UInt64), distinct_count Nullable(UInt64), min Nullable(String), max Nullable(String))))))
+```
+
+Let's have now have a look at the metadata for this file.
+`columns` and `row_groups` both contain arrays of tuples containing many properties, so we'll exclude those for now.
+
+```python
+query = """
+SELECT * EXCEPT(columns, row_groups)
+FROM s3(
+  'https://datasets-documentation.s3.eu-west-3.amazonaws.com/amazon_reviews/amazon_reviews_2015.snappy.parquet', 
+  ParquetMetadata
+)
+"""
+
+chdb.query(query, 'Vertical')
+```
+
+```text
+Row 1:
+──────
+num_columns:             15
+num_rows:                41905631
+num_row_groups:          42
+format_version:          2.6
+metadata_size:           79730
+total_uncompressed_size: 14615827169
+total_compressed_size:   9272262304
+```
+
+From this output, we learn that this Parquet file has over 40 million rows, split across 42 row groups, with 15 columns of data per row.
+A row group is a logical horizontal partitioning of the data into rows.
+Each row group has associated metadata and querying tools can make use of that metadata to efficiently query the file.
+
+Let's take a look at one of the row groups:
+
+```python
+query = """
+WITH rowGroups AS (
+    SELECT rg
+    FROM s3(
+    'https://datasets-documentation.s3.eu-west-3.amazonaws.com/amazon_reviews/amazon_reviews_2015.snappy.parquet',
+    ParquetMetadata
+    )
+    ARRAY JOIN row_groups AS rg
+    LIMIT 1
+)
+SELECT tupleElement(c, 'name') AS name, tupleElement(c, 'total_compressed_size') AS total_compressed_size, 
+       tupleElement(c, 'total_uncompressed_size') AS total_uncompressed_size,
+       tupleElement(tupleElement(c, 'statistics'), 'min') AS min,
+       tupleElement(tupleElement(c, 'statistics'), 'max') AS max
+FROM rowGroups
+ARRAY JOIN tupleElement(rg, 'columns') AS c
+"""
+
+chdb.query(query, 'DataFrame')
+```
+
+```text
+                 name  total_compressed_size  total_uncompressed_size                                                min                                                max
+0         review_date                    493                      646                                              16455                                              16472
+1         marketplace                     66                       64                                                 US                                                 US
+2         customer_id                5207967                  7997207                                              10049                                           53096413
+3           review_id               14748425                 17991290                                     R10004U8OQDOGE                                      RZZZUTBAV1RYI
+4          product_id                8003456                 13969668                                         0000032050                                         BT00DDVMVQ
+5      product_parent                5758251                  7974737                                                645                                          999999730
+6       product_title               41068525                 63355320  ! Small S 1pc Black 1pc Navy (Blue) Replacemen...                            🌴 Vacation On The Beach
+7    product_category                   1726                     1815                                            Apparel                                       Pet Products
+8         star_rating                 369036                   374046                                                  1                                                  5
+9       helpful_votes                 538940                  1022990                                                  0                                               3440
+10        total_votes                 610902                  1080520                                                  0                                               3619
+11               vine                  11426                   125999                                                  0                                                  1
+12  verified_purchase                 102634                   125999                                                  0                                                  1
+13    review_headline               16538189                 27634740                                                     🤹🏽‍♂️🎤Great product. Practice makes perfect. D...
+14        review_body              145886383                232457911                                                                                              🚅 +🐧=💥 😀
+```
+
+## Querying Parquet files
+Next, let's query the contents of the file.
+We can do this by adjusting the above query to remove `ParquetMetadata` and then, say, compute the most popular `star_rating` across all reviews:
+
+```python
+query = """
+SELECT star_rating, count() AS count, formatReadableQuantity(count)
+FROM s3(
+  'https://datasets-documentation.s3.eu-west-3.amazonaws.com/amazon_reviews/amazon_reviews_2015.snappy.parquet'
+)
+GROUP BY ALL
+ORDER BY star_rating
+"""
+
+chdb.query(query, 'DataFrame')
+```
+
+```text
+   star_rating     count formatReadableQuantity(count())
+0            1   3253070                    3.25 million
+1            2   1865322                    1.87 million
+2            3   3130345                    3.13 million
+3            4   6578230                    6.58 million
+4            5  27078664                   27.08 million
+```
+
+Interestingly, there are more 5 star reviews than all the other ratings combined!
+It looks like people like the products on Amazon or, if they don't, they just don't submit a rating.
+
+---
+
+# How to query data in an S3 bucket
+
+**URL:** https://clickhouse.com/docs/chdb/guides/querying-s3
+
+Learn how to query data in an S3 bucket with chDB.
+
+A lot of the world's data lives in Amazon S3 buckets.
+In this guide, we'll learn how to query that data using chDB.
+
+## Setup
+Let's first create a virtual environment:
+
+```bash
+python -m venv .venv
+source .venv/bin/activate
+```
+
+And now we'll install chDB.
+Make sure you have version 2.0.2 or higher:
+
+```bash
+pip install "chdb>=2.0.2"
+```
+
+And now we're going to install IPython:
+
+```bash
+pip install ipython
+```
+
+We're going to use `ipython` to run the commands in the rest of the guide, which you can launch by running:
+
+```bash
+ipython
+```
+
+You can also use the code in a Python script or in your favorite notebook.
+
+## Listing files in an S3 bucket
+Let's start by listing all the files in [an S3 bucket that contains Amazon reviews](/getting-started/example-datasets/amazon-reviews).
+To do this, we can use the [`s3` table function](/sql-reference/table-functions/s3) and pass in the path to a file or a wildcard to a set of files.
+
+:::tip
+If you pass just the bucket name it will throw an exception.
+:::
+
+We're also going to use the [`One`](/interfaces/formats/One) input format so that the file isn't parsed, instead a single row is returned per file and we can access the file via the `_file` virtual column and the path via the `_path` virtual column.
+
+```python
+
+chdb.query("""
+SELECT
+    _file,
+    _path
+FROM s3('s3://datasets-documentation/amazon_reviews/*.parquet', One)
+SETTINGS output_format_pretty_row_numbers=0
+""", 'PrettyCompact')
+```
+
+```text
+┌─_file───────────────────────────────┬─_path─────────────────────────────────────────────────────────────────────┐
+│ amazon_reviews_2010.snappy.parquet  │ datasets-documentation/amazon_reviews/amazon_reviews_2010.snappy.parquet  │
+│ amazon_reviews_1990s.snappy.parquet │ datasets-documentation/amazon_reviews/amazon_reviews_1990s.snappy.parquet │
+│ amazon_reviews_2013.snappy.parquet  │ datasets-documentation/amazon_reviews/amazon_reviews_2013.snappy.parquet  │
+│ amazon_reviews_2015.snappy.parquet  │ datasets-documentation/amazon_reviews/amazon_reviews_2015.snappy.parquet  │
+│ amazon_reviews_2014.snappy.parquet  │ datasets-documentation/amazon_reviews/amazon_reviews_2014.snappy.parquet  │
+│ amazon_reviews_2012.snappy.parquet  │ datasets-documentation/amazon_reviews/amazon_reviews_2012.snappy.parquet  │
+│ amazon_reviews_2000s.snappy.parquet │ datasets-documentation/amazon_reviews/amazon_reviews_2000s.snappy.parquet │
+│ amazon_reviews_2011.snappy.parquet  │ datasets-documentation/amazon_reviews/amazon_reviews_2011.snappy.parquet  │
+└─────────────────────────────────────┴───────────────────────────────────────────────────────────────────────────┘
+```
+
+This bucket contains only Parquet files.
+
+## Querying files in an S3 bucket
+Next, let's learn how to query those files.
+If we want to count the number of rows in each of those files, we can run the following query:
+
+```python
+chdb.query("""
+SELECT
+    _file,
+    count() AS count,
+    formatReadableQuantity(count) AS readableCount    
+FROM s3('s3://datasets-documentation/amazon_reviews/*.parquet')
+GROUP BY ALL
+SETTINGS output_format_pretty_row_numbers=0
+""", 'PrettyCompact')
+```
+
+```text
+┌─_file───────────────────────────────┬────count─┬─readableCount───┐
+│ amazon_reviews_2013.snappy.parquet  │ 28034255 │ 28.03 million   │
+│ amazon_reviews_1990s.snappy.parquet │   639532 │ 639.53 thousand │
+│ amazon_reviews_2011.snappy.parquet  │  6112495 │ 6.11 million    │
+│ amazon_reviews_2015.snappy.parquet  │ 41905631 │ 41.91 million   │
+│ amazon_reviews_2012.snappy.parquet  │ 11541011 │ 11.54 million   │
+│ amazon_reviews_2000s.snappy.parquet │ 14728295 │ 14.73 million   │
+│ amazon_reviews_2014.snappy.parquet  │ 44127569 │ 44.13 million   │
+│ amazon_reviews_2010.snappy.parquet  │  3868472 │ 3.87 million    │
+└─────────────────────────────────────┴──────────┴─────────────────┘
+```
+
+We can also pass in the HTTP URI for an S3 bucket and will get the same results:
+
+```python
+chdb.query("""
+SELECT
+    _file,
+    count() AS count,
+    formatReadableQuantity(count) AS readableCount    
+FROM s3('https://datasets-documentation.s3.eu-west-3.amazonaws.com/amazon_reviews/*.parquet')
+GROUP BY ALL
+SETTINGS output_format_pretty_row_numbers=0
+""", 'PrettyCompact')
+```
+
+Let's have a look at the schema of these Parquet files using the `DESCRIBE` clause:
+
+```python
+chdb.query("""
+DESCRIBE s3('s3://datasets-documentation/amazon_reviews/*.parquet')
+SETTINGS describe_compact_output=1
+""", 'PrettyCompact')
+```
+
+```text
+    ┌─name──────────────┬─type─────────────┐
+ 1. │ review_date       │ Nullable(UInt16) │
+ 2. │ marketplace       │ Nullable(String) │
+ 3. │ customer_id       │ Nullable(UInt64) │
+ 4. │ review_id         │ Nullable(String) │
+ 5. │ product_id        │ Nullable(String) │
+ 6. │ product_parent    │ Nullable(UInt64) │
+ 7. │ product_title     │ Nullable(String) │
+ 8. │ product_category  │ Nullable(String) │
+ 9. │ star_rating       │ Nullable(UInt8)  │
+10. │ helpful_votes     │ Nullable(UInt32) │
+11. │ total_votes       │ Nullable(UInt32) │
+12. │ vine              │ Nullable(Bool)   │
+13. │ verified_purchase │ Nullable(Bool)   │
+14. │ review_headline   │ Nullable(String) │
+15. │ review_body       │ Nullable(String) │
+    └───────────────────┴──────────────────┘
+```
+
+Let's now compute the top product categories based on number of reviews, as well as computing the average star rating:
+
+```python
+chdb.query("""
+SELECT product_category, count() AS reviews, round(avg(star_rating), 2) as avg
+FROM s3('s3://datasets-documentation/amazon_reviews/*.parquet')
+GROUP BY ALL
+LIMIT 10
+""", 'PrettyCompact')
+```
+
+```text
+    ┌─product_category─┬──reviews─┬──avg─┐
+ 1. │ Toys             │  4864056 │ 4.21 │
+ 2. │ Apparel          │  5906085 │ 4.11 │
+ 3. │ Luggage          │   348644 │ 4.22 │
+ 4. │ Kitchen          │  4880297 │ 4.21 │
+ 5. │ Books            │ 19530930 │ 4.34 │
+ 6. │ Outdoors         │  2302327 │ 4.24 │
+ 7. │ Video            │   380596 │ 4.19 │
+ 8. │ Grocery          │  2402365 │ 4.31 │
+ 9. │ Shoes            │  4366757 │ 4.24 │
+10. │ Jewelry          │  1767667 │ 4.14 │
+    └──────────────────┴──────────┴──────┘
+```
+
+## Querying files in a private S3 bucket
+If we're querying files in a private S3 bucket, we need to pass in an access key and secret.
+We can pass in those credentials to the  `s3` table function:
+
+```python
+chdb.query("""
+SELECT product_category, count() AS reviews, round(avg(star_rating), 2) as avg
+FROM s3('s3://datasets-documentation/amazon_reviews/*.parquet', 'access-key', 'secret')
+GROUP BY ALL
+LIMIT 10
+""", 'PrettyCompact')
+```
+
+:::note
+This query won't work because it's a public bucket!
+:::
+
+An alternative way is to used [named collections](/operations/named-collections), but this approach isn't yet supported by chDB.
+
+---
+
+# Execution engine configuration
+
+**URL:** https://clickhouse.com/docs/chdb/configuration/execution-engine
+
+Configure DataStore execution engine - auto, chdb, or pandas
+
+DataStore can execute operations using different backends. This guide explains how to configure and optimize engine selection.
+
+## Available Engines
+| Engine | Description | Best For |
+|--------|-------------|----------|
+| `auto` | Automatically selects best engine per operation | General use (default) |
+| `chdb` | Forces all operations through ClickHouse SQL | Large datasets, aggregations |
+| `pandas` | Forces all operations through pandas | Compatibility testing, pandas-specific features |
+
+## Setting the Engine
+### Global Configuration
+```python
+from chdb.datastore.config import config
+
+# Option 1: Using set method
+config.set_execution_engine('auto')    # Default
+config.set_execution_engine('chdb')    # Force ClickHouse
+config.set_execution_engine('pandas')  # Force pandas
+
+# Option 2: Using shortcuts
+config.use_auto()     # Auto-select
+config.use_chdb()     # Force ClickHouse
+config.use_pandas()   # Force pandas
+```
+
+### Checking Current Engine
+```python
+print(config.execution_engine)  # 'auto', 'chdb', or 'pandas'
+```
+
+---
+
+## Auto Mode
+In `auto` mode (default), DataStore selects the optimal engine for each operation:
+
+### Operations Executed in chDB
+- SQL-compatible filtering (`filter()`, `where()`)
+- Column selection (`select()`)
+- Sorting (`sort()`, `orderby()`)
+- Grouping and aggregation (`groupby().agg()`)
+- Joins (`join()`, `merge()`)
+- Distinct (`distinct()`, `drop_duplicates()`)
+- Limiting (`limit()`, `head()`, `tail()`)
+
+### Operations Executed in pandas
+- Custom apply functions (`apply(custom_func)`)
+- Complex pivot tables with custom aggregations
+- Operations not expressible in SQL
+- When input is already a pandas DataFrame
+
+### Example
+```python
+from chdb import datastore as pd
+from chdb.datastore.config import config
+
+config.use_auto()  # Default
+
+ds = pd.read_csv("data.csv")
+
+# This uses chDB (SQL)
+result = (ds
+    .filter(ds['amount'] > 100)   # SQL: WHERE
+    .groupby('region')            # SQL: GROUP BY
+    .agg({'amount': 'sum'})       # SQL: SUM()
+)
+
+# This uses pandas (custom function)
+result = ds.apply(lambda row: complex_calculation(row), axis=1)
+```
+
+---
+
+## chDB Mode
+Force all operations through ClickHouse SQL:
+
+```python
+config.use_chdb()
+```
+
+### When to Use
+- Processing large datasets (millions of rows)
+- Heavy aggregation workloads
+- When you want maximum SQL optimization
+- Consistent behavior across all operations
+
+### Performance Characteristics
+| Operation Type | Performance |
+|----------------|-------------|
+| GroupBy/Aggregation | Excellent (up to 20x faster) |
+| Complex Filtering | Excellent |
+| Sorting | Very Good |
+| Simple Single Filters | Good (slight overhead) |
+
+### Limitations
+- Custom Python functions may not be supported
+- Some pandas-specific features require conversion
+
+---
+
+## pandas Mode
+Force all operations through pandas:
+
+```python
+config.use_pandas()
+```
+
+### When to Use
+- Compatibility testing with pandas
+- Using pandas-specific features
+- Debugging pandas-related issues
+- When data is already in pandas format
+
+### Performance Characteristics
+| Operation Type | Performance |
+|----------------|-------------|
+| Simple Single Operations | Good |
+| Custom Functions | Excellent |
+| Complex Aggregations | Slower than chDB |
+| Large Datasets | Memory intensive |
+
+---
+
+## Cross-DataStore Engine
+Configure the engine for operations that combine columns from different DataStores:
+
+```python
+# Set cross-DataStore engine
+config.set_cross_datastore_engine('auto')
+config.set_cross_datastore_engine('chdb')
+config.set_cross_datastore_engine('pandas')
+```
+
+### Example
+```python
+ds1 = pd.read_csv("sales.csv")
+ds2 = pd.read_csv("inventory.csv")
+
+# This operation involves two DataStores
+result = ds1.join(ds2, on='product_id')
+# Uses cross_datastore_engine setting
+```
+
+---
+
+## Engine Selection Logic
+### Auto Mode Decision Tree
+```text
+Operation requested
+    │
+    ├─ Can be expressed in SQL?
+    │      │
+    │      ├─ Yes → Use chDB
+    │      │
+    │      └─ No → Use pandas
+    │
+    └─ Cross-DataStore operation?
+           │
+           └─ Use cross_datastore_engine setting
+```
+
+### Function-Level Override
+Some functions can have their engine explicitly configured:
+
+```python
+from chdb.datastore.config import function_config
+
+# Force specific functions to use specific engine
+function_config.use_chdb('length', 'substring')
+function_config.use_pandas('upper', 'lower')
+```
+
+See [Function Config](function-config.md) for details.
+
+---
+
+## Performance Comparison
+Benchmark results on 10M rows:
+
+| Operation | pandas (ms) | chdb (ms) | Speedup |
+|-----------|-------------|-----------|---------|
+| GroupBy count | 347 | 17 | 19.93x |
+| Combined ops | 1,535 | 234 | 6.56x |
+| Complex pipeline | 2,047 | 380 | 5.39x |
+| Filter+Sort+Head | 1,537 | 350 | 4.40x |
+| GroupBy agg | 406 | 141 | 2.88x |
+| Single filter | 276 | 526 | 0.52x |
+
+**Key insights:**
+- chDB excels at aggregations and complex pipelines
+- pandas is slightly faster for simple single operations
+- Use `auto` mode to get the best of both
+
+---
+
+## Best Practices
+### 1. Start with Auto Mode
+```python
+config.use_auto()  # Let DataStore decide
+```
+
+### 2. Profile Before Forcing
+```python
+config.enable_profiling()
+# Run your workload
+# Check profiler report to see where time is spent
+```
+
+### 3. Force Engine for Specific Workloads
+```python
+# For heavy aggregation workloads
+config.use_chdb()
+
+# For pandas compatibility testing
+config.use_pandas()
+```
+
+### 4. Use explain() to Understand Execution
+```python
+ds = pd.read_csv("data.csv")
+query = ds.filter(ds['age'] > 25).groupby('city').agg({'salary': 'sum'})
+
+# See what SQL will be generated
+query.explain()
+```
+
+---
+
+## Troubleshooting
+### Issue: Operation slower than expected
+```python
+# Check current engine
+print(config.execution_engine)
+
+# Enable debug to see what's happening
+config.enable_debug()
+
+# Try forcing specific engine
+config.use_chdb()  # or config.use_pandas()
+```
+
+### Issue: Unsupported operation in chdb mode
+```python
+# Some pandas operations aren't supported in SQL
+# Solution: use auto mode
+config.use_auto()
+
+# Or explicitly convert to pandas first
+df = ds.to_df()
+result = df.some_pandas_specific_operation()
+```
+
+### Issue: Memory issues with large data
+```python
+# Use chdb engine to avoid loading all data into memory
+config.use_chdb()
+
+# Filter early to reduce data size
+result = ds.filter(ds['date'] >= '2024-01-01').to_df()
+
+# For maximum throughput on large datasets, use performance mode
+# which enables parallel Parquet reading and single-SQL aggregation
+config.use_performance_mode()
+```
+
+:::tip Performance Mode
+If you are running heavy aggregation workloads and don't need exact pandas output compatibility (row order, MultiIndex, dtype corrections), consider using [Performance Mode](performance-mode.md). It automatically sets the engine to `chdb` and removes all pandas compatibility overhead.
+:::
+
+---
+
+# Function-level configuration
+
+**URL:** https://clickhouse.com/docs/chdb/configuration/function-config
+
+Configure execution engine and Dtype correction at the function level
+
+DataStore allows fine-grained control over execution at the function level, including engine selection and Dtype correction.
+
+## Function Engine Configuration
+Override the execution engine for specific functions.
+
+### Setting Function Engines
+```python
+from chdb.datastore.config import function_config
+
+# Force specific functions to use chdb
+function_config.use_chdb('length', 'substring', 'concat')
+
+# Force specific functions to use pandas
+function_config.use_pandas('upper', 'lower', 'capitalize')
+
+# Set default preference
+function_config.prefer_chdb()    # Default to chdb
+function_config.prefer_pandas()  # Default to pandas
+
+# Reset to auto
+function_config.reset()
+```
+
+### When to Use
+**Force chdb for:**
+- Functions with better ClickHouse performance
+- Functions that benefit from SQL optimization
+- Large-scale string/datetime operations
+
+**Force pandas for:**
+- Functions with pandas-specific behavior
+- When exact pandas compatibility is required
+- Custom string operations
+
+### Example
+```python
+from chdb import datastore as pd
+from chdb.datastore.config import function_config
+
+# Configure function engines
+function_config.use_chdb('length', 'substring')
+function_config.use_pandas('upper')
+
+ds = pd.read_csv("data.csv")
+
+# length() will use chdb
+ds['name_len'] = ds['name'].str.len()
+
+# substring() will use chdb  
+ds['prefix'] = ds['name'].str.slice(0, 3)
+
+# upper() will use pandas
+ds['name_upper'] = ds['name'].str.upper()
+```
+
+---
+
+## Overlapping Functions
+159+ functions are available in both chdb and pandas engines:
+
+| Category | Functions |
+|----------|-----------|
+| **String** | `length`, `upper`, `lower`, `trim`, `ltrim`, `rtrim`, `concat`, `substring`, `replace`, `reverse`, `contains`, `startswith`, `endswith` |
+| **Math** | `abs`, `round`, `floor`, `ceil`, `exp`, `log`, `log10`, `sqrt`, `pow`, `sin`, `cos`, `tan` |
+| **DateTime** | `year`, `month`, `day`, `hour`, `minute`, `second`, `dayofweek`, `dayofyear`, `quarter` |
+| **Aggregation** | `sum`, `avg`, `min`, `max`, `count`, `std`, `var`, `median` |
+
+For overlapping functions, the engine is selected based on:
+1. Explicit function configuration (if set)
+2. Global execution_engine setting
+3. Auto-selection based on context
+
+---
+
+## chdb-Only Functions
+Some functions are only available through ClickHouse:
+
+| Category | Functions |
+|----------|-----------|
+| **Array** | `arraySum`, `arrayAvg`, `arraySort`, `arrayDistinct`, `groupArray`, `arrayElement` |
+| **JSON** | `JSONExtractString`, `JSONExtractInt`, `JSONExtractFloat`, `JSONHas` |
+| **URL** | `domain`, `path`, `protocol`, `extractURLParameter` |
+| **IP** | `IPv4StringToNum`, `IPv4NumToString`, `isIPv4String` |
+| **Geo** | `greatCircleDistance`, `geoDistance`, `geoToH3` |
+| **Hash** | `cityHash64`, `xxHash64`, `sipHash64`, `MD5`, `SHA256` |
+| **Conditional** | `sumIf`, `countIf`, `avgIf`, `minIf`, `maxIf` |
+
+These functions automatically use chdb engine regardless of configuration.
+
+---
+
+## pandas-Only Functions
+Some functions are only available through pandas:
+
+| Category | Functions |
+|----------|-----------|
+| **Apply** | Custom lambda functions, user-defined functions |
+| **Complex Pivot** | Pivot tables with custom aggregations |
+| **Stack/Unstack** | Complex reshaping operations |
+| **Interpolate** | Time series interpolation methods |
+
+These functions automatically use pandas engine regardless of configuration.
+
+---
+
+## Dtype Correction
+Configure how DataStore corrects data types between engines.
+
+### Correction Levels
+```python
+from chdb.datastore.dtype_correction.config import CorrectionLevel
+from chdb.datastore.config import config
+
+# No correction
+config.set_correction_level(CorrectionLevel.NONE)
+
+# Critical types only (NULL handling, boolean)
+config.set_correction_level(CorrectionLevel.CRITICAL)
+
+# High priority (default) - common type mismatches
+config.set_correction_level(CorrectionLevel.HIGH)
+
+# Medium - more aggressive correction
+config.set_correction_level(CorrectionLevel.MEDIUM)
+
+# All - correct all possible types
+config.set_correction_level(CorrectionLevel.ALL)
+```
+
+### Correction Level Details
+| Level | Description | Types Corrected |
+|-------|-------------|-----------------|
+| `NONE` | No automatic correction | None |
+| `CRITICAL` | Essential corrections | NULL handling, boolean conversion |
+| `HIGH` (default) | Common corrections | Integer/float precision, datetime, string encoding |
+| `MEDIUM` | More corrections | Decimal precision, timezone handling |
+| `ALL` | Maximum correction | All type differences |
+
+### When Types Need Correction
+Type differences can occur when:
+
+1. **ClickHouse → pandas**: Different integer sizes (Int64 vs int64)
+2. **pandas → ClickHouse**: Python objects to SQL types
+3. **NULL handling**: pandas NA vs ClickHouse NULL
+4. **Boolean**: Different boolean representations
+5. **DateTime**: Timezone differences
+
+### Example
+```python
+from chdb.datastore.dtype_correction.config import CorrectionLevel
+from chdb.datastore.config import config
+
+# Strict mode - expect exact type matches
+config.set_correction_level(CorrectionLevel.NONE)
+
+# Relaxed mode - auto-fix type issues
+config.set_correction_level(CorrectionLevel.ALL)
+```
+
+---
+
+## Function Configuration API
+### function_config Object
+```python
+from chdb.datastore.config import function_config
+
+# Force engine for functions
+function_config.use_chdb(*function_names)
+function_config.use_pandas(*function_names)
+
+# Set default preference
+function_config.prefer_chdb()
+function_config.prefer_pandas()
+
+# Reset to default (auto)
+function_config.reset()
+
+# Check configuration
+function_config.get_engine('length')  # Returns 'chdb', 'pandas', or 'auto'
+```
+
+### Per-Call Override
+Some methods support per-call engine override:
+
+```python
+# Using engine parameter (where supported)
+ds['result'] = ds['col'].str.upper(engine='pandas')
+```
+
+---
+
+## Best Practices
+### 1. Start with Defaults
+```python
+# Use auto mode, let DataStore decide
+config.use_auto()
+```
+
+### 2. Configure for Specific Workloads
+```python
+# For ClickHouse-optimized string processing
+function_config.use_chdb('length', 'substring', 'concat')
+
+# For pandas-compatible string behavior
+function_config.use_pandas('upper', 'lower')
+```
+
+### 3. Use Appropriate Correction Level
+```python
+# Development: more permissive
+config.set_correction_level(CorrectionLevel.ALL)
+
+# Production: stricter
+config.set_correction_level(CorrectionLevel.HIGH)
+```
+
+### 4. Test Both Engines
+```python
+# Test with chdb
+config.use_chdb()
+result_chdb = process_data()
+
+# Test with pandas
+config.use_pandas()
+result_pandas = process_data()
+
+# Compare results
+assert result_chdb.equals(result_pandas)
+```
+
+---
+
+# DataStore configuration
+
+**URL:** https://clickhouse.com/docs/chdb/configuration
+
+Configure DataStore execution engine, logging, caching, and profiling
+
+DataStore provides comprehensive configuration options for execution engine selection, compatibility mode, logging, caching, profiling, and dtype correction.
+
+## Quick Reference
+```python
+from chdb.datastore.config import config
+
+# Quick setup presets
+config.enable_debug()           # Enable verbose logging
+config.use_chdb()               # Force ClickHouse engine
+config.use_pandas()             # Force pandas engine
+config.use_auto()               # Auto-select engine (default)
+config.use_performance_mode()   # SQL-first, max throughput
+config.use_pandas_compat()      # Full pandas compatibility (default)
+config.enable_profiling()       # Enable performance profiling
+```
+
+## All Configuration Options
+| Category | Option | Values | Default | Description |
+|----------|--------|--------|---------|-------------|
+| **Logging** | `log_level` | DEBUG/INFO/WARNING/ERROR | WARNING | Log verbosity |
+| | `log_format` | "simple", "verbose" | "simple" | Log message format |
+| **Cache** | `cache_enabled` | True/False | True | Enable result caching |
+| | `cache_ttl` | float (seconds) | 0.0 | Cache time-to-live |
+| **Engine** | `execution_engine` | "auto", "chdb", "pandas" | "auto" | Execution engine |
+| | `cross_datastore_engine` | "auto", "chdb", "pandas" | "auto" | Cross-DataStore operations |
+| **Compat** | `compat_mode` | "pandas", "performance" | "pandas" | Pandas compatibility vs SQL-first throughput |
+| **Profiling** | `profiling_enabled` | True/False | False | Enable profiling |
+| **Dtype** | `correction_level` | NONE/CRITICAL/HIGH/MEDIUM/ALL | HIGH | Dtype correction level |
+
+---
+
+## Configuration Methods
+### Logging Configuration
+```python
+from chdb.datastore.config import config
+
+# Set log level
+config.set_log_level(logging.DEBUG)
+config.set_log_level(logging.INFO)
+config.set_log_level(logging.WARNING)  # Default
+config.set_log_level(logging.ERROR)
+
+# Set log format
+config.set_log_format("simple")   # Default
+config.set_log_format("verbose")  # More details
+
+# Quick enable debug mode
+config.enable_debug()  # Sets DEBUG level + verbose format
+```
+
+See [Logging](../debugging/logging.md) for details.
+
+### Cache Configuration
+```python
+# Enable/disable caching
+config.set_cache_enabled(True)   # Default
+config.set_cache_enabled(False)  # Disable caching
+
+# Set cache TTL (time-to-live)
+config.set_cache_ttl(60.0)  # Cache expires after 60 seconds
+config.set_cache_ttl(0.0)   # No expiration (default)
+
+# Check current settings
+print(config.cache_enabled)
+print(config.cache_ttl)
+```
+
+### Engine Configuration
+```python
+# Set execution engine
+config.set_execution_engine('auto')    # Auto-select (default)
+config.set_execution_engine('chdb')    # Force ClickHouse
+config.set_execution_engine('pandas')  # Force pandas
+
+# Quick presets
+config.use_auto()     # Auto-select
+config.use_chdb()     # Force ClickHouse
+config.use_pandas()   # Force pandas
+
+# Cross-DataStore engine (for operations between different DataStores)
+config.set_cross_datastore_engine('auto')
+config.set_cross_datastore_engine('chdb')
+config.set_cross_datastore_engine('pandas')
+
+# Check current engine
+print(config.execution_engine)
+```
+
+See [Execution Engine](execution-engine.md) for details.
+
+### Compatibility Mode
+```python
+# Performance mode: SQL-first, no pandas compatibility overhead
+config.use_performance_mode()
+# or: config.set_compat_mode('performance')
+
+# Pandas compatibility mode (default)
+config.use_pandas_compat()
+# or: config.set_compat_mode('pandas')
+
+# Check current mode
+print(config.compat_mode)  # 'pandas' or 'performance'
+```
+
+See [Performance Mode](performance-mode.md) for details.
+
+### Profiling Configuration
+```python
+# Enable profiling
+config.enable_profiling()
+config.set_profiling_enabled(True)
+
+# Disable profiling
+config.set_profiling_enabled(False)
+
+# Check if profiling is enabled
+print(config.profiling_enabled)
+```
+
+See [Profiling](../debugging/profiling.md) for details.
+
+### Dtype Correction
+```python
+from chdb.datastore.dtype_correction.config import CorrectionLevel
+
+# Set correction level
+config.set_correction_level(CorrectionLevel.NONE)      # No correction
+config.set_correction_level(CorrectionLevel.CRITICAL)  # Critical types only
+config.set_correction_level(CorrectionLevel.HIGH)      # Default
+config.set_correction_level(CorrectionLevel.MEDIUM)    # More corrections
+config.set_correction_level(CorrectionLevel.ALL)       # All corrections
+```
+
+---
+
+## Using config Object
+The `config` object is a singleton that manages all settings:
+
+```python
+from chdb.datastore.config import config
+
+# Read settings
+print(config.log_level)
+print(config.execution_engine)
+print(config.cache_enabled)
+print(config.profiling_enabled)
+
+# Modify settings
+config.set_log_level(logging.DEBUG)
+config.set_execution_engine('chdb')
+config.set_cache_enabled(False)
+config.enable_profiling()
+```
+
+---
+
+## Configuration in Code
+### Per-Script Configuration
+```python
+from chdb import datastore as pd
+from chdb.datastore.config import config
+
+# Configure at script start
+config.enable_debug()
+config.use_chdb()
+config.enable_profiling()
+
+# Your DataStore code
+ds = pd.read_csv("data.csv")
+result = ds.filter(ds['age'] > 25).groupby('city').agg({'salary': 'mean'})
+```
+
+### Context Manager (Future)
+```python
+# Planned feature: temporary configuration
+with config.override(execution_engine='pandas'):
+    result = ds.process()
+# Original settings restored
+```
+
+---
+
+## Common Configuration Scenarios
+### Development/Debugging
+```python
+from chdb.datastore.config import config
+
+config.enable_debug()        # Verbose logging
+config.enable_profiling()    # Performance tracking
+config.set_cache_enabled(False)  # Disable caching for fresh results
+```
+
+### Production
+```python
+from chdb.datastore.config import config
+
+config.set_log_level(logging.WARNING)  # Minimal logging
+config.set_execution_engine('auto')    # Optimal engine selection
+config.set_cache_enabled(True)         # Enable caching
+config.set_profiling_enabled(False)    # Disable profiling overhead
+```
+
+### Maximum Throughput
+```python
+from chdb.datastore.config import config
+
+config.use_performance_mode()    # SQL-first, no pandas overhead
+config.set_cache_enabled(False)  # Disable cache for streaming
+```
+
+### Performance Testing
+```python
+from chdb.datastore.config import config
+
+config.use_chdb()            # Force ClickHouse for benchmarks
+config.enable_profiling()    # Track performance
+config.set_cache_enabled(False)  # Disable cache for accurate timing
+```
+
+### Pandas Compatibility Testing
+```python
+from chdb.datastore.config import config
+
+config.use_pandas()          # Force pandas engine
+config.enable_debug()        # See what operations are used
+```
+
+---
+
+## Related Documentation
+- [Execution Engine](execution-engine.md) - Engine selection details
+- [Performance Mode](performance-mode.md) - SQL-first mode for maximum throughput
+- [Function Config](function-config.md) - Per-function engine configuration
+- [Logging](../debugging/logging.md) - Logging configuration
+- [Profiling](../debugging/profiling.md) - Performance profiling
+
+---
+
+# Performance mode (compat_mode)
+
+**URL:** https://clickhouse.com/docs/chdb/configuration/performance-mode
+
+SQL-first performance mode that disables pandas compatibility overhead for maximum throughput
+
+DataStore has two compatibility modes that control whether output is shaped for pandas compatibility or optimized for raw SQL performance.
+
+## Overview
+| Mode | `compat_mode` value | Description |
+|------|---------------------|-------------|
+| **Pandas** (default) | `"pandas"` | Full pandas behavior compatibility. Row order preserved, MultiIndex, set_index, dtype corrections, stable sort tiebreakers, `-If`/`isNaN` wrappers. |
+| **Performance** | `"performance"` | SQL-first execution. All pandas compatibility overhead removed. Maximum throughput, but results may differ structurally from pandas. |
+
+### What Performance Mode Disables
+| Overhead | Pandas mode behavior | Performance mode behavior |
+|----------|---------------------|--------------------------|
+| **Row-order preservation** | `_row_id` injection, `rowNumberInAllBlocks()`, `__orig_row_num__` subqueries | Disabled — row order not guaranteed |
+| **Stable sort tiebreaker** | `rowNumberInAllBlocks() ASC` appended to ORDER BY | Disabled — ties may have arbitrary order |
+| **Parquet preserve_order** | `input_format_parquet_preserve_order=1` | Disabled — parallel Parquet reading allowed |
+| **GroupBy auto ORDER BY** | `ORDER BY group_key` added (pandas default `sort=True`) | Disabled — groups returned in arbitrary order |
+| **GroupBy dropna WHERE** | `WHERE key IS NOT NULL` added (pandas default `dropna=True`) | Disabled — NULL groups included |
+| **GroupBy set_index** | Group keys set as index | Disabled — group keys stay as columns |
+| **MultiIndex columns** | `agg({'col': ['sum','mean']})` returns MultiIndex columns | Disabled — flat column names (`col_sum`, `col_mean`) |
+| **`-If`/`isNaN` wrappers** | `sumIf(col, NOT isNaN(col))` for skipna | Disabled — plain `sum(col)` (ClickHouse natively skips NULL) |
+| **`toInt64` on count** | `toInt64(count())` to match pandas int64 | Disabled — native SQL dtype returned |
+| **`fillna(0)` for all-NaN sum** | Sum of all-NaN returns 0 (pandas behavior) | Disabled — returns NULL |
+| **Dtype corrections** | `abs()` unsigned→signed, etc. | Disabled — native SQL dtypes |
+| **Index preservation** | Restores original index after SQL execution | Disabled |
+| **`first()`/`last()`** | `argMin/argMax(col, rowNumberInAllBlocks())` | `any(col)` / `anyLast(col)` — faster but non-deterministic |
+| **Single-SQL aggregation** | ColumnExpr groupby materializes intermediate DataFrame | Injects `LazyGroupByAgg` into lazy ops chain — single SQL query |
+
+---
+
+## Enabling Performance Mode
+### Using config object
+```python
+from chdb.datastore.config import config
+
+# Enable performance mode
+config.use_performance_mode()
+
+# Back to pandas compatibility
+config.use_pandas_compat()
+
+# Check current mode
+print(config.compat_mode)  # 'pandas' or 'performance'
+```
+
+### Using module-level functions
+```python
+from chdb.datastore.config import set_compat_mode, CompatMode, is_performance_mode
+
+# Enable performance mode
+set_compat_mode(CompatMode.PERFORMANCE)
+
+# Check
+print(is_performance_mode())  # True
+
+# Back to default
+set_compat_mode(CompatMode.PANDAS)
+```
+
+### Using convenience imports
+```python
+from chdb import use_performance_mode, use_pandas_compat
+
+use_performance_mode()
+# ... high-performance operations ...
+use_pandas_compat()
+```
+
+:::note
+Setting performance mode automatically sets the execution engine to `chdb`. You do not need to call `config.use_chdb()` separately.
+:::
+
+---
+
+## When to Use Performance Mode
+**Use performance mode when:**
+- Processing large datasets (hundreds of thousands to millions of rows)
+- Running aggregation-heavy workloads (groupby, sum, mean, count)
+- Row order does not matter (e.g., aggregated results, reports, dashboards)
+- You want maximum SQL throughput and minimal overhead
+- Memory usage is a concern (parallel Parquet reading, no intermediate DataFrames)
+
+**Stay in pandas mode when:**
+- You need exact pandas behavior (row order, MultiIndex, dtypes)
+- You rely on `first()`/`last()` returning the true first/last row
+- You use `shift()`, `diff()`, `cumsum()` that depend on row order
+- You're writing tests that compare DataStore output with pandas
+
+---
+
+## Behavior Differences
+### Row Order
+In performance mode, row order is **not guaranteed** for any operation. This includes:
+
+- Filter results
+- GroupBy aggregation results
+- `head()` / `tail()` without explicit `sort_values()`
+- `first()` / `last()` aggregations
+
+If you need ordered results, add an explicit `sort_values()`:
+
+```python
+config.use_performance_mode()
+
+ds = pd.read_csv("data.csv")
+
+# Unordered (fast)
+result = ds.groupby("region")["revenue"].sum()
+
+# Ordered (still fast, just adds ORDER BY)
+result = ds.groupby("region")["revenue"].sum().sort_values()
+```
+
+### GroupBy Results
+| Aspect | Pandas mode | Performance mode |
+|--------|------------|-----------------|
+| Group key location | Index (via `set_index`) | Regular column |
+| Group order | Sorted by key (default) | Arbitrary order |
+| NULL groups | Excluded (default `dropna=True`) | Included |
+| Column format | MultiIndex for multi-agg | Flat names (`col_func`) |
+| `first()`/`last()` | Deterministic (row order) | Non-deterministic (`any()`/`anyLast()`) |
+
+### Aggregation
+```python
+config.use_performance_mode()
+
+# Sum of all-NaN group returns NULL (not 0)
+# Count returns native uint64 (not forced int64)
+# No -If wrappers: sum() instead of sumIf()
+result = ds.groupby("cat")["val"].sum()
+```
+
+### Single-SQL Execution
+In performance mode, `ColumnExpr` groupby aggregation (e.g., `ds[condition].groupby('col')['val'].sum()`) is executed as a **single SQL query** instead of the two-step process used in pandas mode:
+
+```python
+config.use_performance_mode()
+
+# Pandas mode: two SQL queries (filter → materialize → groupby)
+# Performance mode: one SQL query (WHERE + GROUP BY in same query)
+result = ds[ds["rating"] > 3.5].groupby("category")["revenue"].sum()
+
+# Generated SQL (single query):
+# SELECT category, sum(revenue) FROM data WHERE rating > 3.5 GROUP BY category
+```
+
+This eliminates the intermediate DataFrame materialization and can significantly reduce memory usage and execution time.
+
+---
+
+## Comparison with Execution Engine
+Performance mode (`compat_mode`) and execution engine (`execution_engine`) are **independent configuration axes**:
+
+| Config | Controls | Values |
+|--------|----------|--------|
+| `execution_engine` | **Which engine** runs the computation | `auto`, `chdb`, `pandas` |
+| `compat_mode` | **Whether** to reshape output for pandas compatibility | `pandas`, `performance` |
+
+Setting `compat_mode='performance'` automatically sets `execution_engine='chdb'`, since performance mode is designed for SQL execution.
+
+```python
+from chdb.datastore.config import config
+
+# These are independent
+config.use_chdb()              # Force chDB engine, keep pandas compat
+config.use_performance_mode()  # Force chDB + remove pandas overhead
+```
+
+---
+
+## Testing with Performance Mode
+When writing tests for performance mode, results may differ from pandas in row order and structural format. Use these strategies:
+
+### Sort-then-compare (aggregations, filters)
+```python
+# Sort both sides by the same columns before comparing
+ds_result = ds.groupby("cat")["val"].sum()
+pd_result = pd_df.groupby("cat")["val"].sum()
+
+ds_sorted = ds_result.sort_index()
+pd_sorted = pd_result.sort_index()
+np.testing.assert_array_equal(ds_sorted.values, pd_sorted.values)
+```
+
+### Value-range check (first/last)
+```python
+# first() with any() returns an arbitrary element from the group
+result = ds.groupby("cat")["val"].first()
+for group_key in groups:
+    assert result.loc[group_key] in group_values[group_key]
+```
+
+### Schema-and-count (LIMIT without ORDER BY)
+```python
+# head() without sort_values: row set is non-deterministic
+result = ds.head(5)
+assert len(result) == 5
+assert set(result.columns) == expected_columns
+```
+
+---
+
+## Best Practices
+### 1. Enable early in your script
+```python
+from chdb.datastore.config import config
+
+config.use_performance_mode()
+
+# All subsequent operations benefit
+ds = pd.read_parquet("data.parquet")
+result = ds[ds["amount"] > 100].groupby("region")["amount"].sum()
+```
+
+### 2. Add explicit sorting when order matters
+```python
+# For display or downstream processing that expects order
+result = (ds
+    .groupby("region")["revenue"].sum()
+    .sort_values(ascending=False)
+)
+```
+
+### 3. Use for batch/ETL workloads
+```python
+config.use_performance_mode()
+
+# ETL pipeline — order doesn't matter, throughput does
+summary = (ds
+    .filter(ds["date"] >= "2024-01-01")
+    .groupby(["region", "product"])
+    .agg({"revenue": "sum", "quantity": "sum", "rating": "mean"})
+)
+summary.to_df().to_parquet("summary.parquet")
+```
+
+### 4. Switch modes within a session
+```python
+# Performance mode for heavy computation
+config.use_performance_mode()
+aggregated = ds.groupby("cat")["val"].sum()
+
+# Back to pandas mode for exact-match comparison
+config.use_pandas_compat()
+detailed = ds[ds["val"] > 100].head(10)
+```
+
+---
+
+## Related Documentation
+- [Execution Engine](execution-engine.md) — Engine selection (auto/chdb/pandas)
+- [Performance Guide](../guides/pandas-performance.md) — General optimization tips
+- [Key Differences from pandas](../guides/pandas-differences.md) — Behavioral differences
+
+---
+
+# explain() method
+
+**URL:** https://clickhouse.com/docs/chdb/debugging/explain
+
+View DataStore execution plans with the explain() method
+
+The `explain()` method shows the execution plan for a DataStore query, helping you understand what operations will be performed and what SQL will be generated.
+
+## Basic Usage
+```python
+from pathlib import Path
+Path("sales.csv").write_text("""\
+region,product,category,amount,quantity,price,date,order_id
+East,Widget,Electronics,5200,10,120,2024-01-15,1001
+West,Gadget,Electronics,800,5,160,2024-02-20,1002
+East,Gizmo,Home,6500,3,100,2024-03-10,1003
+North,Widget,Electronics,4500,6,150,2024-06-18,1004
+West,Gadget,Electronics,2000,8,250,2024-09-14,1005
+""")
+
+from chdb import datastore as pd
+
+ds = pd.read_csv("sales.csv")
+
+query = (ds
+    .filter(ds['amount'] > 1000)
+    .groupby('region')
+    .agg({'amount': ['sum', 'mean']})
+    .sort('sum', ascending=False)
+)
+
+# View execution plan
+query.explain()
+```
+
+## Syntax
+```python
+explain(verbose=False) -> None
+```
+
+**Parameters:**
+
+| Parameter | Type | Default | Description |
+|-----------|------|---------|-------------|
+| `verbose` | bool | `False` | Show additional metadata |
+
+## Output Format
+### Standard Output
+```text
+================================================================================
+Execution Plan (in execution order)
+================================================================================
+
+ [1] 📊 Data Source: file('sales.csv', 'csv')
+
+Operations:
+────────────────────────────────────────────────────────────────────────────────
+    ️  Segment 1 [chDB] (from source): Operations 2-5
+    ️  Note: SQL operations after Pandas ops use Python() table function
+
+ [2] 🚀 [chDB] WHERE: "amount" > 1000
+ [3] 🚀 [chDB] GROUP BY: region
+ [4] 🚀 [chDB] AGGREGATE: sum(amount), avg(amount)
+ [5] 🚀 [chDB] ORDER BY: sum DESC
+
+────────────────────────────────────────────────────────────────────────────────
+Final State: 📊 Pending (lazy, not yet executed)
+             └─> Will execute when print(), .to_df(), .execute() is called
+
+────────────────────────────────────────────────────────────────────────────────
+Generated SQL Query:
+────────────────────────────────────────────────────────────────────────────────
+
+SELECT region, SUM(amount) AS sum, AVG(amount) AS mean
+FROM file('sales.csv', 'csv')
+WHERE "amount" > 1000
+GROUP BY region
+ORDER BY sum DESC
+
+================================================================================
+```
+
+### Icons Legend
+| Icon | Meaning |
+|------|---------|
+| 📊 | Data source |
+| 🚀 | chDB (SQL) operation |
+| 🐼 | pandas operation |
+
+### Verbose Output
+```python
+query.explain(verbose=True)
+```
+
+Verbose mode shows additional details for each operation, including the full SQL query with internal row-order tracking mechanisms.
+
+---
+
+## Three Execution Phases
+The explain output shows operations in three phases:
+
+### Phase 1: SQL Query Building (Lazy)
+Operations that compile to SQL:
+
+```text
+  1. Source: file('sales.csv', 'CSVWithNames')
+  2. Filter: amount > 1000      
+  3. GroupBy: region
+  4. Aggregate: sum(amount)
+```
+
+### Phase 2: Execution Point
+When a trigger occurs:
+
+```text
+  5. Execute SQL -> DataFrame
+     Trigger: to_df() called
+```
+
+### Phase 3: DataFrame Operations
+Operations after execution:
+
+```text
+  6. [pandas] pivot_table(...)
+  7. [pandas] apply(custom_func)
+```
+
+---
+
+## Understanding the Plan
+### Source Information
+```text
+Source: file('sales.csv', 'CSVWithNames')
+```
+
+- `file()` - ClickHouse file() table function
+- `'CSVWithNames'` - File format with header
+
+Other source types:
+```text
+Source: s3('bucket/data.parquet', ...)
+Source: mysql('host', 'db', 'table', ...)
+Source: __dataframe__  (pandas DataFrame input)
+```
+
+### Filter Operations
+```text
+Filter: amount > 1000 AND status = 'active'
+```
+
+Shows the WHERE clause that will be applied.
+
+### GroupBy and Aggregate
+```text
+GroupBy: region, category
+Aggregate: sum(amount), avg(amount), count(id)
+```
+
+Shows GROUP BY columns and aggregation functions.
+
+### Sort Operations
+```text
+Sort: sum DESC, region ASC
+```
+
+Shows ORDER BY clause.
+
+### Limit Operations
+```text
+Limit: 10
+Offset: 100
+```
+
+Shows LIMIT and OFFSET.
+
+---
+
+## Engine Information
+When using verbose mode, you can see which engine will be used:
+
+```text
+Filter: amount > 1000
+  - Engine: chdb
+  - Pushdown: Yes
+
+Apply: custom_function
+  - Engine: pandas
+  - Pushdown: No
+```
+
+### Pushdown
+- **Yes**: Operation will be executed at the data source (SQL)
+- **No**: Operation requires pandas execution
+
+---
+
+## Examples
+### Simple Query
+```python
+from pathlib import Path
+Path("data.csv").write_text("""\
+name,age,city,salary,department
+Alice,25,NYC,55000,Engineering
+Bob,30,LA,65000,Product
+Charlie,35,NYC,80000,Engineering
+Diana,28,SF,70000,Design
+Eve,42,NYC,95000,Product
+""")
+
+ds = pd.read_csv("data.csv")
+ds.filter(ds['age'] > 25).explain()
+```
+
+```text
+================================================================================
+Execution Plan (in execution order)
+================================================================================
+
+ [1] 📊 Data Source: file('data.csv', 'csv')
+
+Operations:
+────────────────────────────────────────────────────────────────────────────────
+    ️  Segment 1 [chDB] (from source): Operations 2-2
+
+ [2] 🚀 [chDB] WHERE: "age" > 25
+
+────────────────────────────────────────────────────────────────────────────────
+Generated SQL Query:
+────────────────────────────────────────────────────────────────────────────────
+
+SELECT * FROM file('data.csv', 'csv') WHERE "age" > 25
+
+================================================================================
+```
+
+### Complex Aggregation
+```python
+query = (ds
+    .filter(ds['date'] >= '2024-01-01')
+    .filter(ds['amount'] > 100)
+    .select('region', 'category', 'amount')
+    .groupby('region', 'category')
+    .agg({
+        'amount': ['sum', 'mean', 'count']
+    })
+    .sort('sum', ascending=False)
+    .limit(20)
+)
+query.explain()
+```
+
+```text
+================================================================================
+Execution Plan (in execution order)
+================================================================================
+
+ [1] 📊 Data Source: file('sales.csv', 'csv')
+
+Operations:
+────────────────────────────────────────────────────────────────────────────────
+    ️  Segment 1 [chDB] (from source): Operations 2-8
+
+ [2] 🚀 [chDB] WHERE: "date" >= '2024-01-01'
+ [3] 🚀 [chDB] WHERE: "amount" > 100
+ [4] 🚀 [chDB] SELECT: region, category, amount
+ [5] 🚀 [chDB] GROUP BY: region, category
+ [6] 🚀 [chDB] AGGREGATE: sum(amount), avg(amount), count(amount)
+ [7] 🚀 [chDB] ORDER BY: sum DESC
+ [8] 🚀 [chDB] LIMIT: 20
+
+────────────────────────────────────────────────────────────────────────────────
+Generated SQL Query:
+────────────────────────────────────────────────────────────────────────────────
+
+SELECT region, category, 
+       SUM(amount) AS sum, 
+       AVG(amount) AS mean, 
+       COUNT(amount) AS count
+FROM file('sales.csv', 'csv')
+WHERE "date" >= '2024-01-01' AND "amount" > 100
+GROUP BY region, category
+ORDER BY sum DESC
+LIMIT 20
+
+================================================================================
+```
+
+### Mixed SQL and pandas
+When operations cannot be fully pushed to SQL, the plan shows multiple segments:
+
+```python
+query = (ds
+    .filter(ds['age'] > 25)           # SQL
+    .groupby('city')                   # SQL
+    .agg({'salary': 'mean'})           # SQL
+    .apply(lambda x: x * 1.1)          # pandas (triggers segment split)
+    .filter(ds['mean'] > 50000)        # SQL (new segment)
+)
+query.explain()
+```
+
+```text
+================================================================================
+Execution Plan (in execution order)
+================================================================================
+
+ [1] 📊 Data Source: file('data.csv', 'csv')
+
+Operations:
+────────────────────────────────────────────────────────────────────────────────
+    ️  Segment 1 [chDB] (from source): Operations 2-4
+    ️  Segment 2 [Pandas] (on DataFrame): Operation 5
+    ️  Segment 3 [chDB] (on DataFrame): Operation 6
+    ️  Note: SQL operations after Pandas ops use Python() table function
+
+ [2] 🚀 [chDB] WHERE: "age" > 25
+ [3] 🚀 [chDB] GROUP BY: city
+ [4] 🚀 [chDB] AGGREGATE: avg(salary)
+ [5] 🐼 [Pandas] APPLY: lambda
+ [6] 🚀 [chDB] WHERE: "mean" > 50000
+
+================================================================================
+```
+
+---
+
+## Debugging with explain()
+### Check Filter Logic
+```python
+# Verify your filter is correct
+query = ds.filter((ds['age'] > 25) & (ds['city'] == 'NYC'))
+query.explain()
+# Output shows: Filter: age > 25 AND city = 'NYC'
+```
+
+### Verify Column Selection
+```python
+# Check column pruning
+query = ds.select('name', 'age').filter(ds['age'] > 25)
+query.explain()
+# Output shows: SELECT name, age FROM ... WHERE age > 25
+```
+
+### Understand Aggregation
+```python
+# Check aggregation functions
+query = ds.groupby('dept').agg({'salary': ['sum', 'mean', 'std']})
+query.explain()
+# Output shows: SELECT dept, SUM(salary), AVG(salary), stddevPop(salary)
+```
+
+---
+
+## Best Practices
+### 1. Check Before Executing Large Queries
+```python
+# Always explain first for large data
+query = ds.complex_pipeline()
+query.explain()  # Check plan
+
+# If plan looks correct
+result = query.to_df()  # Execute
+```
+
+### 2. Use Verbose for Debugging
+```python
+# When something seems wrong
+query.explain(verbose=True)
+# Shows engine selection and pushdown info
+```
+
+### 3. Compare with to_sql()
+```python
+# explain() shows the plan
+query.explain()
+
+# to_sql() shows just the SQL
+print(query.to_sql())
+
+# Both useful for different purposes
+```
+
+### 4. Check Pushdown Status
+```python
+# Verbose mode shows if operations are pushed down
+query.explain(verbose=True)
+
+# If Pushdown: No, operation runs in pandas
+# Consider restructuring query for better performance
+```
+
+---
+
+# DataStore debugging
+
+**URL:** https://clickhouse.com/docs/chdb/debugging
+
+Debug DataStore operations with explain(), profiling, and logging
+
+DataStore provides comprehensive debugging tools to understand and optimize your data pipelines.
+
+## Debugging Tools Overview
+| Tool | Purpose | When to Use |
+|------|---------|-------------|
+| `explain()` | View execution plan | Understand what SQL will run |
+| Profiler | Measure performance | Find slow operations |
+| Logging | View execution details | Debug unexpected behavior |
+
+## Quick Decision Matrix
+| Need | Tool | Command |
+|------|------|---------|
+| See execution plan | `explain()` | `ds.explain()` |
+| Measure performance | Profiler | `config.enable_profiling()` |
+| Debug SQL queries | Logging | `config.enable_debug()` |
+| All of the above | Combined | See below |
+
+## Quick Setup
+### Enable All Debugging
+```python
+from chdb import datastore as pd
+from chdb.datastore.config import config
+
+# Enable all debugging
+config.enable_debug()        # Verbose logging
+config.enable_profiling()    # Performance tracking
+
+ds = pd.read_csv("data.csv")
+result = ds.filter(ds['age'] > 25).groupby('city').agg({'salary': 'mean'})
+
+# View execution plan
+result.explain()
+
+# Get profiler report
+from chdb.datastore.config import get_profiler
+profiler = get_profiler()
+profiler.report()
+```
+
+---
+
+## explain() Method
+View the execution plan before running a query.
+
+```python title="Query"
+ds = pd.read_csv("data.csv")
+
+query = (ds
+    .filter(ds['amount'] > 1000)
+    .groupby('region')
+    .agg({'amount': ['sum', 'mean']})
+)
+
+# View plan
+query.explain()
+```
+
+```text title="Response"
+Pipeline:
+  Source: file('data.csv', 'CSVWithNames')
+  Filter: amount > 1000
+  GroupBy: region
+  Aggregate: sum(amount), avg(amount)
+
+Generated SQL:
+SELECT region, SUM(amount) AS sum, AVG(amount) AS mean
+FROM file('data.csv', 'CSVWithNames')
+WHERE amount > 1000
+GROUP BY region
+```
+
+See [explain() Documentation](explain.md) for details.
+
+---
+
+## Profiling
+Measure execution time for each operation.
+
+```python title="Query"
+from chdb.datastore.config import config, get_profiler
+
+# Enable profiling
+config.enable_profiling()
+
+# Run operations
+ds = pd.read_csv("large_data.csv")
+result = (ds
+    .filter(ds['amount'] > 100)
+    .groupby('category')
+    .agg({'amount': 'sum'})
+    .sort('sum', ascending=False)
+    .head(10)
+    .to_df()
+)
+
+# View report
+profiler = get_profiler()
+profiler.report(min_duration_ms=0.1)
+```
+
+```text title="Response"
+Performance Report
+==================
+Step                          Duration    Calls
+----                          --------    -----
+read_csv                      1.234s      1
+filter                        0.002s      1
+groupby                       0.001s      1
+agg                           0.089s      1
+sort                          0.045s      1
+head                          0.001s      1
+to_df (SQL execution)         0.567s      1
+----                          --------    -----
+Total                         1.939s      7
+```
+
+See [Profiling Guide](profiling.md) for details.
+
+---
+
+## Logging
+View detailed execution logs.
+
+```python
+from chdb.datastore.config import config
+
+# Enable debug logging
+config.enable_debug()
+
+# Run operations - logs will show:
+# - SQL queries generated
+# - Execution engine used
+# - Cache hits/misses
+# - Timing information
+```
+
+Log output example:
+```text
+DEBUG - DataStore: Creating from file 'data.csv'
+DEBUG - Query: SELECT region, SUM(amount) FROM ... WHERE amount > 1000 GROUP BY region
+DEBUG - Engine: Using chdb for aggregation
+DEBUG - Execution time: 0.089s
+DEBUG - Cache: Storing result (key: abc123)
+```
+
+See [Logging Configuration](logging.md) for details.
+
+---
+
+## Common Debugging Scenarios
+### 1. Query Not Returning Expected Results
+```python
+# Step 1: View the execution plan
+query = ds.filter(ds['age'] > 25).groupby('city').sum()
+query.explain(verbose=True)
+
+# Step 2: Enable logging to see SQL
+config.enable_debug()
+
+# Step 3: Run and check logs
+result = query.to_df()
+```
+
+### 2. Query Running Slowly
+```python
+# Step 1: Enable profiling
+config.enable_profiling()
+
+# Step 2: Run your query
+result = process_data()
+
+# Step 3: Check profiler report
+profiler = get_profiler()
+profiler.report()
+
+# Step 4: Identify slow operations and optimize
+```
+
+### 3. Understanding Engine Selection
+```python
+# Enable verbose logging
+config.enable_debug()
+
+# Run operations
+result = ds.filter(ds['x'] > 10).apply(custom_func)
+
+# Logs will show which engine was used for each operation:
+# DEBUG - filter: Using chdb engine
+# DEBUG - apply: Using pandas engine (custom function)
+```
+
+### 4. Debugging Cache Issues
+```python
+# Enable debug to see cache operations
+config.enable_debug()
+
+# First run
+result1 = ds.filter(ds['x'] > 10).to_df()
+# LOG: Cache miss, executing query
+
+# Second run (should use cache)
+result2 = ds.filter(ds['x'] > 10).to_df()
+# LOG: Cache hit, returning cached result
+
+# If not caching when expected, check:
+# - Are operations identical?
+# - Is cache enabled? config.cache_enabled
+```
+
+---
+
+## Best Practices
+### 1. Debug in Development, Not Production
+```python
+# Development
+config.enable_debug()
+config.enable_profiling()
+
+# Production
+config.set_log_level(logging.WARNING)
+config.set_profiling_enabled(False)
+```
+
+### 2. Use explain() Before Running Large Queries
+```python
+# Build query
+query = ds.filter(...).groupby(...).agg(...)
+
+# Check plan first
+query.explain()
+
+# If plan looks good, execute
+result = query.to_df()
+```
+
+### 3. Profile Before Optimizing
+```python
+# Don't guess what's slow - measure it
+config.enable_profiling()
+result = your_pipeline()
+get_profiler().report()
+```
+
+### 4. Check SQL When Results Are Wrong
+```python
+# View generated SQL
+print(query.to_sql())
+
+# Compare with expected SQL
+# Run SQL directly in ClickHouse to verify
+```
+
+---
+
+## Debugging Tools Summary
+| Tool | Command | Output |
+|------|---------|--------|
+| Explain plan | `ds.explain()` | Execution steps + SQL |
+| Verbose explain | `ds.explain(verbose=True)` | + Metadata |
+| View SQL | `ds.to_sql()` | SQL query string |
+| Enable debug | `config.enable_debug()` | Detailed logs |
+| Enable profiling | `config.enable_profiling()` | Timing data |
+| Profiler report | `get_profiler().report()` | Performance summary |
+| Clear profiler | `get_profiler().reset()` | Clear timing data |
+
+---
+
+## Next Steps
+- [explain() Method](explain.md) - Detailed execution plan documentation
+- [Profiling Guide](profiling.md) - Performance measurement
+- [Logging Configuration](logging.md) - Log level and format setup
+
+---
+
+# DataStore logging
+
+**URL:** https://clickhouse.com/docs/chdb/debugging/logging
+
+Configure DataStore logging for debugging and monitoring
+
+DataStore uses Python's standard logging module. This guide shows how to configure logging for debugging.
+
+## Quick Start
+```python
+from pathlib import Path
+Path("data.csv").write_text("""\
+name,age,city,salary,department
+Alice,25,NYC,55000,Engineering
+Bob,30,LA,65000,Product
+Charlie,35,NYC,80000,Engineering
+Diana,28,SF,70000,Design
+Eve,42,NYC,95000,Product
+""")
+
+from chdb import datastore as pd
+from chdb.datastore.config import config
+
+# Enable debug logging
+config.enable_debug()
+
+# Now all operations will log details
+ds = pd.read_csv("data.csv")
+result = ds.filter(ds['age'] > 25).to_df()
+```
+
+## Log Levels
+| Level | Value | Description |
+|-------|-------|-------------|
+| `DEBUG` | 10 | Detailed information for debugging |
+| `INFO` | 20 | General operational information |
+| `WARNING` | 30 | Warning messages (default) |
+| `ERROR` | 40 | Error messages |
+| `CRITICAL` | 50 | Critical failures |
+
+## Setting Log Level
+```python
+
+from chdb.datastore.config import config
+
+# Using standard logging levels
+config.set_log_level(logging.DEBUG)
+config.set_log_level(logging.INFO)
+config.set_log_level(logging.WARNING)  # Default
+config.set_log_level(logging.ERROR)
+
+# Using quick preset
+config.enable_debug()  # Sets DEBUG level + verbose format
+```
+
+## Log Format
+### Simple Format (Default)
+```python title="Query"
+config.set_log_format("simple")
+```
+
+```text title="Response"
+DEBUG - Executing SQL query
+DEBUG - Cache miss for key abc123
+```
+
+### Verbose Format
+```python title="Query"
+config.set_log_format("verbose")
+```
+
+```text title="Response"
+2024-01-15 10:30:45.123 DEBUG datastore.core - Executing SQL query
+2024-01-15 10:30:45.456 DEBUG datastore.cache - Cache miss for key abc123
+```
+
+---
+
+## What Gets Logged
+### DEBUG Level
+- SQL queries generated
+- Execution engine selection
+- Cache operations (hits/misses)
+- Operation timings
+- Data source information
+
+```text
+DEBUG - Creating DataStore from file 'data.csv'
+DEBUG - SQL: SELECT * FROM file('data.csv', 'CSVWithNames') WHERE age > 25
+DEBUG - Using engine: chdb
+DEBUG - Execution time: 0.089s
+DEBUG - Cache: Storing result (key: abc123)
+```
+
+### INFO Level
+- Major operation completions
+- Configuration changes
+- Data source connections
+
+```text
+INFO - Loaded 1,000,000 rows from data.csv
+INFO - Execution engine set to: chdb
+INFO - Connected to MySQL: localhost:3306/mydb
+```
+
+### WARNING Level
+- Deprecated feature usage
+- Performance warnings
+- Non-critical issues
+
+```text
+WARNING - Large result set (>1M rows) may cause memory issues
+WARNING - Cache TTL exceeded, re-executing query
+WARNING - Column 'date' has mixed types, using string
+```
+
+### ERROR Level
+- Query execution failures
+- Connection errors
+- Data conversion errors
+
+```text
+ERROR - Failed to execute SQL: syntax error near 'FORM'
+ERROR - Connection to MySQL failed: timeout
+ERROR - Cannot convert column 'price' to float
+```
+
+---
+
+## Custom Logging Configuration
+### Using Python Logging
+```python
+
+# Configure root logger
+logging.basicConfig(
+    level=logging.DEBUG,
+    format='%(asctime)s - %(name)s - %(levelname)s - %(message)s',
+    handlers=[
+        logging.FileHandler('datastore.log'),
+        logging.StreamHandler()
+    ]
+)
+
+# Get DataStore logger
+ds_logger = logging.getLogger('chdb.datastore')
+ds_logger.setLevel(logging.DEBUG)
+```
+
+### Log to File
+```python
+
+# Create file handler
+file_handler = logging.FileHandler('datastore_debug.log')
+file_handler.setLevel(logging.DEBUG)
+file_handler.setFormatter(logging.Formatter(
+    '%(asctime)s - %(name)s - %(levelname)s - %(message)s'
+))
+
+# Add to DataStore logger
+ds_logger = logging.getLogger('chdb.datastore')
+ds_logger.addHandler(file_handler)
+```
+
+### Suppress Logging
+```python
+
+# Suppress all DataStore logs
+logging.getLogger('chdb.datastore').setLevel(logging.CRITICAL)
+
+# Or using config
+config.set_log_level(logging.CRITICAL)
+```
+
+---
+
+## Debugging Scenarios
+### Debug SQL Generation
+```python
+config.enable_debug()
+
+ds = pd.read_csv("data.csv")
+result = ds.filter(ds['age'] > 25).groupby('city').sum()
+```
+
+Log output:
+```text
+DEBUG - Creating DataStore from file 'data.csv'
+DEBUG - Building filter: age > 25
+DEBUG - Building groupby: city
+DEBUG - Building aggregation: sum
+DEBUG - Generated SQL:
+        SELECT city, SUM(*) 
+        FROM file('data.csv', 'CSVWithNames')
+        WHERE age > 25
+        GROUP BY city
+```
+
+### Debug Engine Selection
+```python
+config.enable_debug()
+
+result = ds.filter(ds['x'] > 10).apply(custom_func)
+```
+
+Log output:
+```text
+DEBUG - filter: selecting engine (eligible: chdb, pandas)
+DEBUG - filter: using chdb (SQL-compatible)
+DEBUG - apply: selecting engine (eligible: pandas)
+DEBUG - apply: using pandas (custom function)
+```
+
+### Debug Cache Operations
+```python
+config.enable_debug()
+
+# First execution
+result1 = ds.filter(ds['age'] > 25).to_df()
+# DEBUG - Cache miss for query hash abc123
+# DEBUG - Executing query...
+# DEBUG - Caching result (key: abc123, size: 1.2MB)
+
+# Second execution (same query)
+result2 = ds.filter(ds['age'] > 25).to_df()
+# DEBUG - Cache hit for query hash abc123
+# DEBUG - Returning cached result
+```
+
+### Debug Performance Issues
+```python
+config.enable_debug()
+config.enable_profiling()
+
+# Logs will show timing for each operation
+result = (ds
+    .filter(ds['amount'] > 100)
+    .groupby('region')
+    .agg({'amount': 'sum'})
+    .to_df()
+)
+```
+
+Log output:
+```text
+DEBUG - filter: 0.002ms
+DEBUG - groupby: 0.001ms
+DEBUG - agg: 0.003ms
+DEBUG - SQL generation: 0.012ms
+DEBUG - SQL execution: 89.456ms  <- Main time spent here
+DEBUG - Result conversion: 2.345ms
+```
+
+---
+
+## Production Configuration
+### Recommended Settings
+```python
+
+from chdb.datastore.config import config
+
+# Production: minimal logging
+config.set_log_level(logging.WARNING)
+config.set_log_format("simple")
+config.set_profiling_enabled(False)
+```
+
+### Log Rotation
+```python
+
+from logging.handlers import RotatingFileHandler
+
+# Create rotating file handler
+handler = RotatingFileHandler(
+    'datastore.log',
+    maxBytes=10*1024*1024,  # 10MB
+    backupCount=5
+)
+handler.setLevel(logging.WARNING)
+
+# Add to DataStore logger
+logging.getLogger('chdb.datastore').addHandler(handler)
+```
+
+---
+
+## Environment Variables
+You can also configure logging via environment variables:
+
+```bash
+# Set log level
+export CHDB_LOG_LEVEL=DEBUG
+
+# Set log format
+export CHDB_LOG_FORMAT=verbose
+```
+
+```python
+
+# Read from environment
+log_level = os.environ.get('CHDB_LOG_LEVEL', 'WARNING')
+config.set_log_level(getattr(logging, log_level))
+```
+
+---
+
+## Summary
+| Task | Command |
+|------|---------|
+| Enable debug | `config.enable_debug()` |
+| Set level | `config.set_log_level(logging.DEBUG)` |
+| Set format | `config.set_log_format("verbose")` |
+| Log to file | Use Python logging handlers |
+| Suppress logs | `config.set_log_level(logging.CRITICAL)` |
+
+---
+
+# DataStore profiling
+
+**URL:** https://clickhouse.com/docs/chdb/debugging/profiling
+
+Measure DataStore performance with the built-in profiler
+
+The DataStore profiler helps you measure execution time and identify performance bottlenecks.
+
+## Quick Start
+```python
+from chdb import datastore as pd
+from chdb.datastore.config import config, get_profiler
+
+# Enable profiling
+config.enable_profiling()
+
+# Run your operations
+ds = pd.read_csv("large_data.csv")
+result = (ds
+    .filter(ds['amount'] > 100)
+    .groupby('category')
+    .agg({'amount': 'sum'})
+    .sort('sum', ascending=False)
+    .head(10)
+    .to_df()
+)
+
+# View report
+profiler = get_profiler()
+print(profiler.report())
+```
+
+## Enabling Profiling
+```python
+from chdb.datastore.config import config
+
+# Enable profiling
+config.enable_profiling()
+
+# Disable profiling
+config.disable_profiling()
+
+# Check if profiling is enabled
+print(config.profiling_enabled)  # True or False
+```
+
+---
+
+## Profiler API
+### Getting the Profiler
+```python
+from chdb.datastore.config import get_profiler
+
+profiler = get_profiler()
+```
+
+### report()
+Display a performance report.
+
+```python
+profiler.report(min_duration_ms=0.1)
+```
+
+**Parameters:**
+
+| Parameter | Type | Default | Description |
+|-----------|------|---------|-------------|
+| `min_duration_ms` | float | `0.1` | Only show steps >= this duration |
+
+**Example output:**
+
+```text
+======================================================================
+EXECUTION PROFILE
+======================================================================
+   45.79ms (100.0%) Total Execution
+     23.25ms ( 50.8%) Query Planning [ops_count=2]
+     22.29ms ( 48.7%) SQL Segment 1 [ops=2]
+       20.48ms ( 91.9%) SQL Execution
+        1.74ms (  7.8%) Result to DataFrame
+----------------------------------------------------------------------
+      TOTAL:    45.79ms
+======================================================================
+```
+
+The report shows:
+- Duration in milliseconds for each step
+- Percentage of parent/total time
+- Hierarchical nesting of operations
+- Metadata for each step (e.g., `ops_count`, `ops`)
+
+### step()
+Manually time a code block.
+
+```python
+with profiler.step("custom_operation"):
+    # Your code here
+    expensive_operation()
+```
+
+### clear()
+Clear all profiling data.
+
+```python
+profiler.clear()
+```
+
+### summary()
+Get a dictionary of step names to durations (ms).
+
+```python
+summary = profiler.summary()
+for name, duration in summary.items():
+    print(f"{name}: {duration:.2f}ms")
+```
+
+Example output:
+
+```text
+Total Execution: 45.79ms
+Total Execution.Cache Check: 0.00ms
+Total Execution.Query Planning: 23.25ms
+Total Execution.SQL Segment 1: 22.29ms
+Total Execution.SQL Segment 1.SQL Execution: 20.48ms
+Total Execution.SQL Segment 1.Result to DataFrame: 1.74ms
+```
+
+---
+
+## Understanding the Report
+### Step Names
+| Step Name | Description |
+|-----------|-------------|
+| `Total Execution` | Overall execution time |
+| `Query Planning` | Time spent planning the query |
+| `SQL Segment N` | Execution of SQL segment N |
+| `SQL Execution` | Actual SQL query execution |
+| `Result to DataFrame` | Converting results to pandas |
+| `Cache Check` | Checking query cache |
+| `Cache Write` | Writing results to cache |
+
+### Duration
+- **Planning steps** (Query Planning): Usually fast
+- **Execution steps** (SQL Execution): Where actual work happens
+- **Transfer steps** (Result to DataFrame): Converting data to pandas
+
+### Identifying Bottlenecks
+```text
+======================================================================
+EXECUTION PROFILE
+======================================================================
+  200.50ms (100.0%) Total Execution
+    10.25ms (  5.1%) Query Planning [ops_count=4]
+   190.00ms ( 94.8%) SQL Segment 1 [ops=4]
+     185.00ms ( 97.4%) SQL Execution    <- Main bottleneck
+       5.00ms (  2.6%) Result to DataFrame
+----------------------------------------------------------------------
+      TOTAL:   200.50ms
+======================================================================
+```
+
+---
+
+## Profiling Patterns
+### Profile a Single Query
+```python
+config.enable_profiling()
+profiler = get_profiler()
+profiler.clear()  # Clear previous data
+
+# Run query
+result = ds.filter(...).groupby(...).agg(...).to_df()
+
+# View this query's profile
+print(profiler.report())
+```
+
+### Profile Multiple Queries
+```python
+config.enable_profiling()
+profiler = get_profiler()
+profiler.clear()
+
+# Query 1
+with profiler.step("Query 1"):
+    result1 = query1.to_df()
+
+# Query 2
+with profiler.step("Query 2"):
+    result2 = query2.to_df()
+
+print(profiler.report())
+```
+
+### Compare Approaches
+```python
+profiler = get_profiler()
+
+# Approach 1: Filter then groupby
+profiler.clear()
+with profiler.step("filter_then_groupby"):
+    result1 = ds.filter(ds['x'] > 10).groupby('y').sum().to_df()
+summary1 = profiler.summary()
+time1 = summary1.get('filter_then_groupby', 0)
+
+# Approach 2: Groupby then filter
+profiler.clear()
+with profiler.step("groupby_then_filter"):
+    result2 = ds.groupby('y').sum().filter(ds['x'] > 10).to_df()
+summary2 = profiler.summary()
+time2 = summary2.get('groupby_then_filter', 0)
+
+print(f"Approach 1: {time1:.2f}ms")
+print(f"Approach 2: {time2:.2f}ms")
+print(f"Winner: {'Approach 1' if time1 < time2 else 'Approach 2'}")
+```
+
+---
+
+## Optimization Tips
+### 1. Check SQL Execution Time
+If `SQL execution` is the bottleneck:
+- Add more filters to reduce data
+- Use Parquet instead of CSV
+- Check for proper indexes (for database sources)
+
+### 2. Check I/O Time
+If `read_csv` or `read_parquet` is the bottleneck:
+- Use Parquet (columnar, compressed)
+- Read only needed columns
+- Filter at source if possible
+
+### 3. Check Data Transfer
+If `to_df` is slow:
+- Result set may be too large
+- Add more filters or limit
+- Use `head()` for previewing
+
+### 4. Compare Engines
+```python
+from chdb.datastore.config import config
+
+# Profile with chdb
+config.use_chdb()
+profiler.clear()
+result_chdb = query.to_df()
+time_chdb = profiler.total_duration_ms
+
+# Profile with pandas
+config.use_pandas()
+profiler.clear()
+result_pandas = query.to_df()
+time_pandas = profiler.total_duration_ms
+
+print(f"chdb: {time_chdb:.2f}ms")
+print(f"pandas: {time_pandas:.2f}ms")
+```
+
+---
+
+## Best Practices
+### 1. Profile Before Optimizing
+```python
+# Don't guess - measure!
+config.enable_profiling()
+result = your_query.to_df()
+print(get_profiler().report())
+```
+
+### 2. Clear Between Tests
+```python
+profiler.clear()  # Clear previous data
+# Run test
+print(profiler.report())
+```
+
+### 3. Use min_duration_ms for Focus
+```python
+# Only show operations >= 100ms
+profiler.report(min_duration_ms=100)
+```
+
+### 4. Profile Representative Data
+```python
+# Profile with real-world data sizes
+# Small test data may not show real bottlenecks
+```
+
+### 5. Disable in Production
+```python
+# Development
+config.enable_profiling()
+
+# Production
+config.set_profiling_enabled(False)  # Avoid overhead
+```
+
+---
+
+## Example: Full Profiling Session
+```python
+from chdb import datastore as pd
+from chdb.datastore.config import config, get_profiler
+
+# Setup
+config.enable_profiling()
+config.enable_debug()  # Also see what's happening
+profiler = get_profiler()
+
+# Load data
+profiler.clear()
+print("=== Loading Data ===")
+ds = pd.read_csv("sales_2024.csv")  # 10M rows
+print(profiler.report())
+
+# Query 1: Simple filter
+profiler.clear()
+print("\n=== Query 1: Simple Filter ===")
+result1 = ds.filter(ds['amount'] > 1000).to_df()
+print(profiler.report())
+
+# Query 2: Complex aggregation
+profiler.clear()
+print("\n=== Query 2: Complex Aggregation ===")
+result2 = (ds
+    .filter(ds['amount'] > 100)
+    .groupby('region', 'category')
+    .agg({
+        'amount': ['sum', 'mean', 'count'],
+        'quantity': 'sum'
+    })
+    .sort('sum', ascending=False)
+    .head(20)
+    .to_df()
+)
+print(profiler.report())
+
+# Summary
+print("\n=== Summary ===")
+print(f"Query 1: {len(result1)} rows")
+print(f"Query 2: {len(result2)} rows")
+```
+
+---
+
+# Data formats
+
+**URL:** https://clickhouse.com/docs/chdb/reference/data-formats
+
+Data Formats for chDB
+
+When it comes to data formats, chDB is 100% feature compatible with ClickHouse.
+
+Input formats are used to parse the data provided to `INSERT` and `SELECT` from a file-backed table such as `File`, `URL` or `S3`.
+Output formats are used to arrange the results of a `SELECT`, and to perform `INSERT`s into a file-backed table.
+As well as the data formats that ClickHouse supports, chDB also supports:
+
+- `ArrowTable` as an output format, the type is Python `pyarrow.Table`
+- `DataFrame` as an input and output format, the type is Python `pandas.DataFrame`. For examples, see [`test_joindf.py`](https://github.com/chdb-io/chdb-core/blob/main/tests/test_joindf.py)
+- `Debug` as ab output (as an alias of `CSV`), but with enabled debug verbose output from ClickHouse.
+
+The supported data formats from ClickHouse are:
+
+| Format                          | Input | Output |
+|---------------------------------|-------|--------|
+| TabSeparated                    | ✔     | ✔      |
+| TabSeparatedRaw                 | ✔     | ✔      |
+| TabSeparatedWithNames           | ✔     | ✔      |
+| TabSeparatedWithNamesAndTypes   | ✔     | ✔      |
+| TabSeparatedRawWithNames        | ✔     | ✔      |
+| TabSeparatedRawWithNamesAndTypes| ✔     | ✔      |
+| Template                        | ✔     | ✔      |
+| TemplateIgnoreSpaces            | ✔     | ✗      |
+| CSV                             | ✔     | ✔      |
+| CSVWithNames                    | ✔     | ✔      |
+| CSVWithNamesAndTypes            | ✔     | ✔      |
+| CustomSeparated                 | ✔     | ✔      |
+| CustomSeparatedWithNames        | ✔     | ✔      |
+| CustomSeparatedWithNamesAndTypes| ✔     | ✔      |
+| SQLInsert                       | ✗     | ✔      |
+| Values                          | ✔     | ✔      |
+| Vertical                        | ✗     | ✔      |
+| JSON                            | ✔     | ✔      |
+| JSONAsString                    | ✔     | ✗      |
+| JSONAsObject                    | ✔     | ✗      |
+| JSONStrings                     | ✔     | ✔      |
+| JSONColumns                     | ✔     | ✔      |
+| JSONColumnsWithMetadata         | ✔     | ✔      |
+| JSONCompact                     | ✔     | ✔      |
+| JSONCompactStrings              | ✗     | ✔      |
+| JSONCompactColumns              | ✔     | ✔      |
+| JSONEachRow                     | ✔     | ✔      |
+| PrettyJSONEachRow               | ✗     | ✔      |
+| JSONEachRowWithProgress         | ✗     | ✔      |
+| JSONStringsEachRow              | ✔     | ✔      |
+| JSONStringsEachRowWithProgress  | ✗     | ✔      |
+| JSONCompactEachRow              | ✔     | ✔      |
+| JSONCompactEachRowWithNames     | ✔     | ✔      |
+| JSONCompactEachRowWithNamesAndTypes | ✔  | ✔      |
+| JSONCompactEachRowWithProgress  | ✗     | ✔      |
+| JSONCompactStringsEachRow       | ✔     | ✔      |
+| JSONCompactStringsEachRowWithNames | ✔  | ✔      |
+| JSONCompactStringsEachRowWithNamesAndTypes | ✔ | ✔ |
+| JSONCompactStringsEachRowWithProgress | ✗ | ✔      |
+| JSONObjectEachRow               | ✔     | ✔      |
+| BSONEachRow                     | ✔     | ✔      |
+| TSKV                            | ✔     | ✔      |
+| Pretty                          | ✗     | ✔      |
+| PrettyNoEscapes                 | ✗     | ✔      |
+| PrettyMonoBlock                 | ✗     | ✔      |
+| PrettyNoEscapesMonoBlock        | ✗     | ✔      |
+| PrettyCompact                   | ✗     | ✔      |
+| PrettyCompactNoEscapes          | ✗     | ✔      |
+| PrettyCompactMonoBlock          | ✗     | ✔      |
+| PrettyCompactNoEscapesMonoBlock | ✗     | ✔      |
+| PrettySpace                     | ✗     | ✔      |
+| PrettySpaceNoEscapes            | ✗     | ✔      |
+| PrettySpaceMonoBlock            | ✗     | ✔      |
+| PrettySpaceNoEscapesMonoBlock   | ✗     | ✔      |
+| Prometheus                      | ✗     | ✔      |
+| Protobuf                        | ✔     | ✔      |
+| ProtobufSingle                  | ✔     | ✔      |
+| ProtobufList                    | ✔     | ✔      |
+| Avro                            | ✔     | ✔      |
+| AvroConfluent                   | ✔     | ✗      |
+| Parquet                         | ✔     | ✔      |
+| ParquetMetadata                 | ✔     | ✗      |
+| Arrow                           | ✔     | ✔      |
+| ArrowStream                     | ✔     | ✔      |
+| ORC                             | ✔     | ✔      |
+| One                             | ✔     | ✗      |
+| Npy                             | ✔     | ✔      |
+| RowBinary                       | ✔     | ✔      |
+| RowBinaryWithNames              | ✔     | ✔      |
+| RowBinaryWithNamesAndTypes      | ✔     | ✔      |
+| RowBinaryWithDefaults           | ✔     | ✗      |
+| Native                          | ✔     | ✔      |
+| Null                            | ✗     | ✔      |
+| XML                             | ✗     | ✔      |
+| CapnProto                       | ✔     | ✔      |
+| LineAsString                    | ✔     | ✔      |
+| Regexp                          | ✔     | ✗      |
+| RawBLOB                         | ✔     | ✔      |
+| MsgPack                         | ✔     | ✔      |
+| MySQLDump                       | ✔     | ✗      |
+| DWARF                           | ✔     | ✗      |
+| Markdown                        | ✗     | ✔      |
+| Form                            | ✔     | ✗      |
+
+For further information and examples, see [ClickHouse formats for input and output data](/interfaces/formats).
+
+---
+
+# chDB technical reference
+
+**URL:** https://clickhouse.com/docs/chdb/reference
+
+Data Formats for chDB
+
+| Reference page       |
+|----------------------|
+| [Data Formats](/chdb/reference/data-formats)  |
+| [SQL Reference](/chdb/reference/sql-reference) |
+
+---
+
+# SQL reference
+
+**URL:** https://clickhouse.com/docs/chdb/reference/sql-reference
+
+SQL Reference for chDB
+
+chdb supports the same SQL syntax, statements, engines and functions as ClickHouse:
+
+| Topic                      |
+|----------------------------|
+| [SQL Syntax](/sql-reference/syntax)          |
+| [Statements](/sql-reference/statements)          |
+| [Table Engines](/engines/table-engines)       |
+| [Database Engines](/engines/database-engines)    |
+| [Regular Functions](/sql-reference/functions)   |
+| [Aggregate Functions](/sql-reference/aggregate-functions) |
+| [Table Functions](/sql-reference/table-functions)     | 
+| [Window Functions](/sql-reference/window-functions)    |
+
+For further information and examples, see the [ClickHouse SQL Reference](/sql-reference).
+
+---
+
+# chDB architecture deep dive
+
+**URL:** https://github.com/chdb-io/chdb/blob/main/docs/ARCHITECTURE.md
+
+# DataStore Architecture & Design Principles
+
+This document describes the core architecture, design principles, and development philosophy of DataStore. It is intended for contributors and developers who want to understand the internals.
+
+## Core Vision
+
+> **Users write familiar pandas-style code, the backend automatically selects the optimal execution engine.**
+
+DataStore bridges the gap between pandas' intuitive API and SQL's powerful query optimization. Users get the best of both worlds without changing their coding habits.
+
+### Architecture Overview
+
+![DataStore Architecture](_static/datastore_architecture.png)
+
+The diagram above shows the four-layer architecture:
+1. **User API**: pandas-like interface that returns lazy objects
+2. **Lazy Operation Chain**: Operations are recorded, not executed
+3. **Execution Trigger & Planning**: Natural triggers invoke QueryPlanner to create execution segments
+4. **Segmented Execution**: Each segment routes to optimal engine (chDB or Pandas), with intermediate results cached
+
+## Philosophy
+
+### Respect Pandas Experience
+
+We deeply respect the pandas ecosystem and the expertise data scientists have built over years. Pandas has established itself as the de facto standard for data manipulation in Python, and millions of developers are fluent in its API.
+
+**Our goal is NOT to replace pandas**, but to provide a performance-optimized alternative that honors pandas conventions. When a user writes `df.groupby('x').mean()`, they should get the same result whether using pandas or DataStore—just faster for large datasets.
+
+### Lazy Execution for Performance
+
+Traditional pandas executes operations eagerly—every operation immediately processes data. DataStore takes a different approach:
+
+```python
+# Pandas: Each line executes immediately
+df = pd.read_csv("huge.csv")           # Load entire file
+df = df[df['age'] > 25]                # Filter (creates new DataFrame)
+df = df.groupby('city')['salary']      # Prepare groupby
+result = df.mean()                     # Execute groupby
+
+# DataStore: Operations are lazy until needed
+ds = DataStore.from_file("huge.csv")   # Just records the source
+ds = ds.filter(ds.age > 25)            # Records filter condition
+ds = ds.groupby('city')['salary']      # Records groupby
+result = ds.mean()                     # Still lazy!
+print(result)                          # NOW executes - as optimized SQL:
+                                       # SELECT city, avg(salary) FROM file
+                                       # WHERE age > 25 GROUP BY city
+```
+
+**Why this matters:**
+- Cross-row operations (filter, groupby, aggregations) compile to SQL
+- chDB/ClickHouse's columnar engine optimizes these operations
+- Only the final result is materialized, not intermediate DataFrames
+
+### Cache for Exploratory Analysis
+
+Data exploration is iterative. You query, inspect, adjust, repeat. DataStore caches intermediate results:
+
+```python
+ds = DataStore.from_file("data.csv")
+
+# First query - executes SQL
+ds.filter(ds.age > 25).head()          # SQL executed, result cached
+
+# Same filter - uses cache
+ds.filter(ds.age > 25).describe()      # No SQL, uses cached result
+ds.filter(ds.age > 25)['salary'].mean() # No SQL, uses cached result
+```
+
+### Pragmatic Compatibility (Not 100%)
+
+We do NOT guarantee 100% pandas syntax compatibility. That's not our goal and would be impractical.
+
+Instead, we take a **pragmatic approach**:
+
+1. **Extensive Testing**: We run compatibility tests using `import datastore as pd` against real-world pandas code (including Kaggle notebooks) to identify gaps.
+
+2. **Cover Common Patterns**: We prioritize implementing the pandas operations that appear most frequently in data analysis workflows.
+
+3. **Minimal Migration**: Our goal is that users can migrate existing code with **minimal changes**—ideally just changing the import statement.
+
+4. **Document Differences**: When behavior differs from pandas, we document it clearly.
+
+```python
+# Ideal migration path
+- import pandas as pd
++ import datastore as pd
+
+# Most code should work unchanged
+df = pd.read_csv("data.csv")
+df = df[df['value'] > 0]
+result = df.groupby('category').agg({'value': 'sum'})
+```
+
+### Two API Styles
+
+Not everyone loves pandas syntax. DataStore offers two equivalent approaches:
+
+**Pandas-style** (familiar to pandas users):
+```python
+
+df = pd.read_csv("data.csv")
+result = df[df['age'] > 25].groupby('city')['salary'].mean()
+```
+
+**Fluent SQL-style** (explicit and Pythonic):
+```python
+from datastore import DataStore
+
+ds = DataStore.from_file("data.csv")
+result = (ds
+    .filter(ds.age > 25)
+    .select('city', 'salary')
+    .groupby('city')
+    .agg({'salary': 'mean'})
+    .orderby('salary', ascending=False)
+    .to_df())
+```
+
+**Both styles should compile to the same optimized SQL** - API style must not determine the execution engine. Choose based on your preference:
+- **Pandas-style**: Minimal migration, familiar syntax
+- **Fluent-style**: Explicit intent, better readability for complex queries, IDE auto-completion
+
+> **Note**: Full SQL compilation for pandas-style groupby is still in development. This is a known limitation we're actively working to resolve.
+
+### Why chDB/ClickHouse?
+
+ClickHouse is a modern columnar database optimized for analytical queries:
+
+- **Columnar Storage**: Only reads columns you need
+- **Vectorized Execution**: Processes data in batches
+- **Compression**: Efficient storage and I/O
+- **SQL Optimization**: Query planner optimizes your operations
+- **100+ File Formats**: Parquet, CSV, JSON, ORC, Avro, and [80+ more](https://clickhouse.com/docs/interfaces/formats)
+- **20+ Data Sources**: S3, MySQL, PostgreSQL, MongoDB, Iceberg, Delta Lake, etc.
+- **334 Built-in Functions**: String, datetime, geo, URL, IP, JSON, array, and more
+
+By compiling pandas operations to ClickHouse SQL, DataStore gives you these optimizations for free.
+
+### Zero-Copy Data Exchange
+
+A key capability that makes DataStore fast is chDB's **zero-copy** data exchange with pandas:
+
+```
+pandas DataFrame ←────── native ──────→ chDB (ClickHouse)
+                     (zero-copy)
+```
+
+When you call `ds.to_df()`, chDB returns data directly as pandas DataFrame without copying memory. Similarly, when using `DataStore.from_df(df)`, the DataFrame is passed to chDB's `Python()` table function which can query it directly without serialization overhead.
+
+This is critical for exploratory workflows where you frequently switch between pandas operations and SQL queries:
+
+```python
+ds = DataStore.from_file("data.csv")
+df = ds.filter(ds.age > 25).to_df()    # Zero-copy: chDB → pandas
+df['new_col'] = df['a'] * 2            # Pure pandas operation
+ds2 = DataStore.from_df(df)            # Zero-copy: pandas → chDB
+result = ds2.filter(ds2.new_col > 100).to_df()  # Back to chDB
+```
+
+### Comparison with Alternatives
+
+| Aspect | DataStore | Polars | DuckDB |
+|--------|-----------|--------|--------|
+| **Goal** | pandas API + ClickHouse power | New high-perf API | SQL-first analytics |
+| **Learning Curve** | Low (know pandas? you're set) | Medium (new API + LazyFrame) | Medium (SQL-first) |
+| **Ecosystem** | ClickHouse (100+ formats, 20+ sources) | ~10 formats, ~5 sources | ~15 formats, ~10 sources |
+| **Zero-Copy pandas** | ✅ pandas ↔ chDB (native) | ❌ (copy required) | ✅ via Arrow |
+| **Lazy Execution** | ✅ Automatic | ⚠️ Manual (explicit LazyFrame) | ✅ Automatic |
+| **SQL Support** | ✅ Full ClickHouse SQL | ⚠️ Limited (SQLContext) | ✅ Full |
+| **Unique Strength** | pandas comfort + ClickHouse scale | Rust-based, memory efficient | Embedded SQL engine |
+
+## Design Principles
+
+### 1. Fully Lazy Execution Architecture
+
+**Every method that returns DataFrame or Series should return a Lazy object.**
+
+```python
+# All these return lazy objects - no execution happens yet
+ds['column']                    # → ColumnExpr (lazy)
+ds['column'].str.upper()        # → ColumnExpr (lazy)
+ds['column'].mean()             # → LazyAggregate (lazy)
+ds['column'].head(5)            # → LazySeries (lazy)
+ds.groupby('x').size()          # → LazySeries (lazy)
+ds['a'] > 5                     # → ColumnExpr wrapping Condition (lazy)
+```
+
+**Why?**
+- Defers execution until results are truly needed
+- Preserves the ability to choose the optimal execution engine at execution time
+- Enables query optimization by analyzing the full operation chain
+- At execution time, the config system determines whether to use pandas or chDB `ExecutionEngine`
+
+### 2. Natural Execution Triggers (No Explicit `_execute()`)
+
+**Explicitly calling `_execute()` in code and tests is forbidden.**
+
+Execution should be triggered through natural interactions:
+
+| Trigger | Description |
+|---------|-------------|
+| `.values` | Access underlying numpy array |
+| `.index` | Access index |
+| `repr()` / `__repr__` | Display in notebook/REPL |
+| `__iter__` | Iteration |
+| `len()` | Get length |
+| `print()` | Print output |
+| `to_df()` / `to_pandas()` | Explicit conversion |
+
+```python
+# ✅ Good: Natural triggers
+result = ds['age'].mean()
+print(result)                           # Triggers execution via __repr__
+np.testing.assert_array_equal(result.values, expected)  # Triggers via .values
+
+# ❌ Bad: Explicit execution
+result = ds['age'].mean()
+result._execute()                       # FORBIDDEN
+```
+
+**Testing Convention:**
+```python
+# ✅ Use numpy testing with natural triggers
+np.testing.assert_array_equal(result.values, expected.values)
+
+# ❌ Avoid pandas testing that may not recognize lazy objects
+pd.testing.assert_series_equal(result, expected)  # May fail with lazy objects
+```
+
+### 3. Architecture Simplicity & Elegance First
+
+**Backward compatibility is NOT a priority. Architectural elegance IS.**
+
+- First priority: Clean, simple, elegant architecture
+- Avoid duplicate definitions (e.g., `value_counts` should have ONE implementation)
+- Single responsibility for each class
+- Clear naming conventions (e.g., `LazySeries` not `LazySeriesMethod`)
+
+**Example: Unified Naming**
+```python
+# ✅ Good: Clear, unified naming
+class LazySeries:
+    """Wraps any Series method call for lazy evaluation."""
+    pass
+
+# ❌ Bad: Confusing, redundant naming
+class LazySeriesMethod:  # Redundant "Method"
+class LazySlice:         # Split responsibility - merged into LazySeries
+```
+
+### 4. Unified Architecture, Avoid Fragmentation
+
+**Do not create split class hierarchies for different execution engines.**
+
+- `ColumnExpr` uniformly wraps ALL expression types (including `Condition`)
+- `LazySeries` handles all deferred Series method executions
+- No separate `BoolColumnExpr` - comparisons return `ColumnExpr` wrapping `Condition`
+
+```python
+# ✅ Good: Unified approach
+ds['age'] > 25                    # Returns ColumnExpr(Condition)
+(ds['age'] > 25).value_counts()   # Works! ColumnExpr handles it
+
+# ❌ Bad: Fragmented approach (rejected design)
+ds['age'] > 25                    # Returns BoolColumnExpr (separate class)
+# Now need to duplicate methods in BoolColumnExpr...
+```
+
+**Why unified?**
+- Less code duplication
+- Consistent behavior
+- Easier to maintain
+- Single code path to debug
+
+### 5. Cherish Test Failures, Don't Just Fix Tests
+
+**Collect and analyze errors during execution. Test failures are valuable signals.**
+
+When a test fails:
+1. **First**: Analyze if it's a library issue that should be fixed
+2. **Ask**: Is this a feature we should implement but haven't?
+3. **Never**: Modify tests just to make them pass
+
+```python
+# Test fails: ds['col'].str.contains('x', regex=True) doesn't work
+
+# ❌ Bad response: Comment out the test or change expected behavior
+# def test_contains():
+#     pass  # TODO: fix later
+
+# ✅ Good response: Analyze the root cause
+# - Is regex=True not implemented? → Implement it
+# - Is the SQL generation wrong? → Fix the SQL builder
+# - Is this a chDB limitation? → Document it and provide workaround
+```
+
+## Core Classes
+
+### Expression Hierarchy
+
+```
+Expression (base)
+├── Field                    # Column reference: ds['column']
+├── Literal                  # Constant value: 42, 'hello'
+├── Function                 # SQL function: upper(x), sum(x)
+│   └── AggregateFunction    # Aggregate: sum, avg, count
+├── ArithmeticExpression     # Math: a + b, a * b
+├── Condition                # Boolean: a > b, a == b
+│   ├── BinaryCondition      # Two operands: a > b
+│   ├── CompoundCondition    # Combined: (a > b) & (c < d)
+│   └── UnaryCondition       # Single: IS NULL
+├── DateTimePropertyExpr     # dt accessor: ds['date'].dt.year
+└── DateTimeMethodExpr       # dt method: ds['date'].dt.strftime('%Y')
+```
+
+### Lazy Evaluation Classes
+
+```
+Lazy Objects
+├── ColumnExpr               # Wraps Expression, provides pandas-like API
+├── LazySeries               # Deferred Series method execution
+├── LazyAggregate            # Deferred aggregate (mean, sum, etc.)
+├── LazyCondition            # Dual SQL/pandas condition
+└── LazyGroupBy              # Deferred groupby operations
+```
+
+### Accessor Classes
+
+```
+Accessors (via .str, .dt, .arr, etc.)
+├── StringAccessor           # String functions
+├── DateTimeAccessor         # DateTime functions
+├── ArrayAccessor            # Array functions (ClickHouse-specific)
+├── JsonAccessor             # JSON functions (ClickHouse-specific)
+├── UrlAccessor              # URL functions (ClickHouse-specific)
+├── IpAccessor               # IP functions (ClickHouse-specific)
+└── GeoAccessor              # Geo functions (ClickHouse-specific)
+```
+
+## Execution Flow
+
+```
+User Code                    Lazy Building                 Execution
+─────────────────────────────────────────────────────────────────────
+ds['age']                    → ColumnExpr                  
+  .filter(ds.age > 25)       → DataStore (SQL WHERE)      
+  .str.upper()               → ColumnExpr                  
+  .groupby('dept')           → LazyGroupBy                 
+  .mean()                    → LazySeries                  
+  .values                    ──────────────────────────────→ Execute!
+                                                              ↓
+                                                           Config check
+                                                              ↓
+                                                     ┌───────┴───────┐
+                                                     │               │
+                                                   chDB           pandas
+                                                  (SQL)         (in-memory)
+```
+
+## Configuration System
+
+The `config` module controls execution behavior:
+
+```python
+from datastore import config
+
+# Set default execution engine
+config.default_engine = ExecutionEngine.CHDB  # or ExecutionEngine.PANDAS
+
+# Configure per-function engine
+config.function_config.use_pandas('strftime')  # Use pandas for strftime
+config.function_config.use_chdb('sum')         # Use chDB for sum
+
+# Profiling
+config.profiling_enabled = True
+```
+
+## Mixed Execution Model
+
+DataStore supports arbitrary mixing of SQL and pandas operations:
+
+```
+SQL ops (lazy)    →    Pandas op (triggers)    →    SQL on DataFrame    →    Result
+     ↓                        ↓                           ↓
+ Build query            Execute SQL                Use chDB Python()
+                        Cache result               table function
+```
+
+```python
+result = (ds
+    .filter(ds.price > 100)              # SQL (lazy)
+    .add_prefix('sales_')                # Pandas (executes SQL, caches)
+    .filter(ds.sales_revenue > 1000)     # SQL on cached DataFrame!
+    .fillna(0)                           # Pandas on cached
+    .to_df())                            # Return result
+```
+
+## Adding New Features
+
+### Adding a New String Method
+
+1. **Register in `function_definitions.py`:**
+```python
+@register_function(
+    name='my_method',
+    clickhouse_name='myClickHouseFunc',
+    func_type=FunctionType.SCALAR,
+    category=FunctionCategory.STRING,
+    doc='Description of what it does.',
+)
+def _build_my_method(expr, arg1, alias=None):
+    from .functions import Function
+    from .expressions import Literal
+    return Function('myClickHouseFunc', expr, Literal(arg1), alias=alias)
+```
+
+2. **Methods are auto-injected into `StringAccessor`** via the registry.
+
+3. **If it needs execution** (returns DataFrame/changes structure), implement in `ColumnExprStringAccessor`:
+```python
+def my_method(self, ...):
+    series = self._execute_series()
+    result = series.str.my_method(...)
+    return DataStore.from_df(result)
+```
+
+### Adding a New Lazy Operation
+
+1. **Return `LazySeries` from the method:**
+```python
+def my_operation(self):
+    return LazySeries(
+        datastore=self._datastore,
+        method_name='my_operation',
+        method_args=(),
+        method_kwargs={},
+        source_expr=self._expr
+    )
+```
+
+2. **Ensure `LazySeries` knows how to execute it** (usually automatic via pandas delegation).
+
+## Testing Guidelines
+
+### Do's
+```python
+# ✅ Test lazy behavior
+result = ds['col'].mean()
+assert isinstance(result, LazyAggregate)
+
+# ✅ Use natural triggers for execution
+np.testing.assert_array_equal(result.values, expected_values)
+
+# ✅ Test both execution engines when relevant
+with use_pandas():
+    pandas_result = ds['col'].mean().values
+with use_chdb():
+    chdb_result = ds['col'].mean().values
+np.testing.assert_allclose(pandas_result, chdb_result)
+```
+
+### Don'ts
+```python
+# ❌ Don't call _execute() directly
+result._execute()
+
+# ❌ Don't modify tests to pass without understanding why they fail
+# (commented out test)
+
+# ❌ Don't assume execution engine
+# Tests should work with both pandas and chDB when possible
+```
+
+## Error Analysis Protocol
+
+When encountering an error:
+
+1. **Categorize**: Is this a user error, library bug, or missing feature?
+
+2. **Analyze**: 
+   - Check if similar operations work
+   - Review the execution path
+   - Identify where it diverges from expected behavior
+
+3. **Document**: If it's a limitation, document it clearly
+
+4. **Implement**: If it's a missing feature we should have, implement it
+
+5. **Never**: Just suppress or work around without understanding
+
+## File Organization
+
+```
+datastore/
+├── __init__.py              # Public API exports
+├── core.py                  # DataStore class, main entry point
+├── column_expr.py           # ColumnExpr and related classes
+├── expressions.py           # Expression base classes
+├── conditions.py            # Condition classes
+├── functions.py             # Function classes
+├── function_definitions.py  # Function registry definitions
+├── function_registry.py     # Function registration system
+├── lazy_result.py           # LazySeries, LazyCondition, etc.
+├── lazy_ops.py              # Lazy operation utilities
+├── groupby.py               # LazyGroupBy
+├── config.py                # Configuration system
+├── executor.py              # Execution engine
+├── expression_evaluator.py  # Expression evaluation
+├── pandas_compat.py         # PandasCompatMixin
+├── pandas_api.py            # Module-level pandas functions
+├── connection.py            # chDB connection
+└── accessors/               # Accessor classes
+    ├── string.py
+    ├── datetime.py
+    ├── array.py
+    ├── json.py
+    ├── url.py
+    ├── ip.py
+    └── geo.py
+```
+
+## Summary
+
+| Principle | Description |
+|-----------|-------------|
+| **Lazy First** | Every DataFrame/Series-returning method returns a lazy object |
+| **Natural Triggers** | Execution via `.values`, `repr()`, etc. - never explicit `_execute()` |
+| **Elegance > Compatibility** | Clean architecture over backward compatibility |
+| **Unified Design** | Single class hierarchy, no fragmentation by engine |
+| **Cherish Failures** | Analyze test failures deeply, don't just fix tests |
+
+The goal is simple: **pandas API comfort with SQL performance, achieved through elegant lazy evaluation.**
+
+---
+
+# chdb-node — Node.js binding
+
+**URL:** https://github.com/chdb-io/chdb-node
+
+<img src="https://avatars.githubusercontent.com/u/132536224" width=130 />
+
+[![npm version](https://badge.fury.io/js/chdb.svg)](https://badge.fury.io/js/chdb)
+
+# chdb-node
+
+[chDB](https://github.com/chdb-io/chdb) Node.js bindings — an in-process
+ClickHouse engine for Node, Bun and Deno.
+
+> **v3 (Layer 1) is in development.** The v2 `query` / `queryBind` / `Session`
+> API is preserved (your v2 code keeps working); v3 adds async queries,
+> server-side parameter binding, inserts, streaming, and Arrow output.
+
+### Install
+
+```bash
+npm i chdb
+```
+
+Prebuilt native binaries ship as per-platform subpackages (`@chdb/lib-*`,
+resolved via `optionalDependencies`) — no local compilation, no `node-gyp`, no
+Python. First-batch platforms: Linux x64/arm64 (glibc) and macOS x64/arm64.
+Windows is not supported (use WSL2).
+
+### Usage
+
+```javascript
+const { query, queryAsync, insert, Session } = require("chdb"); // or: import { ... } from "chdb"
+
+// Sync standalone query (v2-compatible, returns a string)
+console.log(query("SELECT version(), 'Hello chDB'", "CSV"));
+
+// Async query (non-blocking) -> ChdbResult (text() / json() / bytes() + metrics)
+const r = await queryAsync("SELECT number FROM numbers(5)", { format: "JSONEachRow" });
+console.log(r.rowsRead, r.elapsed);
+
+// Server-side parameter binding (no SQL injection surface)
+const { queryBind } = require("chdb");
+console.log(queryBind("SELECT {n:UInt32} * 2 AS v", { n: 21 }, "CSV")); // 42
+
+// Session: persistent/in-memory database
+const session = new Session(); // temp dir; or new Session("./data")
+session.query("CREATE TABLE t (id UInt32, name String) ENGINE = MergeTree() ORDER BY id");
+
+// Insert (inline, async; never reads stdin)
+await session.insert({ table: "t", values: [{ id: 1, name: "Alice" }, { id: 2, name: "Bob" }] });
+
+// Streaming (chunk-by-chunk, no full buffering)
+for await (const row of session.queryStream("SELECT * FROM t").rows()) {
+  console.log(row);
+}
+
+// Arrow output (no serialization on your side)
+const a = await session.queryAsync("SELECT * FROM t", { format: "arrow" });
+const table = a.toArrow();   // requires the optional `apache-arrow` peer dep
+// const bytes = a.bytes();  // raw Arrow IPC if you bring your own Arrow
+
+session.close(); // (cleanup() is an alias; `using` is supported too)
+```
+
+Errors are typed (`ChdbSyntaxError`, `ChdbQueryError`, `ChdbConnectionError`,
+`ChdbBindError`, `ChdbInsertError`, `ChdbStreamError`, `ChdbArrowError`,
+`ChdbAbortError`, `ChdbTimeoutError`, …), each carrying `.code`, the ClickHouse
+`.clickhouseCode`, and `.cause`.
+
+### Feature matrix
+
+| Capability | Status |
+| --- | --- |
+| Stateless query (sync + async) | ✅ |
+| Session (persistent / in-memory) | ✅ |
+| Server-side parameter binding (`{name:Type}`) | ✅ |
+| Insert (object / positional rows) | ✅ |
+| Streaming results (`AsyncIterable`) | ✅ |
+| Arrow **output** (`format: 'arrow'` + `toArrow()`) | ✅ |
+| AbortSignal / timeout | ✅ (single-shot is honest: rejects early; native runs to completion) |
+| Arrow **scan** (`registerArrowTable`, Arrow input) | ⏳ follow-up |
+| Arrow zero-copy (M2, `{ zeroCopy: true }`) | ⏳ follow-up |
+| chDB ↔ `@clickhouse/client` integration (`chdb/connection`, **experimental**) | ✅ |
+
+### chDB ↔ `@clickhouse/client` integration (`chdb/connection`, experimental)
+
+> **Status**: this integration uses the experimental
+> `createClient({ connection })` hook in `@clickhouse/client`
+> ([clickhouse-js#879](https://github.com/ClickHouse/clickhouse-js/pull/879)
+> merged; framing follow-up
+> [#880](https://github.com/ClickHouse/clickhouse-js/pull/880) merged).
+> Upstream considers this a deliberately narrow chDB-only hook — not a
+> public plugin system — and the shape may change. We'll keep
+> `chdb/connection` working against whatever the upstream hook evolves
+> into.
+
+For users coming from `@clickhouse/client`, chdb-node ships a
+**Connection** implementation under the `chdb/connection` subpath that
+plugs into `@clickhouse/client`'s `createClient({ connection })`
+injection point (tracking issue:
+[clickhouse-js#865](https://github.com/ClickHouse/clickhouse-js/issues/865)).
+
+```ts
+
+const conn = createChdbConnection({ path: ':memory:' })
+const r = await conn.query({ query: 'SELECT * FROM numbers(5)', format: 'JSONEachRow' })
+let body = ''
+for await (const chunk of r.stream) body += Buffer.from(chunk).toString('utf8')
+console.log(JSON.parse(`[${body.trim().split('\n').join(',')}]`))
+await conn.close()
+
+// chDB-specific escape hatches (raw ChdbResult, raw insert, session info)
+conn.chdb.queryAsync('SELECT 1', { format: 'arrow' })  // bytes/text/json/toArrow
+conn.chdb.session.path                                 // bound on-disk path
+```
+
+See [docs/design/pluggable-connection.md](docs/design/pluggable-connection.md)
+for the full design, the `Connection` interface, the `.chdb` extension
+namespace, the `tests/clickhouse-js/skip_list.json` parity blacklist,
+and the sync policy with `@clickhouse/client`.
+
+### Design docs
+
+- [Layered API design](docs/design/architecture.md): the Layer 1 / Layer 2 / Layer 3 architecture, package shape, and intended user-facing surfaces.
+- [Layer 1 native binding reviewer guide](docs/design/layer1-native-binding.md): the PR #43 design and implementation map, organized by commit and review feedback.
+- [chDB ↔ `@clickhouse/client` integration (experimental)](docs/design/pluggable-connection.md): the `chdb/connection` surface, the `Connection` interface chdb-node implements, the `.chdb` extension namespace, and the parity-test sync policy.
+
+### Runtimes
+
+A single N-API binary serves **Node 18/20/22 + Bun + Deno**.
+
+### Develop / build from source
+
+```bash
+npm install              # JS deps only (no compile-on-install)
+npm run libchdb          # download libchdb for this platform
+npm run build            # node-gyp build + fix loader path + tsc (dist)
+npm run test:all         # v2 (mocha) + v3 (vitest)
+npm run build:platform   # package this platform's @chdb/lib-* subpackage
+```
+
+---
+
+# chdb-bun — Bun binding
+
+**URL:** https://github.com/chdb-io/chdb-bun
+
+<a href="https://chdb.fly.dev" target="_blank">
+  <img src="https://avatars.githubusercontent.com/u/132536224" width=130 />
+</a>
+
+[![chDB-bun](https://github.com/chdb-io/chdb-bun/actions/workflows/bun-test.yml/badge.svg)](https://github.com/chdb-io/chdb-bun/actions/workflows/bun-test.yml)
+
+# chdb-bun <img src="https://user-images.githubusercontent.com/1423657/236928733-43e4f74e-5cff-4b3f-8bb7-20df58e10829.png" height=20 />
+Experimental [chDB](https://github.com/chdb-io/chdb) FFI bindings for the [bun runtime](https://bun.sh)
+### Status
+
+- experimental, unstable, subject to changes
+- requires [`libchdb`](https://github.com/chdb-io/chdb) on the system
+- requires `gcc` or `clang`
+
+#### Build binding
+```bash
+bun run build
+bun run example.ts
+```
+
+#### Usage
+
+#### Query(query, *format) (ephemeral)
+```javascript
+
+// Query (ephemeral)
+var result = query("SELECT version()", "CSV");
+console.log(result); // 23.10.1.1
+```
+
+#### Session.Query(query, *format)
+```javascript
+
+const sess = new Session('./chdb-bun-tmp');
+
+// Query Session (persistent)
+sess.query("CREATE FUNCTION IF NOT EXISTS hello AS () -> 'Hello chDB'", "CSV");
+var result = sess.query("SELECT hello()", "CSV");
+console.log(result);
+
+// Before cleanup, you can find the database files in `./chdb-bun-tmp`
+
+sess.cleanup(); // cleanup session, this will delete the database
+```
+
+<br>
+
+---
+
+# chdb-go — Go binding
+
+**URL:** https://github.com/chdb-io/chdb-go
+
+<a href="https://chdb.io" target="_blank">
+  <img src="https://avatars.githubusercontent.com/u/132536224" width=130 />
+</a>
+
+[![chDB-go](https://github.com/chdb-io/chdb-go/actions/workflows/chdb.yml/badge.svg)](https://github.com/chdb-io/chdb-go/actions/workflows/chdb.yml)
+
+# chdb-go
+[chDB](https://github.com/chdb-io/chdb) go bindings and chDB cli.
+
+## Install
+
+### Install libchdb.so
+1. Install [`libchdb`](https://github.com/chdb-io/chdb/releases)
+  - curl -sL https://lib.chdb.io | bash
+
+### Install chdb-go
+1. Install `chdb-go`
+  - `go install github.com/chdb-io/chdb-go/v2@latest`
+2. Run `chdb-go` with or without persistent `--path`
+  - run `$GOPATH/bin/chdb-go`
+
+### or Build from source
+1. Build `chdb-go`
+  - run `make build`
+2. Run `chdb-go` with or without persistent `--path`
+  - run `./chdb-go`
+
+## chdb-go CLI
+
+1. Simple mode
+```bash
+./chdb-go "SELECT 123"
+./chdb-go "SELECT 123" JSON
+```
+2. Interactive mode
+```bash
+./chdb-go # enter interactive mode, but data will be lost after exit
+./chdb-go --path /tmp/chdb # interactive persistent mode
+```
+
+```bash
+chdb-io/chdb-go [main] » ./chdb-go 
+Enter your SQL commands; type 'exit' to quit.
+ :) CREATE DATABASE IF NOT EXISTS testdb;
+
+```
+
+#### Go lib Example
+```go
+package main
+
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"github.com/chdb-io/chdb-go/v2/chdb"
+)
+
+func main() {
+	// Stateless Query (ephemeral)
+	result, err := chdb.Query("SELECT version()", "CSV")
+	if err != nil {
+		fmt.Println(err)
+	}
+	fmt.Println(result)
+
+	tmp_path := filepath.Join(os.TempDir(), "chdb_test")
+	// Stateful Query (persistent)
+	session, _ := chdb.NewSession(tmp_path)
+	// session cleanup will also delete the folder
+	defer session.Cleanup()
+
+	_, err = session.Query("CREATE DATABASE IF NOT EXISTS testdb; " +
+		"CREATE TABLE IF NOT EXISTS testdb.testtable (id UInt32) ENGINE = MergeTree() ORDER BY id;")
+	if err != nil {
+		fmt.Println(err)
+		return
+	}
+
+	_, err = session.Query("USE testdb; INSERT INTO testtable VALUES (1), (2), (3);")
+	if err != nil {
+		fmt.Println(err)
+		return
+	}
+
+	ret, err := session.Query("SELECT * FROM testtable;")
+	if err != nil {
+		fmt.Println(err)
+	} else {
+		fmt.Println(ret)
+	}
+}
+```
+
+#### Go SQL driver for chDB
+```go
+package main
+
+        "database/sql"
+        "log"
+
+        _ "github.com/chdb-io/chdb-go/v2/chdb/driver"
+)
+
+func main() {
+        db, err := sql.Open("chdb", "")
+        if err != nil {
+                log.Fatal(err)
+        }
+        rows, err := db.Query(`select COUNT(*) from url('https://datasets.clickhouse.com/hits_compatible/athena_partitioned/hits_0.parquet')`)
+        if err != nil {
+                log.Fatalf("select fail, err: %s", err)
+        }
+        cols, err := rows.Columns()
+        if err != nil {
+                log.Fatalf("get result columns fail, err: %s", err)
+        }
+        log.Printf("result columns: %v", cols)
+        defer rows.Close()
+        var count int
+        for rows.Next() {
+                err := rows.Scan(&count)
+                if err != nil {
+                        log.Fatalf("scan fail, err: %s", err)
+                }
+                log.Printf("count: %d", count)
+        }
+}
+```
+
+#### Concurrency
+
+chDB runs a single embedded engine per process bound to one data path, but that
+engine accepts multiple connections that execute queries concurrently. The
+`database/sql` driver opens an independent native chDB connection per pooled
+connection, so you can scale read/write parallelism with `SetMaxOpenConns`:
+
+```go
+db, err := sql.Open("chdb", "session=/path/to/data")
+if err != nil {
+        log.Fatal(err)
+}
+defer db.Close()
+
+// Each pooled connection is its own native chDB connection to the same data
+// path, so queries run in parallel instead of serializing on one connection.
+db.SetMaxOpenConns(8)
+```
+
+All connections in a process must share the same data path; opening a second,
+different data path while connections are still open returns an error.
+
+### Golang API docs
+
+- See [lowApi.md](lowApi.md) for the low level APIs.
+- See [chdb.md](chdb.md) for high level APIs.
+
+---
+
+# chdb-rust — Rust binding
+
+**URL:** https://github.com/chdb-io/chdb-rust
+
+<img src="https://avatars.githubusercontent.com/u/132536224" width=130 />
+
+[![Rust](https://github.com/chdb-io/chdb-rust/actions/workflows/rust.yml/badge.svg)](https://github.com/chdb-io/chdb-rust/actions/workflows/rust.yml)
+[![Crates.io](https://img.shields.io/crates/v/chdb-rust.svg)](https://crates.io/crates/chdb-rust)
+[![docs.rs](https://docs.rs/chdb-rust/badge.svg)](https://docs.rs/chdb-rust)
+
+# chdb-rust <img src="https://upload.wikimedia.org/wikipedia/commons/thumb/d/d5/Rust_programming_language_black_logo.svg/1024px-Rust_programming_language_black_logo.svg.png" height=20 />
+
+Experimental [chDB](https://github.com/chdb-io/chdb) FFI bindings for Rust.
+
+## Documentation
+
+**[Full API Documentation](https://docs.rs/crate/chdb-rust/latest)** - Complete Rust API reference on docs.rs
+
+## Status
+
+**Experimental** - This library is currently experimental, unstable, and subject to changes.
+
+The library automatically downloads and manages [`libchdb`](https://github.com/chdb-io/chdb) dependencies during the build process.
+
+## Quick Start
+
+Add `chdb-rust` to your `Cargo.toml`:
+
+```toml
+[dependencies]
+chdb-rust = "1.1.0"
+```
+
+The library will automatically download the required `libchdb` binary during the build process.
+
+## Supported Platforms
+
+- **Linux**: x86_64, aarch64
+- **macOS**: x86_64, arm64 (Apple Silicon)
+
+## Building
+
+### Standard Build
+
+```bash
+cargo build
+```
+
+### Verbose Build (for debugging)
+
+```bash
+RUST_BACKTRACE=full cargo build --verbose
+```
+
+### Manual Installation (Optional)
+
+If you prefer to install `libchdb` manually instead of automatic download:
+
+**System-wide installation:**
+```bash
+./update_libchdb.sh --global
+```
+
+**Local directory installation:**
+```bash
+./update_libchdb.sh --local
+```
+
+## Testing
+
+Run the test suite:
+
+```bash
+cargo test -- --test-threads=1
+```
+
+## Examples
+
+- **Runnable examples**: See the [examples/](examples/) directory
+  ```bash
+  cargo run --example <name>
+  ```
+- **Detailed documentation**: See [docs/examples.md](docs/examples.md) for comprehensive examples and explanations
+- **Test examples**: See [tests/](tests/) directory for additional usage examples
+
+## Contributing
+
+We welcome contributions! Here's how you can help:
+
+### Getting Started
+
+1. **Fork the repository** and clone your fork
+   ```bash
+   git clone https://github.com/YOUR_USERNAME/chdb-rust.git
+   cd chdb-rust
+   ```
+
+2. **Create a branch** for your changes
+   ```bash
+   git checkout -b feature/your-feature-name
+   # or
+   git checkout -b fix/your-bug-fix
+   ```
+
+3. **Make your changes** and ensure they work
+   - Run tests: `cargo test`
+   - Check formatting: `cargo fmt --check`
+   - Run clippy: `cargo clippy`
+
+4. **Commit your changes** with clear, descriptive commit messages
+   ```bash
+   git commit -m "Add feature: description of what you did"
+   ```
+
+5. **Push to your fork** and open a Pull Request
+   ```bash
+   git push origin feature/your-feature-name
+   ```
+
+### Development Guidelines
+
+- **Code Style**: Follow Rust conventions and run `cargo fmt` before committing
+- **Testing**: Add tests for new features and ensure all existing tests pass
+- **Documentation**: Update relevant documentation for user-facing changes
+- **Commit Messages**: Write clear, descriptive commit messages
+- **Pull Requests**: 
+  - Provide a clear description of your changes
+  - Reference any related issues
+  - Ensure CI checks pass
+
+### Reporting Issues
+
+Found a bug or have a feature request? Please open an issue on GitHub with:
+- A clear description of the problem or feature
+- Steps to reproduce (for bugs)
+- Expected vs actual behavior
+- Your environment (OS, Rust version, etc.)
+
+### Questions?
+
+Feel free to open a discussion or issue if you have questions about contributing!

--- a/llms.txt
+++ b/llms.txt
@@ -9,6 +9,7 @@ Things to remember when using chDB:
 - DataFrames are first-class via the `Python(df)` table function: `chdb.query("SELECT * FROM Python(df) WHERE x > 10", output_format="DataFrame")` — DataFrame in, DataFrame out, no `register()` call.
 - Query across sources in one statement: `s3()`, `postgresql()`, `mysql()`, `mongodb()`, `iceberg()`, `deltaLake()`, and `remoteSecure('host:9440', db.table, 'user', 'pass')` for a remote ClickHouse cluster — join local files, DataFrames, and remote systems together.
 - Use `chdb.session.Session('path/to/dir')` for persistent storage; in-memory is the default. The DataStore API (`import datastore as pd`) is a pandas-compatible interface that compiles to optimized SQL — up to 247× faster than pandas on COUNT.
+- Documentation pages under `clickhouse.com/docs` return clean Markdown when requested with an `Accept: text/markdown` header — prefer that over parsing the HTML.
 
 ## Clients
 
@@ -45,6 +46,7 @@ Already using a ClickHouse client library? Point it at an embedded chDB engine �
 ## Examples
 
 - [chDB demos and example notebooks](https://github.com/chdb-io/chdb/tree/main/examples): TPC-H, MovieLens DNN, vector search, Hugging Face Parquet.
+- [OTEL ingestion buffer in Node.js](https://github.com/chdb-io/cookbook/tree/main/otel-ingestion-buffer): move OTEL/LLM-trace data from S3 into ClickHouse without the rows ever passing through JavaScript — one SQL statement reads length-delimited protobuf, merges partial events, enriches, and exports over the native protocol.
 - [NYC Taxi analytics agent on AWS Lambda MicroVMs](https://github.com/nklmish/chdb-lambda-microvm-demo): an AI agent that carries its own query engine — each MicroVM embeds a snapshot-hot chDB for in-process SQL and cross-cloud federation (S3, ClickHouse Cloud, and more) in one statement; chDB is a Lambda MicroVM launch partner.
 - [chDB 4.0 launch with Hex partnership](https://clickhouse.com/blog/chdb.4-0-pandas-hex): "Write Pandas, run ClickHouse, ship from Hex" — the DataStore story.
 - [DataFrame zero-copy journey](https://clickhouse.com/blog/chdb-journey-to-zero-copy): how chDB reaches zero-copy DataFrame interop and 247× faster-than-pandas COUNT.
@@ -58,4 +60,4 @@ Already using a ClickHouse client library? Point it at an embedded chDB engine �
 
 ## Migration from DuckDB
 
-- [Migrate from DuckDB to chDB](https://clickhouse.com/docs/chdb/guides/migration-from-duckdb): API mapping, SQL dialect differences, and a federation walkthrough.
+- [Migrate from DuckDB to chDB](https://github.com/chdb-io/cookbook/tree/main/migration-from-duckdb): a static DuckDB→chDB API analyzer plus a runnable 18-query benchmark with side-by-side SQL and DataFrame round-trip notes.

--- a/scripts/generate_llms_full.py
+++ b/scripts/generate_llms_full.py
@@ -1,0 +1,184 @@
+#!/usr/bin/env python3
+"""Generate llms-full.txt: the full chDB documentation corpus in one file.
+
+Pulls every page under docs/chdb from the ClickHouse/clickhouse-docs repo
+(the source the docs site renders at clickhouse.com/docs/chdb), appends
+repo-native references (docs/ARCHITECTURE.md and the language-binding
+READMEs), and writes llms-full.txt at the repo root.
+
+Each page becomes a block of:
+
+    # <title>
+
+    **URL:** <canonical clickhouse.com or github.com URL>
+
+    <page body>
+
+so that RAG chunks keep their provenance. Run from anywhere:
+
+    python scripts/generate_llms_full.py
+
+Set GITHUB_TOKEN to raise the GitHub API rate limit (only one API call is
+made; unauthenticated is normally fine).
+"""
+
+import json
+import os
+import re
+import sys
+import urllib.request
+
+REPO_ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+DOCS_REPO = "ClickHouse/clickhouse-docs"
+DOCS_PREFIX = "docs/chdb"
+DOCS_BRANCH = "main"
+SITE_BASE = "https://clickhouse.com/docs"
+
+# Pages are emitted in this prefix order so a truncated read still gets the
+# essentials first. Anything unmatched sorts to the end alphabetically.
+SECTION_ORDER = [
+    "docs/chdb/index.md",
+    "docs/chdb/getting-started",
+    "docs/chdb/install",
+    "docs/chdb/api",
+    "docs/chdb/datastore",
+    "docs/chdb/guides",
+    "docs/chdb/configuration",
+    "docs/chdb/debugging",
+    "docs/chdb/reference",
+]
+
+# Repo-native content appended after the docs corpus.
+EXTRA_SOURCES = [
+    (
+        "chDB architecture deep dive",
+        "https://github.com/chdb-io/chdb/blob/main/docs/ARCHITECTURE.md",
+        os.path.join(REPO_ROOT, "docs", "ARCHITECTURE.md"),
+    ),
+]
+BINDING_READMES = [
+    ("chdb-node — Node.js binding", "chdb-io/chdb-node"),
+    ("chdb-bun — Bun binding", "chdb-io/chdb-bun"),
+    ("chdb-go — Go binding", "chdb-io/chdb-go"),
+    ("chdb-rust — Rust binding", "chdb-io/chdb-rust"),
+]
+
+
+def fetch(url, token=None):
+    req = urllib.request.Request(url, headers={"User-Agent": "chdb-llms-full-generator"})
+    if token and "api.github.com" in url:
+        req.add_header("Authorization", f"Bearer {token}")
+    with urllib.request.urlopen(req, timeout=60) as resp:
+        return resp.read().decode("utf-8")
+
+
+def parse_frontmatter(text):
+    """Return (frontmatter dict, body). Handles the simple 'key: value' shape
+    the docs repo uses; list values (keywords) are ignored."""
+    m = re.match(r"^---\r?\n(.*?)\r?\n---\r?\n?", text, re.DOTALL)
+    if not m:
+        return {}, text
+    fm = {}
+    for line in m.group(1).splitlines():
+        if ":" not in line or line.startswith((" ", "\t", "-")):
+            continue
+        key, _, value = line.partition(":")
+        value = value.strip().strip("'\"")
+        if value:
+            fm[key.strip()] = value
+    return fm, text[m.end():]
+
+
+def clean_body(body):
+    # Upstream docs occasionally have a non-breaking space after '##', which
+    # breaks both markdown rendering and the anchor-stripping below
+    body = body.replace("\xa0", " ")
+    # Drop MDX import lines — component tags themselves are kept, matching how
+    # platform.claude.com serves its .md pages.
+    body = re.sub(r"^import\s+.*?;?\s*$", "", body, flags=re.MULTILINE)
+    # Strip Docusaurus explicit heading anchors: '## Setup {#setup}' -> '## Setup'
+    body = re.sub(r"^(#{1,6} .*?)\s*\{#[^}]+\}\s*$", r"\1", body, flags=re.MULTILINE)
+    # Collapse the blank runs the removals leave behind
+    body = re.sub(r"\n{3,}", "\n\n", body)
+    return body.strip()
+
+
+def order_key(path):
+    for i, prefix in enumerate(SECTION_ORDER):
+        if path == prefix or path.startswith(prefix + "/") or path.startswith(prefix + "."):
+            return (i, path)
+    return (len(SECTION_ORDER), path)
+
+
+def main():
+    token = os.environ.get("GITHUB_TOKEN")
+
+    tree = json.loads(
+        fetch(f"https://api.github.com/repos/{DOCS_REPO}/git/trees/{DOCS_BRANCH}?recursive=1", token)
+    )
+    pages = sorted(
+        (
+            entry["path"]
+            for entry in tree["tree"]
+            if entry["type"] == "blob"
+            and entry["path"].startswith(DOCS_PREFIX + "/")
+            and entry["path"].endswith((".md", ".mdx"))
+        ),
+        key=order_key,
+    )
+    if not pages:
+        sys.exit(f"no pages found under {DOCS_PREFIX} in {DOCS_REPO}")
+
+    # Reuse the hand-written preamble (H1 + blockquote + agent notes) from llms.txt.
+    with open(os.path.join(REPO_ROOT, "llms.txt"), encoding="utf-8") as f:
+        llms_txt = f.read()
+    preamble = llms_txt.split("\n## ", 1)[0].strip()
+
+    blocks = [
+        preamble,
+        "This file contains the full chDB documentation corpus. The companion"
+        " index is at https://github.com/chdb-io/chdb/blob/main/llms.txt.",
+    ]
+
+    for path in pages:
+        raw = fetch(f"https://raw.githubusercontent.com/{DOCS_REPO}/{DOCS_BRANCH}/{path}", token)
+        fm, body = parse_frontmatter(raw)
+        slug = fm.get("slug") or "/" + path[len("docs/"):].rsplit(".", 1)[0]
+        title = fm.get("title") or slug
+        block = [f"# {title}", "", f"**URL:** {SITE_BASE}{slug}", ""]
+        if fm.get("description"):
+            block += [fm["description"], ""]
+        block.append(clean_body(body))
+        blocks.append("\n".join(block))
+        print(f"  docs  {path} -> {SITE_BASE}{slug}", file=sys.stderr)
+
+    for title, url, local_path in EXTRA_SOURCES:
+        with open(local_path, encoding="utf-8") as f:
+            content = f.read()
+        blocks.append(f"# {title}\n\n**URL:** {url}\n\n{clean_body(content)}")
+        print(f"  local {local_path}", file=sys.stderr)
+
+    for title, repo in BINDING_READMES:
+        try:
+            content = fetch(f"https://raw.githubusercontent.com/{repo}/main/README.md")
+        except Exception as err:  # noqa: BLE001 - a missing README should not sink the build
+            print(f"  skip  {repo}: {err}", file=sys.stderr)
+            continue
+        blocks.append(
+            f"# {title}\n\n**URL:** https://github.com/{repo}\n\n{clean_body(content)}"
+        )
+        print(f"  repo  {repo}/README.md", file=sys.stderr)
+
+    out_path = os.path.join(REPO_ROOT, "llms-full.txt")
+    output = "\n\n---\n\n".join(blocks) + "\n"
+    with open(out_path, "w", encoding="utf-8") as f:
+        f.write(output)
+    print(
+        f"wrote {out_path}: {len(output):,} bytes, {len(pages)} docs pages"
+        f" + {len(blocks) - len(pages) - 2} extra sources",
+        file=sys.stderr,
+    )
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## What

Three follow-ups to the llms.txt added in #598:

### 1. `llms.txt` content fixes
- The **Migrate from DuckDB** entry pointed at a docs URL that is not published yet (returned 404). It now points at the runnable cookbook — [`migration-from-duckdb`](https://github.com/chdb-io/cookbook/tree/main/migration-from-duckdb) — with the static API analyzer and the 18-query benchmark.
- New **Examples** entry for [`otel-ingestion-buffer`](https://github.com/chdb-io/cookbook/tree/main/otel-ingestion-buffer): a Node.js service moves OTEL/LLM-trace data from S3 into ClickHouse with a single SQL statement, without rows ever passing through the JS heap.
- New agent hint in the header: pages under `clickhouse.com/docs` serve clean Markdown via `Accept: text/markdown`, so agents can skip HTML parsing.

### 2. CI: `.github/workflows/llms-txt-check.yml`
Runs on PRs touching the llms files and weekly:
- **Link check (hard gate):** every link in `llms.txt` must resolve; 404/410 fail the job (with retries; 403/429 rate limits only warn).
- **Coverage diff (informational):** compares the curated links against the chDB entries in the auto-generated [`clickhouse.com/docs/llms.txt`](https://clickhouse.com/docs/llms.txt) and writes both directions to the job summary — published docs pages missing from the curated index (curation candidates), and curated links missing from the docs index (rename/unpublish warnings).

### 3. `llms-full.txt` + generator
`scripts/generate_llms_full.py` (stdlib only) builds the full-corpus companion file that the llms.txt convention pairs with an index:
- all 44 `docs/chdb` pages from ClickHouse/clickhouse-docs, ordered getting-started → install → api → datastore → guides → configuration → debugging → reference,
- plus `docs/ARCHITECTURE.md` and the Node.js / Bun / Go / Rust binding READMEs,
- each page block carries a `**URL:**` provenance line so RAG chunks keep their source.

The generated `llms-full.txt` is committed: **~500 KB ≈ 125k tokens**, so the whole chDB corpus fits in a single model context window.

## Verification
- All 27 links in `llms.txt` checked: every one returns HTTP 200.
- Generator run end-to-end; output spot-checked for leftover MDX imports (0) and heading anchors (0).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add llms-full.txt generation script, CI link-check workflow, and llms.txt fixes
> - Adds [scripts/generate_llms_full.py](https://github.com/chdb-io/chdb/pull/599/files#diff-94ede8b23cf58ec890b83283fd3e5b71a7d8584110baa36b8c4a94737d188091), a CLI script that fetches chDB docs from the ClickHouse/clickhouse-docs GitHub API, cleans Markdown bodies, and writes a concatenated corpus to [llms-full.txt](https://github.com/chdb-io/chdb/pull/599/files#diff-db21784bc3b6a3059d3447a91541acd3f88e0b0f943baee38483f38ba9a7c714) with deterministic section ordering.
> - Adds a [CI workflow](https://github.com/chdb-io/chdb/pull/599/files#diff-f8958fe85d2250d62240742ecb94478df70c95f719e0463afae65a0ec4430deb) that fails if any link in `llms.txt` returns HTTP 404/410 after retries, and posts a coverage diff between curated links and the live docs index to the job summary without affecting pass/fail.
> - Updates [llms.txt](https://github.com/chdb-io/chdb/pull/599/files#diff-f43a9e2f7da89777ca234fc2f236252b27a44652586c9514b243e81bf1b19114) with a new OTEL cookbook link, a revised DuckDB migration entry pointing to a cookbook path, and an agent note recommending `Accept: text/markdown` for docs pages.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 64e6ba6.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->