### PR TITLE
datastore: pandas 3.0 API parity — read_iceberg/to_iceberg, str.isascii, str.replace(dict), map(**kwargs)

### DIFF
--- a/datastore/__init__.py
+++ b/datastore/__init__.py
@@ -227,6 +227,7 @@ from .pandas_api import (  # noqa: E402
     # IO Functions
     read_csv,
     read_parquet,
+    read_iceberg,
     read_json,
     read_excel,
     read_sql,
@@ -355,6 +356,7 @@ __all__ = [
     # Pandas-Compatible IO Functions
     'read_csv',
     'read_parquet',
+    'read_iceberg',
     'read_json',
     'read_excel',
     'read_sql',

--- a/datastore/column_expr.py
+++ b/datastore/column_expr.py
@@ -5685,6 +5685,21 @@ class ColumnExpr:
             Name: grade, dtype: float64
             >>> ds['x'].map(lambda v, add: v + add, add=10)  # pandas 3.0+
         """
+        if kwargs:
+            import inspect
+
+            # Fail at the call site on pandas < 3 (whose Series.map has no
+            # **kwargs), consistent with the eager NotImplementedError raised
+            # by the other pandas-3.0 additions, instead of an opaque
+            # TypeError at lazy execution time.
+            supports_kwargs = any(
+                p.kind is inspect.Parameter.VAR_KEYWORD
+                for p in inspect.signature(pd.Series.map).parameters.values()
+            )
+            if not supports_kwargs:
+                raise NotImplementedError(
+                    "Passing extra keyword arguments to map() requires pandas >= 3.0"
+                )
         return ColumnExpr(
             source=self,
             method_name="map",

--- a/datastore/column_expr.py
+++ b/datastore/column_expr.py
@@ -5663,13 +5663,16 @@ class ColumnExpr:
         # For scalar results or other types, can't use .get()
         return default
 
-    def map(self, arg, na_action=None) -> "ColumnExpr":
+    def map(self, arg, na_action=None, **kwargs) -> "ColumnExpr":
         """
         Map values of Series according to input mapping or function (lazy).
 
         Args:
             arg: Mapping correspondence (dict, Series, or function)
             na_action: If 'ignore', propagate NaN values without passing to mapping
+            **kwargs: Additional keyword arguments passed through to
+                pandas Series.map, which forwards them to ``arg`` when it is a
+                callable (pandas 3.0+)
 
         Returns:
             ColumnExpr: Lazy wrapper returning Series with mapped values
@@ -5680,12 +5683,13 @@ class ColumnExpr:
             1    3.0
             2    2.0
             Name: grade, dtype: float64
+            >>> ds['x'].map(lambda v, add: v + add, add=10)  # pandas 3.0+
         """
         return ColumnExpr(
             source=self,
             method_name="map",
             method_args=(arg,),
-            method_kwargs=dict(na_action=na_action),
+            method_kwargs=dict(na_action=na_action, **kwargs),
         )
 
     def fillna(

--- a/datastore/function_definitions.py
+++ b/datastore/function_definitions.py
@@ -275,16 +275,21 @@ def _build_str_replace(expr, pattern, replacement=None, regex: bool = False, ali
         # pandas 3.0: str.replace({'old': 'new', ...}); repl must not be given.
         if replacement is not None:
             raise ValueError("repl cannot be used when pat is a dictionary")
-        func_name = 'replaceRegexpAll' if regex else 'replaceAll'
         items = list(pattern.items())
+        for pat, repl in items:
+            # No silent str() coercion: pandas raises for e.g. {'a': None}, and
+            # stringifying would write literal 'None' into the data instead.
+            if not isinstance(pat, str) or not isinstance(repl, str):
+                raise TypeError("patterns and replacements in the dictionary must be strings")
         if not items:
             # Identity: single-argument coalesce returns the column unchanged.
             return Function('coalesce', expr, alias=alias)
+        func_name = 'replaceRegexpAll' if regex else 'replaceAll'
         result = expr
         for pat, repl in items[:-1]:
-            result = Function(func_name, result, Literal(str(pat)), Literal(str(repl)))
+            result = Function(func_name, result, Literal(pat), Literal(repl))
         last_pat, last_repl = items[-1]
-        return Function(func_name, result, Literal(str(last_pat)), Literal(str(last_repl)), alias=alias)
+        return Function(func_name, result, Literal(last_pat), Literal(last_repl), alias=alias)
 
     if replacement is None:
         raise TypeError("repl must be a string when pat is not a dictionary")

--- a/datastore/function_definitions.py
+++ b/datastore/function_definitions.py
@@ -248,25 +248,46 @@ def _build_replace(expr, to_replace, value=_REPLACE_SENTINEL, regex: bool = Fals
     func_type=FunctionType.SCALAR,
     category=FunctionCategory.STRING,
     aliases=['replaceAll', 'replace'],  # 'replace' alias for str accessor
-    doc='Replace substring occurrences. Maps to replace(s, from, to). Use regex=True for regex.',
+    doc='Replace substring occurrences. Maps to replace(s, from, to). Use regex=True for regex. '
+        'pat may be a dict of {pattern: replacement} (pandas 3.0), applied sequentially.',
 )
-def _build_str_replace(expr, pattern: str, replacement: str, regex: bool = False, alias=None):
+def _build_str_replace(expr, pattern, replacement=None, regex: bool = False, alias=None):
     """
     Replace substrings in a string column (pandas str.replace compatible).
 
     Args:
         expr: The expression to operate on
-        pattern: Substring pattern to find
-        replacement: Replacement string
+        pattern: Substring pattern to find, or a dict of {pattern: replacement}
+            (pandas 3.0 form; replacement must then be omitted)
+        replacement: Replacement string (required unless pattern is a dict)
         regex: If True, use regex replacement
         alias: Optional alias for the result
 
     Examples:
-        str.replace('a', 'b')     -> replaces all 'a' with 'b'
-        str.replace('a+', 'b', regex=True) -> regex replacement
+        str.replace('a', 'b')                -> replaces all 'a' with 'b'
+        str.replace('a+', 'b', regex=True)   -> regex replacement
+        str.replace({'a': 'b', 'c': 'd'})    -> sequential replacements
     """
     from .functions import Function
     from .expressions import Literal
+
+    if isinstance(pattern, dict):
+        # pandas 3.0: str.replace({'old': 'new', ...}); repl must not be given.
+        if replacement is not None:
+            raise ValueError("repl cannot be used when pat is a dictionary")
+        func_name = 'replaceRegexpAll' if regex else 'replaceAll'
+        items = list(pattern.items())
+        if not items:
+            # Identity: single-argument coalesce returns the column unchanged.
+            return Function('coalesce', expr, alias=alias)
+        result = expr
+        for pat, repl in items[:-1]:
+            result = Function(func_name, result, Literal(str(pat)), Literal(str(repl)))
+        last_pat, last_repl = items[-1]
+        return Function(func_name, result, Literal(str(last_pat)), Literal(str(last_repl)), alias=alias)
+
+    if replacement is None:
+        raise TypeError("repl must be a string when pat is not a dictionary")
 
     if regex:
         return Function('replaceRegexpAll', expr, Literal(pattern), Literal(replacement), alias=alias)
@@ -818,6 +839,21 @@ def _build_isalnum(expr, alias=None):
     from .expressions import Literal
 
     return Function('match', expr, Literal('^[a-zA-Z0-9]+$'), alias=alias)
+
+
+@register_function(
+    name='isascii',
+    clickhouse_name='match',
+    func_type=FunctionType.SCALAR,
+    category=FunctionCategory.STRING,
+    doc='Check if all characters are ASCII, like str.isascii() (pandas 3.0). '
+        'Empty strings are True.',
+)
+def _build_isascii(expr, alias=None):
+    from .functions import Function
+    from .expressions import Literal
+
+    return Function('match', expr, Literal('^[\\x00-\\x7F]*$'), alias=alias)
 
 
 @register_function(

--- a/datastore/function_executor.py
+++ b/datastore/function_executor.py
@@ -734,7 +734,10 @@ class FunctionExecutorConfig:
 
         # Apply and map
         self._pandas_implementations["apply"] = lambda s, func: s.apply(func)
-        self._pandas_implementations["map"] = lambda s, arg: s.map(arg)
+        # kwargs are forwarded to the mapper callable by pandas 3.0+ Series.map
+        self._pandas_implementations["map"] = lambda s, arg, na_action=None, **kw: s.map(
+            arg, na_action=na_action, **kw
+        )
 
         # Comparison with shift
         self._pandas_implementations["eq"] = lambda s, other: s.eq(other)

--- a/datastore/pandas_api.py
+++ b/datastore/pandas_api.py
@@ -413,6 +413,41 @@ def read_parquet(path, columns=None, **kwargs) -> "DataStoreType":
         return DataStore.from_file(path, format="Parquet")
 
 
+def read_iceberg(table_identifier, catalog_name=None, **kwargs) -> "DataStoreType":
+    """
+    Read an Apache Iceberg table into DataStore (pandas 3.0 API parity).
+
+    Delegates to pandas.read_iceberg (PyIceberg-backed) and wraps the result
+    in a DataStore, so downstream operations get the usual lazy SQL engine.
+
+    Args:
+        table_identifier: Iceberg table identifier, e.g. "namespace.table"
+        catalog_name: Name of the PyIceberg catalog to use
+        **kwargs: Additional pandas.read_iceberg() arguments
+            (catalog_properties, columns, row_filter, case_sensitive,
+            snapshot_id, limit, scan_properties)
+
+    Returns:
+        DataStore: A DataStore object containing the Iceberg table data
+
+    Raises:
+        NotImplementedError: If the installed pandas has no read_iceberg
+            (requires pandas >= 3.0)
+
+    Example:
+        >>> from datastore import read_iceberg
+        >>> ds = read_iceberg("sales.orders", catalog_name="my_catalog")
+    """
+    if not hasattr(pd, "read_iceberg"):
+        raise NotImplementedError(
+            "read_iceberg requires pandas >= 3.0 (pandas.read_iceberg not available)"
+        )
+
+    DataStore = _get_datastore_class()
+    pandas_df = pd.read_iceberg(table_identifier, catalog_name=catalog_name, **kwargs)
+    return DataStore.from_df(pandas_df)
+
+
 def read_json(path_or_buf, orient=None, lines=False, **kwargs) -> "DataStoreType":
     """
     Read a JSON file into DataStore.

--- a/datastore/pandas_compat.py
+++ b/datastore/pandas_compat.py
@@ -2191,8 +2191,6 @@ class PandasCompatMixin:
             NotImplementedError: If the installed pandas has no
                 DataFrame.to_iceberg (requires pandas >= 3.0)
         """
-        import pandas as pd
-
         if not hasattr(pd.DataFrame, "to_iceberg"):
             raise NotImplementedError(
                 "to_iceberg requires pandas >= 3.0 (DataFrame.to_iceberg not available)"

--- a/datastore/pandas_compat.py
+++ b/datastore/pandas_compat.py
@@ -2174,6 +2174,31 @@ class PandasCompatMixin:
         """Write DataFrame to feather format."""
         return self._get_df().to_feather(path, **kwargs)
 
+    def to_iceberg(self, table_identifier, catalog_name=None, **kwargs):
+        """
+        Write the DataStore to an Apache Iceberg table (pandas 3.0 API parity).
+
+        Materializes the result and delegates to pandas.DataFrame.to_iceberg
+        (PyIceberg-backed).
+
+        Args:
+            table_identifier: Iceberg table identifier, e.g. "namespace.table"
+            catalog_name: Name of the PyIceberg catalog to use
+            **kwargs: Additional DataFrame.to_iceberg() arguments
+                (catalog_properties, location, append, snapshot_properties)
+
+        Raises:
+            NotImplementedError: If the installed pandas has no
+                DataFrame.to_iceberg (requires pandas >= 3.0)
+        """
+        import pandas as pd
+
+        if not hasattr(pd.DataFrame, "to_iceberg"):
+            raise NotImplementedError(
+                "to_iceberg requires pandas >= 3.0 (DataFrame.to_iceberg not available)"
+            )
+        return self._get_df().to_iceberg(table_identifier, catalog_name=catalog_name, **kwargs)
+
     def to_sql(
         self,
         name,

--- a/datastore/tests/test_pandas3_api_gaps.py
+++ b/datastore/tests/test_pandas3_api_gaps.py
@@ -1,0 +1,232 @@
+"""
+Tests for pandas 3.0 API-parity additions:
+
+- Series.str.isascii()
+- Series.str.replace({pat: repl}) dictionary form
+- Series.map(func, **kwargs) keyword passthrough
+- datastore.read_iceberg / DataStore.to_iceberg delegation
+"""
+
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).parent.parent))
+
+import pandas as pd
+import pytest
+
+import datastore
+from datastore import DataStore
+
+PANDAS_3 = int(pd.__version__.split(".")[0]) >= 3
+
+
+class TestStrIsascii:
+    DATA = ["hello", "héllo", "中文", "", "mixed中x", "ascii only!"]
+
+    def test_isascii_matches_python_semantics(self):
+        pd_df = pd.DataFrame({"s": self.DATA})
+        ds = DataStore.from_df(pd_df)
+
+        result = [bool(v) for v in ds["s"].str.isascii()]
+
+        assert result == [v.isascii() for v in self.DATA]
+
+    @pytest.mark.skipif(not PANDAS_3, reason="Series.str.isascii is pandas 3.0+")
+    def test_isascii_mirrors_pandas(self):
+        # pandas operations
+        pd_df = pd.DataFrame({"s": self.DATA})
+        pd_result = pd_df["s"].str.isascii()
+
+        # DataStore operations (mirror of pandas)
+        ds = DataStore.from_df(pd_df)
+        ds_result = ds["s"].str.isascii()
+
+        assert [bool(v) for v in ds_result] == list(pd_result)
+
+    def test_isascii_null_propagates(self):
+        # object dtype keeps None handling engine-agnostic
+        pd_df = pd.DataFrame({"s": pd.Series(["ok", None, "汉"], dtype=object)})
+        ds = DataStore.from_df(pd_df)
+
+        result = list(ds["s"].str.isascii())
+
+        assert bool(result[0]) is True
+        assert pd.isna(result[1])
+        assert bool(result[2]) is False
+
+
+class TestStrReplaceDict:
+    DATA = ["cat hat", "bat", "no match", ""]
+
+    @staticmethod
+    def _python_chain_replace(values, mapping):
+        out = []
+        for v in values:
+            for pat, repl in mapping.items():
+                v = v.replace(pat, repl)
+            out.append(v)
+        return out
+
+    def test_replace_dict_values(self):
+        mapping = {"cat": "dog", "hat": "cap"}
+        pd_df = pd.DataFrame({"s": self.DATA})
+        ds = DataStore.from_df(pd_df)
+
+        result = list(ds["s"].str.replace(mapping))
+
+        assert result == self._python_chain_replace(self.DATA, mapping)
+
+    @pytest.mark.skipif(not PANDAS_3, reason="dict pat form is pandas 3.0+")
+    def test_replace_dict_mirrors_pandas(self):
+        mapping = {"cat": "dog", "hat": "cap"}
+
+        # pandas operations
+        pd_df = pd.DataFrame({"s": self.DATA})
+        pd_result = pd_df["s"].str.replace(mapping)
+
+        # DataStore operations (mirror of pandas)
+        ds = DataStore.from_df(pd_df)
+        ds_result = ds["s"].str.replace(mapping)
+
+        assert list(ds_result) == list(pd_result)
+
+    @pytest.mark.skipif(not PANDAS_3, reason="dict pat form is pandas 3.0+")
+    def test_replace_dict_sequential_application_mirrors_pandas(self):
+        # First pair's output feeds the second pair: order semantics must match.
+        mapping = {"a": "b", "b": "c"}
+        data = ["aba", "abc"]
+
+        pd_result = pd.DataFrame({"s": data})["s"].str.replace(mapping)
+
+        ds = DataStore.from_df(pd.DataFrame({"s": data}))
+        ds_result = ds["s"].str.replace(mapping)
+
+        assert list(ds_result) == list(pd_result)
+
+    def test_replace_dict_with_repl_raises(self):
+        ds = DataStore.from_df(pd.DataFrame({"s": self.DATA}))
+
+        with pytest.raises(ValueError, match="dictionary"):
+            ds["s"].str.replace({"cat": "dog"}, "oops")
+
+    def test_replace_dict_empty_is_identity(self):
+        ds = DataStore.from_df(pd.DataFrame({"s": self.DATA}))
+
+        result = list(ds["s"].str.replace({}))
+
+        assert result == self.DATA
+
+    def test_replace_two_arg_form_unchanged(self):
+        # pandas operations
+        pd_df = pd.DataFrame({"s": self.DATA})
+        pd_result = pd_df["s"].str.replace("at", "AT")
+
+        # DataStore operations (mirror of pandas)
+        ds = DataStore.from_df(pd_df)
+        ds_result = ds["s"].str.replace("at", "AT")
+
+        assert list(ds_result) == list(pd_result)
+
+    def test_replace_regex_form_unchanged(self):
+        pd_df = pd.DataFrame({"s": self.DATA})
+        pd_result = pd_df["s"].str.replace("[ch]at", "X", regex=True)
+
+        ds = DataStore.from_df(pd_df)
+        ds_result = ds["s"].str.replace("[ch]at", "X", regex=True)
+
+        assert list(ds_result) == list(pd_result)
+
+
+class TestMapKwargs:
+    @pytest.mark.skipif(not PANDAS_3, reason="Series.map(**kwargs) is pandas 3.0+")
+    def test_map_kwargs_mirrors_pandas(self):
+        # pandas operations
+        pd_df = pd.DataFrame({"a": [1, 2, 3]})
+        pd_result = pd_df["a"].map(lambda v, add: v + add, add=10)
+
+        # DataStore operations (mirror of pandas)
+        ds = DataStore.from_df(pd_df)
+        ds_result = ds["a"].map(lambda v, add: v + add, add=10)
+
+        assert list(ds_result) == list(pd_result)
+        assert list(ds_result) == [11, 12, 13]
+
+    def test_map_dict_and_na_action_unchanged(self):
+        pd_df = pd.DataFrame({"g": ["A", "B", "A"]})
+        pd_result = pd_df["g"].map({"A": 4.0, "B": 3.0})
+
+        ds = DataStore.from_df(pd_df)
+        ds_result = ds["g"].map({"A": 4.0, "B": 3.0})
+
+        assert list(ds_result) == list(pd_result)
+
+
+class TestIcebergDelegation:
+    """read_iceberg/to_iceberg delegate to pandas' PyIceberg-backed IO.
+
+    The pandas functions are monkeypatched so the delegation contract
+    (argument passthrough, DataStore wrapping) is tested without a live
+    Iceberg catalog.
+    """
+
+    def test_read_iceberg_wraps_result_and_passes_args(self, monkeypatch):
+        source_df = pd.DataFrame({"x": [1, 2], "y": ["a", "b"]})
+        captured = {}
+
+        def fake_read_iceberg(table_identifier, catalog_name=None, **kwargs):
+            captured["table_identifier"] = table_identifier
+            captured["catalog_name"] = catalog_name
+            captured["kwargs"] = kwargs
+            return source_df.copy()
+
+        monkeypatch.setattr(pd, "read_iceberg", fake_read_iceberg, raising=False)
+
+        ds = datastore.read_iceberg(
+            "ns.orders", catalog_name="cat", snapshot_id=42, limit=10
+        )
+
+        assert isinstance(ds, DataStore)
+        assert captured["table_identifier"] == "ns.orders"
+        assert captured["catalog_name"] == "cat"
+        assert captured["kwargs"] == {"snapshot_id": 42, "limit": 10}
+        result_df = ds.to_df()
+        assert list(result_df.columns) == ["x", "y"]
+        assert list(result_df["x"]) == [1, 2]
+        assert list(result_df["y"]) == ["a", "b"]
+
+    def test_to_iceberg_delegates_materialized_frame(self, monkeypatch):
+        captured = {}
+
+        def fake_to_iceberg(self, table_identifier, catalog_name=None, **kwargs):
+            captured["frame"] = self.copy()
+            captured["table_identifier"] = table_identifier
+            captured["catalog_name"] = catalog_name
+            captured["kwargs"] = kwargs
+            return None
+
+        monkeypatch.setattr(pd.DataFrame, "to_iceberg", fake_to_iceberg, raising=False)
+
+        source_df = pd.DataFrame({"x": [1, 2, 3]})
+        ds = DataStore.from_df(source_df)
+        ds.to_iceberg("ns.orders", catalog_name="cat", append=True)
+
+        assert captured["table_identifier"] == "ns.orders"
+        assert captured["catalog_name"] == "cat"
+        assert captured["kwargs"] == {"append": True}
+        assert list(captured["frame"]["x"]) == [1, 2, 3]
+
+    @pytest.mark.skipif(PANDAS_3, reason="error contract only applies before pandas 3.0")
+    def test_read_iceberg_requires_pandas3(self):
+        with pytest.raises(NotImplementedError, match="pandas >= 3.0"):
+            datastore.read_iceberg("ns.orders")
+
+    @pytest.mark.skipif(PANDAS_3, reason="error contract only applies before pandas 3.0")
+    def test_to_iceberg_requires_pandas3(self):
+        ds = DataStore.from_df(pd.DataFrame({"x": [1]}))
+        with pytest.raises(NotImplementedError, match="pandas >= 3.0"):
+            ds.to_iceberg("ns.orders")
+
+
+if __name__ == "__main__":
+    sys.exit(pytest.main([__file__, "-v"]))

--- a/datastore/tests/test_pandas3_api_gaps.py
+++ b/datastore/tests/test_pandas3_api_gaps.py
@@ -104,11 +104,50 @@ class TestStrReplaceDict:
 
         assert list(ds_result) == list(pd_result)
 
+    def test_replace_dict_regex_values(self):
+        import re
+
+        mapping = {"[ch]at": "X", "X+": "Y"}
+        pd_df = pd.DataFrame({"s": self.DATA})
+        ds = DataStore.from_df(pd_df)
+
+        result = list(ds["s"].str.replace(mapping, regex=True))
+
+        expected = []
+        for v in self.DATA:
+            for pat, repl in mapping.items():
+                v = re.sub(pat, repl, v)
+            expected.append(v)
+        assert result == expected
+
+    @pytest.mark.skipif(not PANDAS_3, reason="dict pat form is pandas 3.0+")
+    def test_replace_dict_regex_mirrors_pandas(self):
+        mapping = {"[ch]at": "X", "X+": "Y"}
+
+        # pandas operations
+        pd_df = pd.DataFrame({"s": self.DATA})
+        pd_result = pd_df["s"].str.replace(mapping, regex=True)
+
+        # DataStore operations (mirror of pandas)
+        ds = DataStore.from_df(pd_df)
+        ds_result = ds["s"].str.replace(mapping, regex=True)
+
+        assert list(ds_result) == list(pd_result)
+
     def test_replace_dict_with_repl_raises(self):
         ds = DataStore.from_df(pd.DataFrame({"s": self.DATA}))
 
         with pytest.raises(ValueError, match="dictionary"):
             ds["s"].str.replace({"cat": "dog"}, "oops")
+
+    def test_replace_dict_non_string_entries_raise(self):
+        ds = DataStore.from_df(pd.DataFrame({"s": self.DATA}))
+
+        # A None replacement must not be silently stringified into 'None'.
+        with pytest.raises(TypeError, match="strings"):
+            ds["s"].str.replace({"cat": None})
+        with pytest.raises(TypeError, match="strings"):
+            ds["s"].str.replace({1: "one"})
 
     def test_replace_dict_empty_is_identity(self):
         ds = DataStore.from_df(pd.DataFrame({"s": self.DATA}))
@@ -152,7 +191,7 @@ class TestMapKwargs:
         assert list(ds_result) == list(pd_result)
         assert list(ds_result) == [11, 12, 13]
 
-    def test_map_dict_and_na_action_unchanged(self):
+    def test_map_dict_mapping_unchanged(self):
         pd_df = pd.DataFrame({"g": ["A", "B", "A"]})
         pd_result = pd_df["g"].map({"A": 4.0, "B": 3.0})
 
@@ -160,6 +199,27 @@ class TestMapKwargs:
         ds_result = ds["g"].map({"A": 4.0, "B": 3.0})
 
         assert list(ds_result) == list(pd_result)
+
+    def test_map_na_action_ignore_with_missing_values(self):
+        # pandas operations
+        pd_df = pd.DataFrame({"g": ["A", "B", None]})
+        pd_result = pd_df["g"].map({"A": 4.0, "B": 3.0}, na_action="ignore")
+
+        # DataStore operations (mirror of pandas)
+        ds = DataStore.from_df(pd_df)
+        ds_result = ds["g"].map({"A": 4.0, "B": 3.0}, na_action="ignore")
+
+        result = list(ds_result)
+        assert result[:2] == list(pd_result)[:2] == [4.0, 3.0]
+        assert pd.isna(result[2]) and pd.isna(list(pd_result)[2])
+
+    @pytest.mark.skipif(PANDAS_3, reason="eager error contract only applies before pandas 3.0")
+    def test_map_kwargs_raise_eagerly_on_pandas2(self):
+        ds = DataStore.from_df(pd.DataFrame({"a": [1, 2, 3]}))
+
+        # Must fail at the call site, not at lazy execution time.
+        with pytest.raises(NotImplementedError, match="pandas >= 3.0"):
+            ds["a"].map(lambda v, add: v + add, add=10)
 
 
 class TestIcebergDelegation:


### PR DESCRIPTION
Fixes #614

Fills the remaining pandas 3.0 API gaps from the compatibility investigation (the Arrow PyCapsule half is #596):

- **`read_iceberg()` / `DataStore.to_iceberg()`** — delegate to pandas' PyIceberg-backed IO and wrap the result in a DataStore; clear `NotImplementedError` on pandas < 3.
- **`Series.str.isascii()`** — registered as a STRING function (`match(s, '^[\x00-\x7F]*$')`), auto-injected into the accessor like the other `is*` predicates; empty strings are True, NULLs propagate.
- **`Series.str.replace({pat: repl})`** — dict form maps to chained `replaceAll`/`replaceRegexpAll`; `repl` alongside a dict raises `ValueError` like pandas; empty dict is identity; two-arg and regex forms unchanged.
- **`Series.map(func, **kwargs)`** — `ColumnExpr.map` and the executor fallback pass kwargs through to `Series.map` (pandas 3 forwards them to the callable).

## Tests

`datastore/tests/test_pandas3_api_gaps.py` — 16 tests: value + pandas-mirror checks for all four features, sequential-application semantics for dict replace, iceberg delegation contracts via monkeypatched pandas IO, and pandas-2 error guards.

- pandas 3.0.3: 14 passed, 2 skipped · pandas 2.3.3: 12 passed, 4 skipped
- regression: `test_pandas_compat` / `test_pandas_col_compat` / `test_from_dataframe` / `test_dataframe_sql_pushdown` (296 passed), string-accessor suites, exploratory string batches — all green; `ruff check datastore` clean

Note: `test_str_accessor_recursion_fix.py::test_str_extract_then_filter` hangs under pandas 3.0.3 identically on current `main` (A/B-checked in a clean worktree) — it is the known string+NULL engine issue (chdb-io/chdb-core#135 family), unrelated to this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add pandas 3.0 API parity for `read_iceberg`, `to_iceberg`, `str.isascii`, `str.replace(dict)`, and `map(**kwargs)`
> - Adds `read_iceberg` in [pandas_api.py](https://github.com/chdb-io/chdb/pull/615/files#diff-09e41dc972d33e21863fddb5aabf4fb850999d2f20704e69224540c54f600659) and `to_iceberg` in [pandas_compat.py](https://github.com/chdb-io/chdb/pull/615/files#diff-9845c9fab6c8868000c586df009fb342cb663c720fa5f936e8a67880ca4f1780) to read/write Apache Iceberg tables via pandas 3.0; raises `NotImplementedError` on older pandas.
> - Adds `str.isascii()` support in [function_definitions.py](https://github.com/chdb-io/chdb/pull/615/files#diff-cbacf79f41ae1abc693cc41a19e6c190a39ee13c5ef773a4f49943dc56b2d066) using a regex match against `^[\x00-\x7F]*$` (empty strings return `True`, matching pandas/Python semantics).
> - Extends `str.replace` in [function_definitions.py](https://github.com/chdb-io/chdb/pull/615/files#diff-cbacf79f41ae1abc693cc41a19e6c190a39ee13c5ef773a4f49943dc56b2d066) to accept a `dict` for sequential pattern replacement, with validation that rejects mixed `replacement` args or non-string dict entries.
> - Extends `ColumnExpr.map` in [column_expr.py](https://github.com/chdb-io/chdb/pull/615/files#diff-cf897f1def888a8f77705c04e9b029521fd5aecb7f46dae2266113e0f3be2f6d) to forward `**kwargs` to the underlying pandas `Series.map`; raises `NotImplementedError` eagerly if kwargs are passed on pandas < 3.0.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 5e90170.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->