### PR TITLE
ci: pin pyarrow<25 in Linux arm64 DataStore step

### DIFF
--- a/.github/workflows/build_linux_arm64_wheels-gh.yml
+++ b/.github/workflows/build_linux_arm64_wheels-gh.yml
@@ -117,7 +117,10 @@ jobs:
 
               pyenv shell $version
               python -m pip install dist/*.whl --force-reinstall
-              python -m pip install pytest pytest-cov hypothesis ray "$PANDAS_CONSTRAINT"
+              # pyarrow 25.0.0 manylinux aarch64 wheel mis-decodes dictionary-encoded
+              # parquet columns (crash or silent wrong data); pin until fixed upstream.
+              # See https://github.com/chdb-io/chdb/issues/603
+              python -m pip install pytest pytest-cov hypothesis ray "$PANDAS_CONSTRAINT" "pyarrow<25"
               echo "Installed pandas version:"
               python -c "import pandas; print(pandas.__version__)"
 


### PR DESCRIPTION
### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)

### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Pin pyarrow<25 in the Linux arm64 DataStore CI step to avoid a pyarrow 25.0.0 aarch64 parquet decode bug.

### Fixes

Fixes #603

### Reproduction

`Build & Test Linux arm64` on `main` @ 83c8d00b failed **2/2 attempts** at
`datastore/tests/test_head_performance.py::TestTailPerformanceOptimization::test_tail_uses_sql_offset_limit`
on the Python 3.10 + pandas 2.3.3 + **pyarrow 25.0.0** combo:
run https://github.com/chdb-io/chdb/actions/runs/29224196603 (attempts 1 and 2).

- Attempt 1: `pyarrow.lib.ArrowInvalid: Index not in dictionary bounds` from `pd.read_parquet()` on a file pandas itself just wrote.
- Attempt 2: silent corruption — `pd.read_parquet().tail(5)` returns `[0, 96, 97, 98, 99]` while chdb reading the same file returns the correct `[95, 96, 97, 98, 99]`.

### Root cause

pyarrow 25.0.0's `manylinux_2_28_aarch64` wheel (published 2026-07-10T08:25Z, three hours after the last green arm64 run, which used 24.0.0) nondeterministically mis-decodes dictionary-encoded parquet columns: the misread index is either out of bounds (attempt 1) or valid-but-wrong (attempt 2: `dict[0]` instead of `dict[95]`). chdb's native parquet reader is not affected — if the file were corrupt on disk, chdb's `OFFSET 95 LIMIT 5` would return the same wrong value; it does not. Full analysis in #603.

Not reproducible on macOS arm64 (same commit, same pyarrow 25.0.0, all combos green) nor on Linux x86_64 (600 local iterations of the exact round-trip, with and without chdb loaded in-process, zero failures) — the pin is therefore scoped to the Linux arm64 workflow only, so the other platforms keep exercising latest pyarrow.

### Fix

Add `"pyarrow<25"` to the DataStore test-step pip install in `build_linux_arm64_wheels-gh.yml` (this line runs after the wheel install, so it also downgrades the transitively-resolved pyarrow). Comment links #603 so the pin can be dropped when a fixed upstream release (e.g. 25.0.1) is out. No effect on the py3.9 combo, which already resolves to pyarrow 21.0.0 (no cp39 wheels in 25.x).

### Regression test

The `Test DataStore (Linux arm64)` job itself: with the pin it resolves pyarrow 24.0.0 on py>=3.10 — the exact configuration of the last green main run (29071356055). YAML validated locally; the change cannot be exercised outside CI (no arm64 host available to me).


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Pin `pyarrow<25` in Linux arm64 DataStore CI test step
> Adds a `pyarrow<25` version constraint to the pip install command in the [Linux arm64 wheels workflow](https://github.com/chdb-io/chdb/pull/604/files#diff-fd24c962953455ae96b49526dd5a9f87b30c58a054fa3be36afa304ba1f55359) to work around an upstream incompatibility. Three comments are added inline to explain the pin and reference the upstream issue.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 48ec270.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->