### PR TITLE
Pin pyarrow<25 in the Linux arm64 DataStore test environment

### DIFF
--- a/.github/workflows/build_linux_arm64_wheels-gh.yml
+++ b/.github/workflows/build_linux_arm64_wheels-gh.yml
@@ -78,7 +78,8 @@ jobs:
               python /tmp/get-pip.py || python -m ensurepip --upgrade || true
             fi
             python -m pip install --upgrade pip
-            python -m pip install setuptools tox pandas pyarrow wheel pytest pytest-cov
+            # pyarrow 25.0.0 corrupts parquet reads on linux-aarch64; remove this pin once a fixed pyarrow release is out
+            python -m pip install setuptools tox pandas "pyarrow<25" wheel pytest pytest-cov
             pyenv shell --unset
           done
       - uses: actions/checkout@v3
@@ -117,7 +118,8 @@ jobs:
 
               pyenv shell $version
               python -m pip install dist/*.whl --force-reinstall
-              python -m pip install pytest pytest-cov hypothesis ray "$PANDAS_CONSTRAINT"
+              # pyarrow 25.0.0 corrupts parquet reads on linux-aarch64; remove this pin once a fixed pyarrow release is out
+              python -m pip install pytest pytest-cov hypothesis ray "$PANDAS_CONSTRAINT" "pyarrow<25"
               echo "Installed pandas version:"
               python -c "import pandas; print(pandas.__version__)"
 


### PR DESCRIPTION
## What

Pin the CI test environment for `Test DataStore (Linux arm64)` to `pyarrow<25`. CI-only change — the `pyarrow>=13.0.0` requirement in `pyproject.toml` is untouched, so nothing changes for users.

## Why

pyarrow 25.0.0 (released 2026-07-10) corrupts parquet reads on linux-aarch64. `Test DataStore (Linux arm64)` on main started failing on `test_tail_uses_sql_offset_limit` even though the DataStore code is unchanged since v4.2.0:

- attempt 1: `pd.read_parquet` crashes with `pyarrow.lib.ArrowInvalid: Index not in dictionary bounds` reading back a file pandas itself just wrote
- attempt 2 (rerun): the same read silently returns a wrong value (`[0, 96, 97, 98, 99]` instead of `[95, 96, 97, 98, 99]`) — the chDB side of the comparison was correct both times

The last green main run (Jul 10) resolved pyarrow 24.0.0; the failing runs (Jul 13) resolved 25.0.0. macOS arm64 with the same code is green. Both install sites need the pin because `pip install dist/*.whl --force-reinstall` re-resolves chdb's `pyarrow>=13` dependency to the latest release.

## Removal

This pin is temporary: it will be removed from CI once a pyarrow release with the linux-aarch64 fix is out (tracked by the inline comments).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Pin `pyarrow<25` in the Linux arm64 DataStore test environment
> Adds a `pyarrow<25` version constraint to both pip install steps in the [Linux arm64 wheels workflow](.github/workflows/build_linux_arm64_wheels-gh.yml) — the initial dependency setup and the per-pandas-constraint test runs. Each pin includes an inline comment explaining the reason for the constraint.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 6fe6fab.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->