### PR TITLE
Enable external sort by default and restore the server memory limit

### DIFF
--- a/datastore/config.py
+++ b/datastore/config.py
@@ -343,7 +343,7 @@ def use_pandas_compat() -> None:
 _chdb_settings: Dict[str, Any] = {
     'memory_worker_correct_memory_tracker': 1,
     'max_server_memory_usage': 0,
-    'max_server_memory_usage_to_ram_ratio': 0,
+    'max_server_memory_usage_to_ram_ratio': 0.9,
 }
 _chdb_settings_frozen: bool = False
 

--- a/datastore/connection.py
+++ b/datastore/connection.py
@@ -115,10 +115,13 @@ class Connection:
         settings = {**get_chdb_settings(), **self.connection_params}
         user_value = settings.get('max_bytes_before_external_sort')
         if user_value is not None:
+            if isinstance(user_value, bool):
+                raise ValueError(f"Invalid max_bytes_before_external_sort value: {user_value!r}")
             if isinstance(user_value, (int, float)):
                 self._conn.query(f"SET max_bytes_before_external_sort = {int(user_value)}")
             else:
-                self._conn.query(f"SET max_bytes_before_external_sort = '{user_value}'")
+                escaped = str(user_value).replace("\\", "\\\\").replace("'", "\\'")
+                self._conn.query(f"SET max_bytes_before_external_sort = '{escaped}'")
             return
         try:
             raw = self._conn.query(

--- a/datastore/connection.py
+++ b/datastore/connection.py
@@ -96,10 +96,33 @@ class Connection:
             self._conn = chdb.connect(conn_str)
             if self._conn is not None:
                 _freeze_chdb_settings()
+                self._apply_external_sort_default()
             self._logger.debug("[chDB] Connected: %s", conn_str)
             return self
         except Exception as e:
             raise ConnectionError(f"Failed to connect to chdb: {e}")
+
+    def _apply_external_sort_default(self) -> None:
+        """Enable external sort with half of the server memory limit as threshold."""
+        settings = {**get_chdb_settings(), **self.connection_params}
+        user_value = settings.get('max_bytes_before_external_sort')
+        if user_value is not None:
+            if isinstance(user_value, (int, float)):
+                self._conn.query(f"SET max_bytes_before_external_sort = {int(user_value)}")
+            else:
+                self._conn.query(f"SET max_bytes_before_external_sort = '{user_value}'")
+            return
+        try:
+            raw = self._conn.query(
+                "SELECT value FROM system.server_settings WHERE name = 'max_server_memory_usage'",
+                'TSV',
+            )
+            server_limit = int(str(raw).strip() or 0)
+            if server_limit <= 0:
+                return
+            self._conn.query(f"SET max_bytes_before_external_sort = {server_limit // 2}")
+        except Exception as e:
+            self._logger.debug("[chDB] Could not apply external sort default: %s", e)
 
     def cursor(self):
         """Get a cursor for executing queries."""

--- a/datastore/connection.py
+++ b/datastore/connection.py
@@ -96,7 +96,15 @@ class Connection:
             self._conn = chdb.connect(conn_str)
             if self._conn is not None:
                 _freeze_chdb_settings()
-                self._apply_external_sort_default()
+                try:
+                    self._apply_external_sort_default()
+                except Exception:
+                    try:
+                        self._conn.close()
+                    except Exception:
+                        pass
+                    self._conn = None
+                    raise
             self._logger.debug("[chDB] Connected: %s", conn_str)
             return self
         except Exception as e:

--- a/datastore/tests/test_chdb_settings.py
+++ b/datastore/tests/test_chdb_settings.py
@@ -379,8 +379,9 @@ class TestExternalSortDefault:
         conn = Connection(':memory:')
         conn.connect()
         try:
-            value, _ = self._query_setting(conn, 'max_bytes_ratio_before_external_sort')
-            assert float(value) == 0.5
+            value, changed = self._query_setting(conn, 'max_bytes_ratio_before_external_sort')
+            assert changed == '0'
+            assert float(value) > 0
         finally:
             conn.close()
 
@@ -409,12 +410,9 @@ class TestExternalSortDefault:
 
         set_chdb_setting('max_bytes_before_external_sort', 'not_a_valid_size')
         conn = Connection(':memory:')
-        try:
-            with pytest.raises(DataStoreConnectionError, match="Failed to connect"):
-                conn.connect()
-        finally:
-            if conn._conn is not None:
-                conn.close()
+        with pytest.raises(DataStoreConnectionError, match="Failed to connect"):
+            conn.connect()
+        assert conn._conn is None
 
     def test_no_server_limit_skips_external_sort_default(self):
         _run_chdb_in_subprocess("""
@@ -427,11 +425,11 @@ class TestExternalSortDefault:
             conn.connect()
             try:
                 r = conn._conn.query(
-                    "SELECT value FROM system.settings "
+                    "SELECT changed FROM system.settings "
                     "WHERE name = 'max_bytes_before_external_sort'",
                     'TSV',
                 )
-                assert str(r).strip() == '0', f"Expected '0' but got: {r}"
+                assert str(r).strip() == '0', f"Expected setting to be unchanged but got: {r}"
             finally:
                 conn.close()
         """)

--- a/datastore/tests/test_chdb_settings.py
+++ b/datastore/tests/test_chdb_settings.py
@@ -32,7 +32,7 @@ def _reset_chdb_settings_state():
     _config_module._chdb_settings = {
         'memory_worker_correct_memory_tracker': 1,
         'max_server_memory_usage': 0,
-        'max_server_memory_usage_to_ram_ratio': 0,
+        'max_server_memory_usage_to_ram_ratio': 0.9,
     }
     _config_module._chdb_settings_frozen = False
 
@@ -74,7 +74,7 @@ class TestChdbSettingsDefaults:
         assert settings == {
             'memory_worker_correct_memory_tracker': 1,
             'max_server_memory_usage': 0,
-            'max_server_memory_usage_to_ram_ratio': 0,
+            'max_server_memory_usage_to_ram_ratio': 0.9,
         }
 
     def test_default_applied_to_connection(self):
@@ -95,14 +95,18 @@ class TestChdbSettingsDefaults:
         conn.connect()
         try:
             r = conn._conn.query(
-                "SELECT name, value FROM system.server_settings "
-                "WHERE name IN ('max_server_memory_usage', 'max_server_memory_usage_to_ram_ratio') "
-                "ORDER BY name",
+                "SELECT value FROM system.server_settings "
+                "WHERE name = 'max_server_memory_usage_to_ram_ratio'",
                 'CSV',
             )
-            result = str(r)
-            assert '"max_server_memory_usage","0"' in result
-            assert '"max_server_memory_usage_to_ram_ratio","0"' in result
+            assert '"0.9"' in str(r)
+
+            r = conn._conn.query(
+                "SELECT value FROM system.server_settings "
+                "WHERE name = 'max_server_memory_usage'",
+                'TSV',
+            )
+            assert int(str(r).strip()) > 0
         finally:
             conn.close()
 
@@ -178,7 +182,7 @@ class TestChdbSettingsDataStoreConfig:
         assert config.chdb_settings == {
             'memory_worker_correct_memory_tracker': 1,
             'max_server_memory_usage': 0,
-            'max_server_memory_usage_to_ram_ratio': 0,
+            'max_server_memory_usage_to_ram_ratio': 0.9,
         }
 
     def test_config_set_chdb_setting(self):
@@ -342,6 +346,107 @@ class TestChdbSettingsDataStoreInternal:
         """)
 
 
+class TestExternalSortDefault:
+    """Verify max_bytes_before_external_sort is derived from the server memory limit."""
+
+    def _query_setting(self, conn, name):
+        r = conn._conn.query(
+            f"SELECT value, changed FROM system.settings WHERE name = '{name}'",
+            'CSV',
+        )
+        value, changed = str(r).strip().rsplit(',', 1)
+        return value.strip('"'), changed.strip()
+
+    def test_default_is_half_of_server_memory_limit(self):
+        conn = Connection(':memory:')
+        conn.connect()
+        try:
+            raw = conn._conn.query(
+                "SELECT value FROM system.server_settings "
+                "WHERE name = 'max_server_memory_usage'",
+                'TSV',
+            )
+            server_limit = int(str(raw).strip())
+            assert server_limit > 0
+
+            value, changed = self._query_setting(conn, 'max_bytes_before_external_sort')
+            assert int(value) == server_limit // 2
+            assert changed == '1'
+        finally:
+            conn.close()
+
+    def test_ratio_valve_kept_at_engine_default(self):
+        conn = Connection(':memory:')
+        conn.connect()
+        try:
+            value, _ = self._query_setting(conn, 'max_bytes_ratio_before_external_sort')
+            assert float(value) == 0.5
+        finally:
+            conn.close()
+
+    def test_user_override_applied_as_is(self):
+        set_chdb_setting('max_bytes_before_external_sort', 123456789)
+        conn = Connection(':memory:')
+        conn.connect()
+        try:
+            value, changed = self._query_setting(conn, 'max_bytes_before_external_sort')
+            assert int(value) == 123456789
+            assert changed == '1'
+        finally:
+            conn.close()
+
+    def test_instance_param_override_applied_as_is(self):
+        conn = Connection(':memory:', max_bytes_before_external_sort=987654321)
+        conn.connect()
+        try:
+            value, _ = self._query_setting(conn, 'max_bytes_before_external_sort')
+            assert int(value) == 987654321
+        finally:
+            conn.close()
+
+    def test_invalid_user_override_raises(self):
+        from datastore.exceptions import ConnectionError as DataStoreConnectionError
+
+        set_chdb_setting('max_bytes_before_external_sort', 'not_a_valid_size')
+        conn = Connection(':memory:')
+        try:
+            with pytest.raises(DataStoreConnectionError, match="Failed to connect"):
+                conn.connect()
+        finally:
+            if conn._conn is not None:
+                conn.close()
+
+    def test_no_server_limit_skips_external_sort_default(self):
+        _run_chdb_in_subprocess("""
+            from datastore.config import set_chdb_setting
+            from datastore.connection import Connection
+
+            set_chdb_setting('max_server_memory_usage_to_ram_ratio', 0)
+
+            conn = Connection(':memory:')
+            conn.connect()
+            try:
+                r = conn._conn.query(
+                    "SELECT value FROM system.settings "
+                    "WHERE name = 'max_bytes_before_external_sort'",
+                    'TSV',
+                )
+                assert str(r).strip() == '0', f"Expected '0' but got: {r}"
+            finally:
+                conn.close()
+        """)
+
+    def test_applied_via_global_executor(self):
+        executor = get_executor()
+        executor._ensure_connected()
+
+        value, changed = self._query_setting(
+            executor.connection, 'max_bytes_before_external_sort'
+        )
+        assert int(value) > 0
+        assert changed == '1'
+
+
 class TestChdbSettingsConnectionString:
     """Verify connection string is built correctly."""
 
@@ -351,7 +456,7 @@ class TestChdbSettingsConnectionString:
         assert ':memory:?' in conn_str
         assert 'memory_worker_correct_memory_tracker=1' in conn_str
         assert 'max_server_memory_usage=0' in conn_str
-        assert 'max_server_memory_usage_to_ram_ratio=0' in conn_str
+        assert 'max_server_memory_usage_to_ram_ratio=0.9' in conn_str
 
     def test_connection_string_override(self):
         set_chdb_setting('memory_worker_correct_memory_tracker', 0)

--- a/datastore/tests/test_chdb_settings.py
+++ b/datastore/tests/test_chdb_settings.py
@@ -106,7 +106,9 @@ class TestChdbSettingsDefaults:
                 "WHERE name = 'max_server_memory_usage'",
                 'TSV',
             )
-            assert int(str(r).strip()) > 0
+            raw = str(r).strip()
+            assert raw, "max_server_memory_usage not found in system.server_settings"
+            assert int(raw) > 0
         finally:
             conn.close()
 
@@ -354,7 +356,9 @@ class TestExternalSortDefault:
             f"SELECT value, changed FROM system.settings WHERE name = '{name}'",
             'CSV',
         )
-        value, changed = str(r).strip().rsplit(',', 1)
+        raw = str(r).strip()
+        assert raw, f"Setting '{name}' not found in system.settings"
+        value, changed = raw.rsplit(',', 1)
         return value.strip('"'), changed.strip()
 
     def test_default_is_half_of_server_memory_limit(self):
@@ -379,9 +383,8 @@ class TestExternalSortDefault:
         conn = Connection(':memory:')
         conn.connect()
         try:
-            value, changed = self._query_setting(conn, 'max_bytes_ratio_before_external_sort')
+            _, changed = self._query_setting(conn, 'max_bytes_ratio_before_external_sort')
             assert changed == '0'
-            assert float(value) > 0
         finally:
             conn.close()
 
@@ -409,6 +412,15 @@ class TestExternalSortDefault:
         from datastore.exceptions import ConnectionError as DataStoreConnectionError
 
         set_chdb_setting('max_bytes_before_external_sort', 'not_a_valid_size')
+        conn = Connection(':memory:')
+        with pytest.raises(DataStoreConnectionError, match="Failed to connect"):
+            conn.connect()
+        assert conn._conn is None
+
+    def test_bool_user_override_raises(self):
+        from datastore.exceptions import ConnectionError as DataStoreConnectionError
+
+        set_chdb_setting('max_bytes_before_external_sort', True)
         conn = Connection(':memory:')
         with pytest.raises(DataStoreConnectionError, match="Failed to connect"):
             conn.connect()


### PR DESCRIPTION
Closes #610

- Restore `max_server_memory_usage_to_ram_ratio=0.9` in the default chdb settings, re-enabling the catchable server-level memory limit and the ratio-based auto-spill for GROUP BY / JOIN.
- After connect, set `max_bytes_before_external_sort` to half of the effective server memory limit (official recommendation, ClickHouse Cloud default) so large ORDER BY spills to disk instead of failing with MEMORY_LIMIT_EXCEEDED. A user-provided value via `set_chdb_setting` or connection params is applied as-is; if the server limit is disabled, nothing is set.

Validation: in a 1GB cgroup a 1.6GB sort previously failed with MEMORY_LIMIT_EXCEEDED and now completes in 65s (4 spill parts); on a 123GB box a 4GB sort runs unchanged (329s vs 331s baseline, no spill) because the default ratio valve keeps sorts in memory until real memory pressure.

Unit tests cover the new defaults, the derived sort threshold, user overrides, and the disabled-limit fallback.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Enable external sort by default and restore server memory limit to 0.9 of RAM
> - Changes the default `max_server_memory_usage_to_ram_ratio` from `0` to `0.9` in [datastore/config.py](https://github.com/chdb-io/chdb/pull/611/files#diff-5cac076f9632371fd2a4e9a35a94846c51fa8b681451866351fb966c446e4a64), restoring a meaningful server memory limit.
> - Adds `Connection._apply_external_sort_default()` in [datastore/connection.py](https://github.com/chdb-io/chdb/pull/611/files#diff-5bedd723d353a154f038b0c67bbe3900ae887c8c88fa31837ba3bb34a585ee33) that sets `max_bytes_before_external_sort` to half the server memory limit after each connection is established.
> - User-supplied overrides for `max_bytes_before_external_sort` (via global settings or per-instance params) are applied as-is; boolean overrides are rejected with a `ValueError`.
> - Risk: if applying the external sort setting fails (e.g. invalid override value), `connect()` now aborts and leaves `_conn` as `None` instead of succeeding silently.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized c7f2e48.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->