### PR TITLE
Add smolagents tools and a README map of framework integrations

### DIFF
--- a/README.md
+++ b/README.md
@@ -572,6 +572,16 @@ curl -sL https://raw.githubusercontent.com/chdb-io/chdb/main/install_skill.sh | 
 ```
 
 
+## Agent Framework Integrations
+
+`chdb.agents` ships an agent-safe tool surface (`ChDBTool`: read-only by default, capped results, errors returned as envelopes the model can self-correct from), and every framework binding below is a thin shell over it — same tool names, descriptions, and behavior everywhere:
+
+- **[LlamaIndex](https://github.com/chdb-io/llama-index-tools-chdb)** — `pip install llama-index-tools-chdb`, then `ChDBToolSpec().to_tool_list()`.
+- **[Pydantic AI](https://github.com/chdb-io/pydantic-ai-chdb)** — `pip install pydantic-ai-chdb`, then `Agent(..., capabilities=[ChDBCapability()])`; typed engine errors become `ModelRetry`.
+- **[smolagents](chdb/agents/smolagents.py)** — built in: `from chdb.agents.smolagents import chdb_smol_tools` (requires `pip install smolagents`).
+- **[MCP](https://github.com/ClickHouse/mcp-clickhouse)** — mcp-clickhouse runs chdb in-process (`CHDB_ENABLED=true`) for any MCP-speaking agent.
+- **[Node.js](https://github.com/chdb-io/chdb-node)** — the `chdb` npm package ships Vercel AI SDK (`chdb/ai-sdk`) and Mastra (`chdb/mastra`) adapters.
+
 ## Events
 
 - Demo chDB at [ClickHouse v23.7 livehouse!](https://t.co/todc13Kn19) and [Slides](https://docs.google.com/presentation/d/1ikqjOlimRa7QAg588TAB_Fna-Tad2WMg7_4AgnbQbFA/edit?usp=sharing)

--- a/chdb/agents/smolagents.py
+++ b/chdb/agents/smolagents.py
@@ -202,9 +202,13 @@ def chdb_smol_tools(
     only for writable suites (``read_only=False``); on a read-only session,
     declare files via ``attachments`` instead.
 
-    Pass an existing ``chdb.agents.ChDBTool`` as ``engine`` to control its
-    lifecycle yourself (the other arguments are then ignored).
+    Lifecycle: when the factory creates the engine itself, the FIRST
+    returned tool owns it — ``tools[0].close()`` releases the session for
+    the whole suite. Pass an existing ``chdb.agents.ChDBTool`` as ``engine``
+    to control its lifecycle yourself instead (the other arguments are then
+    ignored and no tool will close it).
     """
+    factory_owns_engine = engine is None
     if engine is None:
         engine = ChDBTool(
             path,
@@ -227,4 +231,10 @@ def chdb_smol_tools(
     if not getattr(engine, "read_only", True):
         tool_classes.append(ChDBAttachFileTool)
 
-    return [tool_class(engine=engine) for tool_class in tool_classes]
+    tools = [tool_class(engine=engine) for tool_class in tool_classes]
+    if factory_owns_engine:
+        # Hand ownership of the factory-created session to the first tool,
+        # so the suite has exactly one deterministic closer and a plain
+        # `chdb_smol_tools()` call cannot leak the engine.
+        tools[0]._owns_engine = True
+    return tools

--- a/chdb/agents/smolagents.py
+++ b/chdb/agents/smolagents.py
@@ -1,0 +1,230 @@
+"""smolagents tools over chdb.agents.ChDBTool.
+
+Usage::
+
+    from chdb.agents.smolagents import chdb_smol_tools
+    from smolagents import CodeAgent, InferenceClientModel
+
+    agent = CodeAgent(
+        tools=chdb_smol_tools(attachments={"events": "data/events.parquet"}),
+        model=InferenceClientModel(),
+    )
+    agent.run("What are the top 5 event types by count?")
+
+Requires the ``smolagents`` package (not a chdb dependency); importing this
+module without it raises a descriptive ImportError.
+
+Each tool returns the JSON envelope produced by ``ChDBTool.call()`` —
+``{"ok": true, "result": …}`` or ``{"ok": false, "error": {code, type,
+message}}`` — so the model always reads engine errors and can self-correct.
+Tool names, descriptions, and input metadata come from the descriptors this
+package bundles (the single source of truth across chDB bindings).
+
+These tools hold a live engine, so they are for local use, not for
+``push_to_hub`` (smolagents serializes tool source code and literal init
+parameters when sharing; a process-bound database session cannot survive
+that round trip).
+"""
+
+import json
+
+try:
+    from smolagents import Tool
+except ImportError as exc:  # pragma: no cover - exercised only without smolagents
+    raise ImportError(
+        "The 'smolagents' package is required for chdb.agents.smolagents. "
+        "Install it with: pip install smolagents"
+    ) from exc
+
+from chdb.agents.descriptors import load_descriptors
+from chdb.agents.tool import ChDBTool
+
+_DESCRIPTORS = {t["name"]: t for t in load_descriptors()["tools"]}
+
+
+def _inputs_for(tool_name):
+    """Build the smolagents ``inputs`` dict from the bundled descriptors."""
+    inputs = {}
+    for param in _DESCRIPTORS[tool_name].get("params", []):
+        entry = {"type": param["type"], "description": param["description"]}
+        if not param.get("required", False):
+            entry["nullable"] = True
+        inputs[param["name"]] = entry
+    return inputs
+
+
+class _ChDBBaseTool(Tool):
+    """Shared engine plumbing for the chDB smolagents tools.
+
+    Each tool instance lazily creates its own chDB session from the
+    constructor arguments on first use, or reuses an existing
+    ``chdb.agents.ChDBTool`` passed as ``engine``. Tools that must see each
+    other's state (attach_file followed by run_select_query) have to share
+    one engine — build the suite with ``chdb_smol_tools()`` or pass the same
+    ``engine`` to each tool.
+    """
+
+    output_type = "string"
+
+    def __init__(
+        self,
+        path=":memory:",
+        *,
+        read_only=True,
+        max_rows=1000,
+        max_bytes=1_000_000,
+        max_execution_time=None,
+        file_allowlist=None,
+        attachments=None,
+        engine=None,
+        **kwargs,
+    ):
+        super().__init__(**kwargs)
+        self._engine = engine
+        self._engine_config = dict(
+            path=path,
+            read_only=read_only,
+            max_rows=max_rows,
+            max_bytes=max_bytes,
+            max_execution_time=max_execution_time,
+            file_allowlist=file_allowlist,
+            attachments=attachments,
+        )
+        self._owns_engine = engine is None
+
+    @property
+    def engine(self):
+        """The underlying ``chdb.agents.ChDBTool``, created on first use."""
+        if self._engine is None:
+            config = self._engine_config
+            self._engine = ChDBTool(
+                config["path"],
+                read_only=config["read_only"],
+                max_rows=config["max_rows"],
+                max_bytes=config["max_bytes"],
+                max_execution_time=config["max_execution_time"],
+                file_allowlist=config["file_allowlist"],
+                attachments=config["attachments"],
+            )
+        return self._engine
+
+    def close(self):
+        """Close the engine this tool created; an injected one stays with its owner."""
+        if self._owns_engine and self._engine is not None:
+            self._engine.close()
+            self._engine = None
+
+    def _dispatch(self, arguments):
+        return json.dumps(self.engine.call(self.name, arguments))
+
+
+class ChDBRunSelectQueryTool(_ChDBBaseTool):
+    name = "run_select_query"
+    description = _DESCRIPTORS["run_select_query"]["description"]
+    inputs = _inputs_for("run_select_query")
+
+    def forward(self, sql: str, params: dict | None = None) -> str:
+        return self._dispatch({"sql": sql, "params": params})
+
+
+class ChDBListDatabasesTool(_ChDBBaseTool):
+    name = "list_databases"
+    description = _DESCRIPTORS["list_databases"]["description"]
+    inputs = _inputs_for("list_databases")
+
+    def forward(self) -> str:
+        return self._dispatch({})
+
+
+class ChDBListTablesTool(_ChDBBaseTool):
+    name = "list_tables"
+    description = _DESCRIPTORS["list_tables"]["description"]
+    inputs = _inputs_for("list_tables")
+
+    def forward(self, database: str | None = None) -> str:
+        return self._dispatch({"database": database})
+
+
+class ChDBDescribeTableTool(_ChDBBaseTool):
+    name = "describe_table"
+    description = _DESCRIPTORS["describe_table"]["description"]
+    inputs = _inputs_for("describe_table")
+
+    def forward(self, target: str, database: str | None = None) -> str:
+        return self._dispatch({"target": target, "database": database})
+
+
+class ChDBGetSampleDataTool(_ChDBBaseTool):
+    name = "get_sample_data"
+    description = _DESCRIPTORS["get_sample_data"]["description"]
+    inputs = _inputs_for("get_sample_data")
+
+    def forward(
+        self, target: str, database: str | None = None, limit: int | None = None
+    ) -> str:
+        return self._dispatch({"target": target, "database": database, "limit": limit})
+
+
+class ChDBListFunctionsTool(_ChDBBaseTool):
+    name = "list_functions"
+    description = _DESCRIPTORS["list_functions"]["description"]
+    inputs = _inputs_for("list_functions")
+
+    def forward(self, like: str | None = None, limit: int | None = None) -> str:
+        return self._dispatch({"like": like, "limit": limit})
+
+
+class ChDBAttachFileTool(_ChDBBaseTool):
+    name = "attach_file"
+    description = _DESCRIPTORS["attach_file"]["description"]
+    inputs = _inputs_for("attach_file")
+
+    def forward(self, name: str, path: str, format: str | None = None) -> str:
+        return self._dispatch({"name": name, "path": path, "format": format})
+
+
+def chdb_smol_tools(
+    path=":memory:",
+    *,
+    read_only=True,
+    max_rows=1000,
+    max_bytes=1_000_000,
+    max_execution_time=None,
+    file_allowlist=None,
+    attachments=None,
+    engine=None,
+):
+    """Build the chDB tool suite for smolagents over one shared engine.
+
+    All returned tools run against the same chDB session, so a table
+    registered by attach_file (or declared via ``attachments``) is visible
+    to run_select_query and the introspection tools. attach_file is included
+    only for writable suites (``read_only=False``); on a read-only session,
+    declare files via ``attachments`` instead.
+
+    Pass an existing ``chdb.agents.ChDBTool`` as ``engine`` to control its
+    lifecycle yourself (the other arguments are then ignored).
+    """
+    if engine is None:
+        engine = ChDBTool(
+            path,
+            read_only=read_only,
+            max_rows=max_rows,
+            max_bytes=max_bytes,
+            max_execution_time=max_execution_time,
+            file_allowlist=file_allowlist,
+            attachments=attachments,
+        )
+
+    tool_classes = [
+        ChDBRunSelectQueryTool,
+        ChDBListDatabasesTool,
+        ChDBListTablesTool,
+        ChDBDescribeTableTool,
+        ChDBGetSampleDataTool,
+        ChDBListFunctionsTool,
+    ]
+    if not getattr(engine, "read_only", True):
+        tool_classes.append(ChDBAttachFileTool)
+
+    return [tool_class(engine=engine) for tool_class in tool_classes]

--- a/tests/test_agents_smolagents.py
+++ b/tests/test_agents_smolagents.py
@@ -1,0 +1,123 @@
+"""Tests for chdb.agents.smolagents (skipped when smolagents is not installed).
+
+Instantiation itself is half the test surface: smolagents validates each
+tool's `inputs` metadata against the `forward()` signature (key presence and
+nullable agreement) at construction time.
+"""
+
+import json
+import os
+import tempfile
+import unittest
+
+try:
+    import smolagents  # noqa: F401
+
+    HAS_SMOLAGENTS = True
+except ImportError:
+    HAS_SMOLAGENTS = False
+
+
+READ_ONLY_TOOLS = [
+    "run_select_query",
+    "list_databases",
+    "list_tables",
+    "describe_table",
+    "get_sample_data",
+    "list_functions",
+]
+
+
+@unittest.skipUnless(HAS_SMOLAGENTS, "smolagents not installed")
+class TestSmolagentsTools(unittest.TestCase):
+    def test_suite_names_and_attach_file_gating(self):
+        from chdb.agents.smolagents import chdb_smol_tools
+
+        read_only = chdb_smol_tools()
+        try:
+            self.assertEqual([t.name for t in read_only], READ_ONLY_TOOLS)
+        finally:
+            read_only[0].engine.close()
+
+        writable = chdb_smol_tools(read_only=False)
+        try:
+            self.assertEqual([t.name for t in writable][-1], "attach_file")
+        finally:
+            writable[0].engine.close()
+
+    def test_descriptions_and_inputs_come_from_descriptors(self):
+        from chdb.agents import load_descriptors
+        from chdb.agents.smolagents import chdb_smol_tools
+
+        descriptors = {t["name"]: t for t in load_descriptors()["tools"]}
+        tools = chdb_smol_tools()
+        try:
+            for tool in tools:
+                descriptor = descriptors[tool.name]
+                self.assertEqual(tool.description, descriptor["description"])
+                params = {p["name"]: p for p in descriptor.get("params", [])}
+                self.assertEqual(set(tool.inputs), set(params))
+                for name, entry in tool.inputs.items():
+                    self.assertEqual(entry["type"], params[name]["type"])
+                    self.assertEqual(
+                        entry.get("nullable", False),
+                        not params[name].get("required", False),
+                    )
+        finally:
+            tools[0].engine.close()
+
+    def test_call_path_returns_envelopes(self):
+        from chdb.agents.smolagents import ChDBRunSelectQueryTool
+
+        tool = ChDBRunSelectQueryTool()
+        try:
+            ok = json.loads(tool(sql="SELECT 21 * 2 AS x"))
+            self.assertTrue(ok["ok"])
+            self.assertEqual(ok["result"]["rows"], [{"x": 42}])
+
+            err = json.loads(tool(sql="SELEC bad"))
+            self.assertFalse(err["ok"])
+            self.assertEqual(err["error"]["type"], "UNKNOWN_IDENTIFIER")
+
+            readonly = json.loads(
+                tool(sql="CREATE TABLE t (x Int64) ENGINE = Memory")
+            )
+            self.assertFalse(readonly["ok"])
+        finally:
+            tool.close()
+
+    def test_attach_then_query_shares_engine(self):
+        from chdb.agents.smolagents import chdb_smol_tools
+
+        d = tempfile.mkdtemp()
+        csv = os.path.join(d, "people.csv")
+        with open(csv, "w") as fh:
+            fh.write("name,age\nada,36\ngrace,45\n")
+
+        tools = {t.name: t for t in chdb_smol_tools(read_only=False)}
+        try:
+            attached = json.loads(tools["attach_file"](name="people", path=csv))
+            self.assertTrue(attached["ok"])
+            queried = json.loads(
+                tools["run_select_query"](sql="SELECT count() AS n FROM people")
+            )
+            self.assertTrue(queried["ok"])
+            self.assertEqual(queried["result"]["rows"], [{"n": "2"}])
+        finally:
+            tools["run_select_query"].engine.close()
+
+    def test_injected_engine_not_closed(self):
+        from chdb.agents import ChDBTool
+        from chdb.agents.smolagents import ChDBRunSelectQueryTool
+
+        engine = ChDBTool()
+        try:
+            tool = ChDBRunSelectQueryTool(engine=engine)
+            tool.close()
+            self.assertTrue(engine.call("run_select_query", {"sql": "SELECT 1"})["ok"])
+        finally:
+            engine.close()
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_agents_smolagents.py
+++ b/tests/test_agents_smolagents.py
@@ -37,13 +37,29 @@ class TestSmolagentsTools(unittest.TestCase):
         try:
             self.assertEqual([t.name for t in read_only], READ_ONLY_TOOLS)
         finally:
-            read_only[0].engine.close()
+            read_only[0].close()
 
         writable = chdb_smol_tools(read_only=False)
         try:
             self.assertEqual([t.name for t in writable][-1], "attach_file")
         finally:
-            writable[0].engine.close()
+            writable[0].close()
+
+    def test_factory_hands_engine_ownership_to_first_tool(self):
+        from chdb.agents import ChDBTool
+        from chdb.agents.smolagents import chdb_smol_tools
+
+        tools = chdb_smol_tools()
+        self.assertTrue(tools[0]._owns_engine)
+        self.assertTrue(all(not t._owns_engine for t in tools[1:]))
+        tools[0].close()
+
+        engine = ChDBTool()
+        try:
+            injected = chdb_smol_tools(engine=engine)
+            self.assertTrue(all(not t._owns_engine for t in injected))
+        finally:
+            engine.close()
 
     def test_descriptions_and_inputs_come_from_descriptors(self):
         from chdb.agents import load_descriptors
@@ -64,7 +80,7 @@ class TestSmolagentsTools(unittest.TestCase):
                         not params[name].get("required", False),
                     )
         finally:
-            tools[0].engine.close()
+            tools[0].close()
 
     def test_call_path_returns_envelopes(self):
         from chdb.agents.smolagents import ChDBRunSelectQueryTool
@@ -75,7 +91,7 @@ class TestSmolagentsTools(unittest.TestCase):
             self.assertTrue(ok["ok"])
             self.assertEqual(ok["result"]["rows"], [{"x": 42}])
 
-            err = json.loads(tool(sql="SELEC bad"))
+            err = json.loads(tool(sql="SELECT nonexistent_column FROM system.one"))
             self.assertFalse(err["ok"])
             self.assertEqual(err["error"]["type"], "UNKNOWN_IDENTIFIER")
 
@@ -89,22 +105,23 @@ class TestSmolagentsTools(unittest.TestCase):
     def test_attach_then_query_shares_engine(self):
         from chdb.agents.smolagents import chdb_smol_tools
 
-        d = tempfile.mkdtemp()
-        csv = os.path.join(d, "people.csv")
-        with open(csv, "w") as fh:
-            fh.write("name,age\nada,36\ngrace,45\n")
+        with tempfile.TemporaryDirectory() as d:
+            csv = os.path.join(d, "people.csv")
+            with open(csv, "w") as fh:
+                fh.write("name,age\nada,36\ngrace,45\n")
 
-        tools = {t.name: t for t in chdb_smol_tools(read_only=False)}
-        try:
-            attached = json.loads(tools["attach_file"](name="people", path=csv))
-            self.assertTrue(attached["ok"])
-            queried = json.loads(
-                tools["run_select_query"](sql="SELECT count() AS n FROM people")
-            )
-            self.assertTrue(queried["ok"])
-            self.assertEqual(queried["result"]["rows"], [{"n": "2"}])
-        finally:
-            tools["run_select_query"].engine.close()
+            suite = chdb_smol_tools(read_only=False)
+            tools = {t.name: t for t in suite}
+            try:
+                attached = json.loads(tools["attach_file"](name="people", path=csv))
+                self.assertTrue(attached["ok"])
+                queried = json.loads(
+                    tools["run_select_query"](sql="SELECT count() AS n FROM people")
+                )
+                self.assertTrue(queried["ok"])
+                self.assertEqual(queried["result"]["rows"], [{"n": "2"}])
+            finally:
+                suite[0].close()
 
     def test_injected_engine_not_closed(self):
         from chdb.agents import ChDBTool


### PR DESCRIPTION
## What

- **`chdb.agents.smolagents`** — smolagents `Tool` subclasses over `ChDBTool`: `run_select_query`, `list_databases`, `list_tables`, `describe_table`, `get_sample_data`, `list_functions`, `attach_file` (writable sessions only), plus a `chdb_smol_tools()` factory that builds the suite over one shared engine so attached tables are visible across tools. Tool names, descriptions, and input metadata load from the bundled descriptors at import time, so the model-visible surface cannot drift from the other bindings. Every call returns the `call()` JSON envelope, so engine errors reach the model as typed, correctable results.
- **README** — new *Agent Framework Integrations* section linking the LlamaIndex ([llama-index-tools-chdb](https://pypi.org/project/llama-index-tools-chdb/)) and Pydantic AI ([pydantic-ai-chdb](https://pypi.org/project/pydantic-ai-chdb/)) packages, this module, mcp-clickhouse's chdb mode, and the chdb-node adapters.

## Notes

- `smolagents` stays an optional install: the module lazy-imports it and raises a descriptive ImportError; nothing else in the package imports the module.
- These tools are for local use, not `push_to_hub` — smolagents serializes tool source and literal init parameters when sharing, and a process-bound database session cannot survive that round trip (documented in the module docstring).
- Tests: `tests/test_agents_smolagents.py` (unittest, `skipUnless`): 5 passed with smolagents 1.26.0 installed (including smolagents' own `__call__` validation path, attach-then-query engine sharing, and read-only gating), 5 skipped cleanly without it.

*Authored with AI assistance (Claude Code); designed, tested, and reviewed by the chDB team.*

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add smolagents tool suite and agent framework integration docs to chdb
> - Adds [chdb/agents/smolagents.py](https://github.com/chdb-io/chdb/pull/609/files#diff-5eb1d5e916b896da1736054a237672aa5a0a1bd79716e18fc00a8f5233422d70) with seven smolagents `Tool` subclasses (`run_select_query`, `list_databases`, `list_tables`, `describe_table`, `get_sample_data`, `list_functions`, `attach_file`) backed by the existing chDB agent descriptors.
> - The `chdb_smol_tools` factory creates a suite sharing a single engine; `attach_file` is excluded for read-only sessions, and engine ownership is assigned to the first tool so closing it disposes the engine.
> - Adds an 'Agent Framework Integrations' section to [README.md](https://github.com/chdb-io/chdb/pull/609/files#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5) documenting tool surfaces for LlamaIndex, Pydantic AI, smolagents, MCP, and Node.js adapters.
> - Tests in [tests/test_agents_smolagents.py](https://github.com/chdb-io/chdb/pull/609/files#diff-0284d505aeec6668813c73494ba40b6c4c191843c2560b3b19e6be529cd1eae4) are guarded by smolagents availability and cover suite composition, engine ownership, descriptor parity, and JSON envelope returns.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized c270945.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->