### PR TITLE
feat: add chdb.durable — Durable Analytical Object subpackage

### DIFF
--- a/chdb/durable/__init__.py
+++ b/chdb/durable/__init__.py
@@ -1,0 +1,35 @@
+"""chdb.durable — Durable Analytical Object.
+
+An addressable, single-writer chDB engine whose authoritative state lives in
+object storage you own (S3 / GCS / Azure Blob / any S3-compatible / a local
+folder). Restore is fast, the lease makes single-writer a guarantee not an
+assumption, and the on-disk format is portable — your object is a folder you
+can move between clouds.
+
+    from chdb import durable as cd
+    ns = cd.Namespace("s3://bucket/prefix", owner="worker-1")
+    obj = ns.open("user-123")            # lease + restore (base + WAL replay)
+    obj.execute("INSERT INTO mem.beliefs VALUES (...)")
+    obj.flush()                          # cut a WAL segment (RPO boundary)
+    obj.checkpoint()                     # fold into a fresh base
+    obj.close()                          # flush + release lease
+    ns.scan("SELECT count() FROM mem.beliefs", ids=["user-1", "user-2"])
+
+Security scope: chdb.durable provides single-writer *coordination* (the lease
++ compare-and-set fence), not security. Access control is entirely your object
+store's IAM — anyone who can write the object's prefix can read, modify, or
+take its lock. There is no application-level auth, no client-side encryption,
+and no tamper protection: head/WAL/checkpoints are stored as-is (rely on the
+bucket's server-side encryption if you need at-rest encryption). For
+multi-tenant use, give each tenant credentials scoped to its own prefix.
+"""
+from .errors import DurableError, LeaseError, MissingDependency
+from .namespace import Namespace
+from .object import DurableObject
+from .backends import Backend, make_backend
+
+__all__ = [
+    "Namespace", "DurableObject", "Backend", "make_backend",
+    "DurableError", "LeaseError", "MissingDependency",
+]
+__version__ = "0.1.0"

--- a/chdb/durable/backends/__init__.py
+++ b/chdb/durable/backends/__init__.py
@@ -1,0 +1,81 @@
+"""Storage-backend abstraction — the seam that makes a Durable Analytical
+Object's home vendor-neutral.
+
+A backend is a tiny key/value store scoped to one object's prefix, with a
+*conditional create* (`put_if_absent`) and *conditional replace*
+(`replace_if_match`) — the two primitives the single-writer lease is built on.
+Every provider implements the same `Backend` protocol; the on-disk *format*
+(a chDB File backup + WAL segments + JSON manifest) is identical everywhere,
+so moving an object between clouds is a byte copy.
+
+`make_backend(url, sub)` maps a URL to a backend scoped to `<base>/<sub>`:
+    local:/path/to/root
+    s3://bucket/prefix          (endpoint via CHDB_DURABLE_S3_ENDPOINT for MinIO/R2)
+    gcs://bucket/prefix
+    azure://container/prefix
+"""
+from __future__ import annotations
+
+import os
+from typing import Optional, Protocol, runtime_checkable
+from urllib.parse import urlparse
+
+
+@runtime_checkable
+class Backend(Protocol):
+    def get(self, key: str) -> Optional[bytes]: ...
+    def get_with_etag(self, key: str): ...  # -> (Optional[bytes], Optional[str])
+    def put(self, key: str, data: bytes) -> None: ...
+    def put_if_absent(self, key: str, data: bytes): ...  # -> Optional[str] etag, or None if it exists
+    def head_etag(self, key: str) -> Optional[str]: ...
+    def replace_if_match(self, key: str, data: bytes, etag: str) -> Optional[str]: ...
+    def delete_prefix(self, prefix: str = "") -> None: ...
+
+
+def make_backend(url: str, sub: str = "") -> Backend:
+    """Build a backend scoped to `<base_prefix>/<sub>` from a URL."""
+    u = urlparse(url)
+    scheme = u.scheme or "local"
+
+    if scheme == "local":
+        from .local import LocalFSBackend
+        root = (u.netloc + u.path) if u.netloc else u.path
+        base = os.path.realpath(root)
+        # Constrain the object id beneath root — a caller-controlled sub like
+        # "../../x", an absolute path, or a symlink to an outside dir would
+        # otherwise escape the namespace and let Namespace.destroy() rm -rf an
+        # arbitrary directory. realpath resolves symlinks before the check.
+        full = os.path.realpath(os.path.join(base, sub)) if sub else base
+        # os.path.join(base, "") appends exactly one separator, and yields the
+        # bare separator when base is the filesystem root — so `local:/` works.
+        if full != base and not full.startswith(os.path.join(base, "")):
+            raise ValueError(f"object id escapes backend root: {sub!r}")
+        return LocalFSBackend(full)
+
+    container = u.netloc
+    base = u.path.strip("/")
+    prefix = f"{base}/{sub}".strip("/") if sub else base
+
+    if scheme == "s3":
+        from .s3 import S3Backend
+        region = os.getenv("AWS_REGION", "us-east-1")
+        endpoint = os.getenv("CHDB_DURABLE_S3_ENDPOINT")
+        if endpoint:
+            # custom endpoint (MinIO / R2 / …) with static keys
+            return S3Backend(container, prefix, endpoint_url=endpoint,
+                             access_key=os.getenv("AWS_ACCESS_KEY_ID"),
+                             secret_key=os.getenv("AWS_SECRET_ACCESS_KEY"),
+                             region=region)
+        # real AWS: let boto3's default chain resolve creds (env incl. session
+        # token, SSO, or instance profile) — don't pin static keys
+        return S3Backend(container, prefix, region=region)
+    if scheme == "gcs":
+        from .gcs import GCSBackend
+        return GCSBackend(container, prefix,
+                          token=os.getenv("CHDB_DURABLE_GCS_TOKEN"),  # optional; else ADC
+                          project=os.getenv("CHDB_DURABLE_GCP_PROJECT"))
+    if scheme == "azure":
+        from .azure import AzureBlobBackend
+        return AzureBlobBackend(container, prefix,
+                                conn_str=os.environ["CHDB_DURABLE_AZURE_CONN"])
+    raise ValueError(f"unsupported durable backend scheme: {scheme!r}")

--- a/chdb/durable/backends/azure.py
+++ b/chdb/durable/backends/azure.py
@@ -1,0 +1,72 @@
+"""Native Azure Blob backend. Lease primitive = `overwrite=False` create
+(ResourceExists), Azure's single-writer primitive; no S3 API needed."""
+from __future__ import annotations
+
+from typing import Optional
+
+from ..errors import MissingDependency
+
+
+class AzureBlobBackend:
+    def __init__(self, container: str, prefix: str, *, conn_str: str):
+        try:
+            from azure.storage.blob import ContainerClient
+        except ImportError as e:
+            raise MissingDependency(
+                "azure backend needs azure-storage-blob: pip install 'chdb[durable-azure]'") from e
+        self.prefix = prefix.strip("/")
+        self.cc = ContainerClient.from_connection_string(conn_str, container)
+        try:
+            self.cc.create_container()
+        except Exception:
+            pass
+
+    def _n(self, key: str) -> str:
+        return f"{self.prefix}/{key}" if self.prefix else key
+
+    def get(self, key: str) -> Optional[bytes]:
+        return self.get_with_etag(key)[0]
+
+    def get_with_etag(self, key: str):
+        from azure.core.exceptions import ResourceNotFoundError
+        try:
+            d = self.cc.download_blob(self._n(key))
+            return (d.readall(), d.properties.etag)  # bytes + etag in one round-trip
+        except ResourceNotFoundError:
+            return (None, None)
+
+    def put(self, key: str, data: bytes) -> None:
+        self.cc.upload_blob(self._n(key), data, overwrite=True)
+
+    def put_if_absent(self, key: str, data: bytes) -> Optional[str]:
+        from azure.core.exceptions import ResourceExistsError
+        try:
+            r = self.cc.upload_blob(self._n(key), data, overwrite=False)
+            return r.get("etag")  # etag of the blob we just created
+        except ResourceExistsError:
+            return None
+
+    def head_etag(self, key: str) -> Optional[str]:
+        from azure.core.exceptions import ResourceNotFoundError
+        try:
+            return self.cc.get_blob_client(self._n(key)).get_blob_properties().etag
+        except ResourceNotFoundError:
+            return None
+
+    def replace_if_match(self, key: str, data: bytes, etag: str) -> Optional[str]:
+        from azure.core import MatchConditions
+        from azure.core.exceptions import ResourceModifiedError, ResourceNotFoundError
+        try:
+            r = self.cc.upload_blob(self._n(key), data, overwrite=True,
+                                    etag=etag, match_condition=MatchConditions.IfNotModified)
+            return r.get("etag")  # returned by the upload; no extra round-trip
+        except (ResourceModifiedError, ResourceNotFoundError):
+            return None  # etag mismatch or target gone — CAS did not match
+
+    def delete_prefix(self, prefix: str = "") -> None:
+        # trailing "/" bounds the match to this object (not sibling "foobar/...");
+        # empty scope (both empty) = the whole container.
+        stripped = f"{self.prefix}/{prefix}".strip("/")
+        p = stripped + "/" if stripped else ""
+        for b in self.cc.list_blobs(name_starts_with=p):
+            self.cc.delete_blob(b.name)

--- a/chdb/durable/backends/gcs.py
+++ b/chdb/durable/backends/gcs.py
@@ -1,0 +1,84 @@
+"""Native GCS backend. Lease primitive = generation-match conditional write
+(`if_generation_match=0` to create), GCS's own single-writer primitive."""
+from __future__ import annotations
+
+from typing import Optional
+
+from ..errors import MissingDependency
+
+
+class GCSBackend:
+    def __init__(self, bucket: str, prefix: str, *, token: Optional[str] = None, project=None):
+        try:
+            from google.cloud import storage
+        except ImportError as e:
+            raise MissingDependency(
+                "gcs backend needs google-cloud-storage: pip install 'chdb[durable-gcs]'") from e
+        self.prefix = prefix.strip("/")
+        if token:
+            # Explicit bare token: for constrained envs (e.g. a metadata-server
+            # access token). NOTE: it cannot refresh — it stops working once the
+            # short-lived token expires. Prefer leaving token unset to use
+            # Application Default Credentials, which refresh automatically.
+            from google.oauth2.credentials import Credentials
+            client = storage.Client(project=project, credentials=Credentials(token=token))
+        else:
+            client = storage.Client(project=project)  # ADC (auto-refreshing)
+        self.bucket = client.bucket(bucket)
+
+    def _b(self, key: str):
+        return self.bucket.blob(f"{self.prefix}/{key}" if self.prefix else key)
+
+    def get(self, key: str) -> Optional[bytes]:
+        return self.get_with_etag(key)[0]
+
+    def get_with_etag(self, key: str):
+        from google.cloud.exceptions import NotFound
+        b = self._b(key)
+        try:
+            data = b.download_as_bytes()  # populates b.generation
+        except NotFound:
+            return (None, None)
+        gen = b.generation
+        if gen is None:
+            b.reload()
+            gen = b.generation
+        return (data, str(gen))
+
+    def put(self, key: str, data: bytes) -> None:
+        self._b(key).upload_from_string(data)
+
+    def put_if_absent(self, key: str, data: bytes) -> Optional[str]:
+        from google.api_core.exceptions import PreconditionFailed
+        b = self._b(key)
+        try:
+            b.upload_from_string(data, if_generation_match=0)
+            return str(b.generation)  # generation of the object we just created
+        except PreconditionFailed:
+            return None
+
+    def head_etag(self, key: str) -> Optional[str]:
+        from google.cloud.exceptions import NotFound
+        b = self._b(key)
+        try:
+            b.reload()
+        except NotFound:
+            return None
+        return str(b.generation)
+
+    def replace_if_match(self, key: str, data: bytes, etag: str) -> Optional[str]:
+        from google.api_core.exceptions import PreconditionFailed
+        b = self._b(key)
+        try:
+            b.upload_from_string(data, if_generation_match=int(etag))
+            return str(b.generation)  # updated by the upload; no extra round-trip
+        except PreconditionFailed:
+            return None
+
+    def delete_prefix(self, prefix: str = "") -> None:
+        # trailing "/" bounds the match to this object (not sibling "foobar/...");
+        # empty scope (both empty) = the whole bucket.
+        stripped = f"{self.prefix}/{prefix}".strip("/")
+        p = stripped + "/" if stripped else ""
+        for blob in self.bucket.list_blobs(prefix=p):
+            blob.delete()

--- a/chdb/durable/backends/local.py
+++ b/chdb/durable/backends/local.py
@@ -1,0 +1,103 @@
+"""Local filesystem backend — the most vendor-neutral home of all: a folder.
+
+**Scope: development, tests, and single-writer/single-host use.** The strong
+concurrency guarantees a Durable Analytical Object relies on — atomic
+conditional writes for the lease/head CAS — belong to the object-store
+backends (S3 `IfMatch`/`IfNoneMatch`, GCS generation-match, Azure ETag), which
+provide them natively. This backend approximates them on a POSIX filesystem
+(`O_CREAT|O_EXCL` for create, `flock` for compare-and-set, path containment in
+`_p`) as a best effort so tests are realistic, but it is not intended for
+multi-host or production concurrent access. Point `durable:` at a cloud (or
+S3-compatible) backend for that.
+"""
+from __future__ import annotations
+
+import os
+import shutil
+from typing import Optional
+
+
+class LocalFSBackend:
+    def __init__(self, root: str):
+        self.root = os.path.abspath(root)
+
+    def _p(self, key: str) -> str:
+        # Constrain every key under root: an absolute key or ".." would
+        # otherwise let put/delete_prefix write or rm outside the backend.
+        full = os.path.realpath(os.path.join(self.root, key))
+        root = os.path.realpath(self.root)
+        if full != root and not full.startswith(root + os.sep):
+            raise ValueError(f"key escapes backend root: {key!r}")
+        return full
+
+    def get(self, key: str) -> Optional[bytes]:
+        try:
+            with open(self._p(key), "rb") as f:
+                return f.read()
+        except FileNotFoundError:
+            return None
+
+    def get_with_etag(self, key: str):
+        # Read body and etag from the SAME file descriptor so they describe the
+        # same version — a separate stat could pair an old body with a new etag
+        # if the file is replaced between the two calls.
+        try:
+            fd = os.open(self._p(key), os.O_RDONLY)
+        except FileNotFoundError:
+            return (None, None)
+        try:
+            st = os.fstat(fd)
+            f = os.fdopen(fd, "rb")
+            fd = -1  # fdopen owns the descriptor now
+            with f:
+                data = f.read()
+        except BaseException:
+            if fd >= 0:  # only close if fdopen never took ownership
+                os.close(fd)
+            raise
+        return (data, f"{st.st_mtime_ns}-{st.st_size}")
+
+    def put(self, key: str, data: bytes) -> None:
+        p = self._p(key)
+        os.makedirs(os.path.dirname(p), exist_ok=True)
+        tmp = f"{p}.tmp"
+        with open(tmp, "wb") as f:
+            f.write(data)
+        os.replace(tmp, p)  # atomic
+
+    def put_if_absent(self, key: str, data: bytes) -> Optional[str]:
+        p = self._p(key)
+        os.makedirs(os.path.dirname(p), exist_ok=True)
+        try:
+            fd = os.open(p, os.O_CREAT | os.O_EXCL | os.O_WRONLY)
+        except FileExistsError:
+            return None
+        with os.fdopen(fd, "wb") as f:
+            f.write(data)
+            f.flush()
+            st = os.fstat(f.fileno())  # etag of exactly what we created
+        return f"{st.st_mtime_ns}-{st.st_size}"
+
+    def head_etag(self, key: str) -> Optional[str]:
+        try:
+            st = os.stat(self._p(key))
+        except FileNotFoundError:
+            return None
+        return f"{st.st_mtime_ns}-{st.st_size}"
+
+    def replace_if_match(self, key: str, data: bytes, etag: str) -> Optional[str]:
+        import fcntl
+        # serialize check-then-act across processes so two writers can't both
+        # observe the same etag and both write (which would defeat the CAS).
+        lockpath = self._p(key) + ".lock"
+        os.makedirs(os.path.dirname(lockpath), exist_ok=True)
+        with open(lockpath, "w") as lf:
+            fcntl.flock(lf, fcntl.LOCK_EX)
+            if self.head_etag(key) != etag:
+                return None
+            self.put(key, data)
+            return self.head_etag(key)
+
+    def delete_prefix(self, prefix: str = "") -> None:
+        target = self._p(prefix) if prefix else self.root
+        shutil.rmtree(target, ignore_errors=True)

--- a/chdb/durable/backends/s3.py
+++ b/chdb/durable/backends/s3.py
@@ -1,0 +1,94 @@
+"""S3-compatible backend: AWS S3, MinIO, Cloudflare R2, Backblaze, Tigris,
+and GCS via its S3-interoperability endpoint — one code path, `endpoint_url`
+picks the provider. Lease primitive = conditional PUT (`IfNoneMatch` / `IfMatch`)."""
+from __future__ import annotations
+
+from typing import Optional
+
+from ..errors import MissingDependency
+
+
+class S3Backend:
+    def __init__(self, bucket: str, prefix: str, *, endpoint_url=None,
+                 access_key=None, secret_key=None, region="us-east-1"):
+        try:
+            import boto3
+        except ImportError as e:
+            raise MissingDependency("s3 backend needs boto3: pip install 'chdb[durable]'") from e
+        self.bucket = bucket
+        self.prefix = prefix.strip("/")
+        self.s3 = boto3.client(
+            "s3", endpoint_url=endpoint_url, region_name=region,
+            aws_access_key_id=access_key, aws_secret_access_key=secret_key,
+        )
+
+    def _k(self, key: str) -> str:
+        return f"{self.prefix}/{key}" if self.prefix else key
+
+    def get(self, key: str) -> Optional[bytes]:
+        return self.get_with_etag(key)[0]
+
+    def get_with_etag(self, key: str):
+        import botocore
+        try:
+            r = self.s3.get_object(Bucket=self.bucket, Key=self._k(key))
+            return (r["Body"].read(), r["ETag"])  # bytes + etag in one round-trip
+        except botocore.exceptions.ClientError as e:
+            if e.response["Error"]["Code"] in ("NoSuchKey", "404", "NoSuchBucket"):
+                return (None, None)
+            raise
+
+    def put(self, key: str, data: bytes) -> None:
+        self.s3.put_object(Bucket=self.bucket, Key=self._k(key), Body=data)
+
+    def put_if_absent(self, key: str, data: bytes) -> Optional[str]:
+        import botocore
+        try:
+            r = self.s3.put_object(Bucket=self.bucket, Key=self._k(key), Body=data,
+                                   IfNoneMatch="*")
+            return r["ETag"]  # etag of the object we just created
+        except botocore.exceptions.ClientError as e:
+            if e.response["Error"]["Code"] in ("PreconditionFailed", "412"):
+                return None
+            raise
+
+    def head_etag(self, key: str) -> Optional[str]:
+        import botocore
+        try:
+            return self.s3.head_object(Bucket=self.bucket, Key=self._k(key))["ETag"]
+        except botocore.exceptions.ClientError as e:
+            # only "absent" maps to None — transient errors (throttling, 5xx,
+            # access denied) must propagate, not masquerade as a missing key.
+            if e.response["Error"]["Code"] in ("404", "NoSuchKey", "NoSuchBucket"):
+                return None
+            raise
+
+    def replace_if_match(self, key: str, data: bytes, etag: str) -> Optional[str]:
+        import botocore
+        try:
+            r = self.s3.put_object(Bucket=self.bucket, Key=self._k(key), Body=data,
+                                   IfMatch=etag)
+            return r["ETag"]
+        except botocore.exceptions.ClientError as e:
+            # precondition failed, or the target is gone (deleted) — either way
+            # the compare-and-set did not match.
+            if e.response["Error"]["Code"] in ("PreconditionFailed", "412",
+                                               "NoSuchKey", "404"):
+                return None
+            raise
+
+    def delete_prefix(self, prefix: str = "") -> None:
+        # trailing "/" bounds the match to this object — without it, destroying
+        # "foo" would also delete sibling keys under "foobar/...". An empty
+        # scope (prefix and self.prefix both empty) means the whole bucket.
+        stripped = self._k(prefix).strip("/")
+        p = stripped + "/" if stripped else ""
+        paginator = self.s3.get_paginator("list_objects_v2")
+        for page in paginator.paginate(Bucket=self.bucket, Prefix=p):
+            objs = [{"Key": o["Key"]} for o in page.get("Contents", [])]
+            if objs:
+                resp = self.s3.delete_objects(Bucket=self.bucket, Delete={"Objects": objs})
+                errs = resp.get("Errors") or []
+                if errs:  # S3 reports per-key failures here even on a 200
+                    raise RuntimeError(
+                        f"delete_prefix: {len(errs)} object(s) not deleted, e.g. {errs[0]}")

--- a/chdb/durable/errors.py
+++ b/chdb/durable/errors.py
@@ -1,0 +1,14 @@
+"""Exceptions for chdb.durable."""
+from __future__ import annotations
+
+
+class DurableError(RuntimeError):
+    """Base class for all chdb.durable errors."""
+
+
+class LeaseError(DurableError):
+    """The single-writer lease could not be acquired or was lost."""
+
+
+class MissingDependency(DurableError):
+    """A backend extra (boto3 / google-cloud-storage / azure-storage-blob) is not installed."""

--- a/chdb/durable/namespace.py
+++ b/chdb/durable/namespace.py
@@ -1,0 +1,61 @@
+"""Namespace — addressable objects on one backend, and cross-object query.
+
+`ns.open(id)` mints (or reopens) the object at `<base>/<id>`. `ns.scan()`
+runs the same read-only query across many objects and unions the rows.
+It restores each object in turn (cost is O(number of objects)); it suits
+small fan-outs, not large cross-object analytics.
+"""
+from __future__ import annotations
+
+import json
+import time
+from typing import Iterable, List, Tuple
+
+from .backends import make_backend
+from .errors import LeaseError
+from .object import validate_oid
+from .object import DurableObject
+
+
+class Namespace:
+    def __init__(self, url: str, *, owner: str = None, db: str = "mem"):
+        self.url = url
+        self.owner = owner
+        self.db = db
+
+    def open(self, oid: str, *, read_only: bool = False,
+             force: bool = False) -> DurableObject:
+        backend = make_backend(self.url, oid)
+        obj = DurableObject(oid, backend, owner=self.owner, db=self.db,
+                            read_only=read_only)
+        try:
+            obj.open(force=force)  # force=True: crash-recovery takeover (fence-safe)
+        except BaseException:
+            obj.close()  # reclaim the temp dir if open() failed (e.g. lease held)
+            raise
+        return obj
+
+    def destroy(self, oid: str, *, force: bool = False) -> None:
+        validate_oid(oid)  # a hierarchical/empty id would delete unrelated objects
+        backend = make_backend(self.url, oid)
+        if not force:
+            # refuse to delete out from under a live writer — that would lose
+            # its head/checkpoints/WAL and fail its next commit.
+            raw = backend.get("head.json")
+            if raw:
+                lease = json.loads(raw).get("lease", {})
+                if lease.get("owner") and lease.get("expires_at", 0) >= time.time():
+                    raise LeaseError(
+                        f"{oid!r} has an active lease; pass force=True to destroy anyway")
+        backend.delete_prefix("")
+
+    def scan(self, sql: str, ids: Iterable[str], fmt: str = "CSV") -> List[Tuple[str, str]]:
+        """Run `sql` read-only against each object; return [(id, result)]."""
+        out: List[Tuple[str, str]] = []
+        for oid in ids:
+            obj = self.open(oid, read_only=True)
+            try:
+                out.append((oid, obj.query(sql, fmt).data()))
+            finally:
+                obj.close()
+        return out

--- a/chdb/durable/object.py
+++ b/chdb/durable/object.py
@@ -1,0 +1,373 @@
+"""The Durable Analytical Object.
+
+An addressable chDB engine whose authoritative state lives in object storage:
+a base checkpoint (a chDB File backup) plus WAL segments. The lease and the
+manifest live in a *single* `head.json` object so the cold path is few
+round-trips, which is what dominates in-region open latency:
+
+  open (warm) = 1 read (head, with etag) + [ take-lease PUT ‖ base GET ]
+              + restore + 1 re-assert PUT (confirm the lease survived restore)
+
+The lease is the head's `lease` field; taking it is a conditional replace on
+the head's etag, which *is* the generation fence — a superseded writer's next
+commit fails the compare-and-set. Local MergeTree is the hot working copy;
+the object is a portable folder of open-format files.
+"""
+from __future__ import annotations
+
+import concurrent.futures
+import json
+import math
+import os
+import re
+import shutil
+import tempfile
+import time
+import uuid
+from typing import List, Optional
+from xml.sax.saxutils import escape as _xml_escape
+
+from chdb import session as chs
+
+from .backends import Backend
+from .errors import LeaseError
+
+_HEAD = "head.json"
+
+
+def validate_oid(oid: str) -> str:
+    """Object ids must be flat, non-overlapping keys — no path separators, no
+    empty/`.`/`..`. This prevents one id's prefix from containing another's
+    (e.g. destroying "tenant" wiping "tenant/user")."""
+    if not oid or "/" in oid or "\\" in oid or oid in (".", ".."):
+        raise ValueError(f"invalid object id {oid!r}: must be non-empty with no '/' or '\\'")
+    return oid
+
+
+class DurableObject:
+    def __init__(self, oid: str, backend: Backend, *, owner: Optional[str] = None,
+                 db: str = "mem", read_only: bool = False, lease_ttl: float = 60.0):
+        validate_oid(oid)
+        if not (lease_ttl > 0) or not math.isfinite(lease_ttl):
+            # 0/negative/NaN/inf would set expires_at in the past (or never),
+            # breaking single-writer exclusion.
+            raise ValueError("lease_ttl must be a positive, finite number of seconds")
+        self.oid = oid
+        self.backend = backend
+        self.owner = owner or uuid.uuid4().hex[:8]
+        self.db = db
+        self.read_only = read_only
+        self.ttl = lease_ttl
+        # sanitize the id for the temp-dir prefix — a "/" (e.g. "tenant/user")
+        # would make mkdtemp reference a nonexistent subdir and fail.
+        _safe = re.sub(r"[^A-Za-z0-9._-]", "_", oid)[:64] or "obj"
+        self._work = tempfile.mkdtemp(prefix=f"dao-{_safe}-")
+        self._bkp = os.path.join(self._work, "backup")
+        os.makedirs(self._bkp, exist_ok=True)
+        self._cfg = os.path.join(self._work, "conf.xml")
+        with open(self._cfg, "w") as f:
+            # XML-escape the path — a TMPDIR containing & or < would otherwise
+            # produce malformed config and fail session startup.
+            f.write(f"<clickhouse><backups><allowed_path>{_xml_escape(self._bkp)}"
+                    f"</allowed_path></backups></clickhouse>")
+        self.session: Optional[chs.Session] = None
+        # manifest fields live inside head.json
+        self.base: Optional[str] = None
+        self.wal: List[str] = []
+        self.seq = 0
+        self.generation = 0
+        self._head_etag: Optional[str] = None
+        self._buf: List[str] = []  # unflushed write statements
+        self._lease_expires = 0.0  # our local view of the lease deadline
+        self._instance = uuid.uuid4().hex  # this live instance (owner string may repeat)
+
+    def _now(self) -> float:
+        return time.time()
+
+    def _head_body(self, now: float) -> bytes:
+        return json.dumps({
+            "lease": {"owner": self.owner, "instance": self._instance,
+                      "generation": self.generation, "expires_at": now + self.ttl},
+            "manifest": {"db": self.db, "base": self.base,
+                         "wal": self.wal, "seq": self.seq},
+        }).encode()
+
+    def _write_head(self) -> None:
+        """Commit the head via compare-and-set on our etag. The CAS *is* the
+        fence: if a newer writer took the lease, our etag is stale and this
+        raises instead of clobbering their state."""
+        now = self._now()
+        new_etag = self.backend.replace_if_match(_HEAD, self._head_body(now), self._head_etag)
+        if new_etag is None:
+            raise LeaseError(f"fenced: object {self.oid} was taken by another writer")
+        self._head_etag = new_etag
+        # same instant as the persisted expires_at (not now+RTT), so renewal
+        # isn't scheduled past the real deadline.
+        self._lease_expires = now + self.ttl
+
+    def _start_session(self) -> None:
+        self.session = chs.Session(f"{self._work}?config-file={self._cfg}")
+
+    # -- lifecycle --------------------------------------------------------
+    def open(self, force: bool = False) -> bool:
+        # Read the head first — no chDB session yet, so a held object raises
+        # LeaseError before we hit chDB's one-session-per-process limit.
+        data, etag = self.backend.get_with_etag(_HEAD)
+
+        if data is None:                       # cold: object does not exist yet
+            if not self.read_only:
+                self.generation = 1
+                now = self._now()
+                etag = self.backend.put_if_absent(_HEAD, self._head_body(now))
+                if not etag:
+                    raise LeaseError("object created concurrently by another writer")
+                # adopt the etag from the create itself — a separate head_etag()
+                # could race a concurrent open(force=True) and pick up its etag.
+                self._head_etag = etag
+                self._lease_expires = now + self.ttl
+            try:
+                self._start_session()
+                self.session.query(f"CREATE DATABASE IF NOT EXISTS {self.db}")
+            except Exception:
+                self._abort_open()
+                raise
+            return False
+
+        head = json.loads(data)
+        m = head["manifest"]
+        # honor the persisted database name — the object owns it. Keeping a
+        # caller-supplied self.db would rewrite the manifest and make _restore
+        # build the wrong database (WAL replay then fails).
+        self.db = m.get("db", self.db)
+        self.base, self.wal, self.seq = m.get("base"), list(m.get("wal", [])), m.get("seq", 0)
+
+        if self.read_only:
+            base_blob = self.backend.get(self.base) if self.base else None
+            try:
+                self._start_session()
+                self._restore(base_blob)
+            except Exception:
+                self._abort_open()  # free the chDB session on a failed restore
+                raise
+            return True
+
+        lease = head.get("lease", {})
+        owner, exp = lease.get("owner", ""), lease.get("expires_at", 0)
+        inst = lease.get("instance", "")
+        # Held iff a *different live instance* still owns it. An unexpired lease
+        # blocks even the same owner string — it may be another live instance,
+        # so same-owner is NOT a free pass (that would fence the live holder and,
+        # via chDB's one-session limit, abort to owner="" and let a third writer
+        # in). Only released (owner=""), expired, or our own instance is free.
+        # force=True is the crash-recovery takeover: skip the held check and
+        # take the lease anyway. It's safe because the head CAS fences the old
+        # holder — its next commit fails — so we don't need to wait out the TTL.
+        if not force and owner != "" and exp >= self._now() and inst != self._instance:
+            raise LeaseError(
+                f"object held by {owner!r}/{inst[:8]} (gen {lease.get('generation')})")
+        self.generation = lease.get("generation", 0) + 1
+
+        # overlap the lease-take (CAS PUT) with the base download — independent
+        # once we know the base key, so wall-clock ≈ one round-trip not two.
+        now = self._now()
+        with concurrent.futures.ThreadPoolExecutor(max_workers=2) as ex:
+            f_lease = ex.submit(self.backend.replace_if_match, _HEAD, self._head_body(now), etag)
+            f_base = ex.submit(self.backend.get, self.base) if self.base else None
+            new_etag = f_lease.result()
+            base_blob = f_base.result() if f_base else None
+        if new_etag is None:
+            raise LeaseError("lease taken by another writer during open")
+        self._head_etag = new_etag
+        self._lease_expires = now + self.ttl
+        try:
+            self._start_session()
+            self._restore(base_blob)
+            # A slow restore can outlast lease_ttl; re-assert the lease so we
+            # never return a writable session whose lease already expired and
+            # was taken by another writer. The CAS fails if we were superseded.
+            self._write_head()
+        except Exception:
+            self._abort_open()  # release the just-taken lease so we don't block others
+            raise
+        return True
+
+    def _abort_open(self) -> None:
+        """A failure after the lease was taken must not strand it until TTL:
+        release it via CAS (owner="") and drop the partial session."""
+        if not self.read_only and self._head_etag is not None:
+            saved = self.owner
+            try:
+                self.owner = ""  # serialize an empty owner into the release write only
+                self._write_head()
+            except Exception:
+                pass
+            finally:
+                self.owner = saved  # don't leave the instance owner-less for a retry
+            self._head_etag = None  # released here; close() must not release again
+        if self.session is not None:
+            try:
+                self.session.close()
+            except Exception:
+                pass
+            self.session = None
+
+    def _restore(self, base_blob: Optional[bytes]) -> None:
+        if self.base and base_blob is None:
+            # the manifest references a base checkpoint but it's gone from
+            # storage — fail loudly rather than silently opening empty and
+            # replacing committed state (same policy as missing WAL segments).
+            raise RuntimeError(f"missing base checkpoint {self.base} — durable state incomplete")
+        if base_blob is not None:
+            local = os.path.join(self._bkp, "base.tar.gz")
+            with open(local, "wb") as f:
+                f.write(base_blob)
+            self.session.query(f"RESTORE DATABASE {self.db} FROM File('{local}')", "CSV")
+        else:
+            self.session.query(f"CREATE DATABASE IF NOT EXISTS {self.db}")
+        from .wal import replay
+        for seg_key in self.wal:
+            seg = self.backend.get(seg_key)
+            if seg is None:
+                # every WAL key was committed in the head manifest — a missing
+                # object means incomplete/corrupt state; fail loudly, don't
+                # silently open with committed writes omitted.
+                raise RuntimeError(f"missing WAL segment {seg_key} — durable state incomplete")
+            replay(seg, lambda sql: self.session.query(sql, "CSV"))
+
+    # -- read / write -----------------------------------------------------
+    def query(self, sql: str, fmt: str = "CSV"):
+        return self.session.query(sql, fmt)
+
+    def execute(self, sql: str) -> None:
+        if self.read_only:
+            raise RuntimeError("object opened read-only")
+        self.session.query(sql, "CSV")
+        self._buf.append(sql)
+        # Renew the lease before it lapses so a long-lived writer isn't fenced by
+        # another writer while still active. No extra round-trip until near expiry.
+        if self._now() >= self._lease_expires - self.ttl * 0.25:
+            self._write_head()
+
+    # -- durability -------------------------------------------------------
+    def _reconcile_committed(self, *, base=None, wal_key=None) -> bool:
+        """After an ambiguous `_write_head` failure (the CAS response may have
+        been lost), re-read the head. Because our keys are unique, if the head
+        now references our key then the CAS *did* commit — adopt its etag and
+        treat the write as durable, instead of rolling back (which would make a
+        retry double-publish the same boundary)."""
+        data, etag = self.backend.get_with_etag(_HEAD)
+        if data is None:
+            return False
+        head = json.loads(data)
+        m = head.get("manifest", {})
+        lease = head.get("lease", {})
+        key_ok = (base is not None and m.get("base") == base) or \
+                 (wal_key is not None and wal_key in (m.get("wal") or []))
+        # A retained key proves our write is durable — but we must ALSO still
+        # own the lease. If another writer took over (kept the key), adopting
+        # their etag would let us CAS over them and defeat the fence.
+        owns = (lease.get("instance") == self._instance
+                and lease.get("generation") == self.generation)
+        if key_ok and owns:
+            self._head_etag = etag
+            self._buf = []
+            return True
+        return False
+
+    def flush(self) -> Optional[str]:
+        """Cut a WAL segment and commit the head (RPO boundary). One PUT for the
+        segment + one CAS for the head."""
+        if self.read_only or not self._buf:
+            return None
+        from .wal import WalBuffer
+        wb = WalBuffer()
+        for s in self._buf:
+            wb.append(s)
+        new_seq = self.seq + 1
+        # unique suffix so a retry after an ambiguous head CAS (committed but
+        # the response was lost) never overwrites an already-published segment.
+        key = f"wal/{self.generation}-{new_seq}-{uuid.uuid4().hex[:8]}.jsonl"
+        self.backend.put(key, wb.serialize())
+        # Adopt the new manifest state only if the head CAS succeeds; on failure
+        # roll back (keeping _buf) so a retry publishes a fresh unique segment.
+        # The uploaded-but-unreferenced segment is left as an orphan — see the
+        # GC TODO on checkpoint().
+        prev_seq, prev_wal = self.seq, list(self.wal)
+        self.seq, self.wal = new_seq, prev_wal + [key]
+        try:
+            self._write_head()
+        except Exception:
+            if self._reconcile_committed(wal_key=key):
+                return key  # CAS actually landed; the response was lost
+            self.seq, self.wal = prev_seq, prev_wal
+            raise
+        self._buf = []
+        return key
+
+    def checkpoint(self) -> str:
+        """Fold base + WAL into a fresh base; truncate the WAL. One PUT for the
+        base + one CAS for the head.
+
+        Checkpoints are *full* snapshots. Incremental checkpoints (ClickHouse
+        `base_backup`) are planned once native BACKUP-to-S3 ships in a chdb
+        release (chdb-core #133/#134), to cut cost for larger objects.
+
+        TODO(gc): no garbage collection yet. A superseded base checkpoint, the
+        folded WAL segments, and orphan segments/checkpoints left by failed or
+        ambiguous flushes all remain in object storage indefinitely — only the
+        current base + live WAL are referenced by the head. A future
+        compaction/GC pass should delete blobs the head no longer references
+        (guarded so an in-flight reader of an older head isn't cut off).
+        """
+        if self.read_only:
+            raise RuntimeError("object opened read-only")
+        new_seq = self.seq + 1
+        stamp = uuid.uuid4().hex[:8]  # unique key: retry after an ambiguous CAS won't overwrite
+        local = os.path.join(self._bkp, f"ckpt-{self.generation}-{new_seq}-{stamp}.tar.gz")
+        if os.path.exists(local):
+            os.remove(local)
+        self.session.query(f"BACKUP DATABASE {self.db} TO File('{local}')", "CSV")
+        with open(local, "rb") as f:
+            data = f.read()
+        key = f"checkpoints/{self.generation}-{new_seq}-{stamp}.tar.gz"
+        self.backend.put(key, data)
+        # Adopt the new base only after the head CAS succeeds (roll back on failure).
+        prev = (self.seq, self.base, list(self.wal))
+        self.seq, self.base, self.wal = new_seq, key, []
+        try:
+            self._write_head()
+        except Exception:
+            if self._reconcile_committed(base=key):
+                self._buf = []
+                return key  # CAS actually landed; the response was lost
+            self.seq, self.base, self.wal = prev
+            raise
+        self._buf = []
+        return key
+
+    def suspend(self) -> None:
+        self.flush()
+
+    def close(self) -> None:
+        try:
+            if self.read_only:
+                return
+            if self.session is not None:
+                # If we've been fenced, flush() raises — let it propagate so the
+                # caller learns their buffered writes were NOT persisted rather
+                # than close() returning normally and silently dropping them.
+                # (The session + temp dir are still reclaimed by the finally.)
+                self.flush()
+            # release the lease (owner="") via CAS so a next writer takes it cleanly
+            if self._head_etag is not None:
+                self.owner = ""
+                try:
+                    self._write_head()
+                except LeaseError:
+                    pass
+        finally:
+            if self.session is not None:
+                self.session.close()
+                self.session = None
+            # reclaim the per-instance temp dir (config + local backup scratch)
+            shutil.rmtree(self._work, ignore_errors=True)

--- a/chdb/durable/wal.py
+++ b/chdb/durable/wal.py
@@ -1,0 +1,63 @@
+"""Write-ahead log — the incremental tier between full checkpoints.
+
+Each write statement is appended to a buffer; `flush()` writes the buffered
+statements as one segment and records it in the manifest, so RPO ≈ the flush
+interval instead of the (larger) checkpoint interval. On open, the base
+checkpoint is restored, then every WAL segment is replayed in order.
+
+V1 is statement-based: each segment is newline-delimited JSON of the write SQL,
+and `open()` replays those statements to reconstruct state since the base.
+
+**Correct usage — write only deterministic statements between checkpoints.**
+Because recovery *re-executes* the logged SQL, a statement must produce the same
+result on replay as it did originally:
+
+  - DO log inserts/updates of *literal* values, e.g.
+    `INSERT INTO mem.beliefs VALUES ('k', 'v', '2026-01-01 00:00:00')`.
+  - DON'T log statements whose result depends on evaluation time or randomness —
+    `now()`, `today()`, `rand()`, `generateUUIDv4()`, `INSERT ... SELECT` from a
+    volatile/streaming source, or anything reading external mutable state. On
+    replay these yield *different* rows than were originally committed.
+  - If you need a timestamp/id, compute it in the caller and log the literal.
+  - Non-deterministic or bulk transformations belong in a `checkpoint()` (which
+    snapshots actual state), not in WAL statements.
+
+A future V2 may store row data as Parquet segments (so replay is data, not
+re-execution, and `ns.scan()` can read segments via `s3()` without restoring),
+which would remove this determinism requirement.
+"""
+from __future__ import annotations
+
+import json
+from typing import List
+
+
+class WalBuffer:
+    """Accumulates write statements until flushed to a segment."""
+
+    def __init__(self):
+        self._stmts: List[str] = []
+
+    def append(self, sql: str) -> None:
+        self._stmts.append(sql)
+
+    def __len__(self) -> int:
+        return len(self._stmts)
+
+    def serialize(self) -> bytes:
+        return b"".join(json.dumps({"sql": s}).encode() + b"\n" for s in self._stmts)
+
+    def clear(self) -> None:
+        self._stmts = []
+
+
+def replay(segment: bytes, run) -> int:
+    """Replay one segment's statements via `run(sql)`. Returns count."""
+    n = 0
+    for line in segment.splitlines():
+        line = line.strip()
+        if not line:
+            continue
+        run(json.loads(line)["sql"])
+        n += 1
+    return n

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,6 +40,14 @@ publish = ["twine", "wheel"]
 # (`clickhouse_connect.get_client(backend="chdb")`). clickhouse-connect 1.0+ needs Python 3.10+.
 clickhouse-connect = ["clickhouse-connect>=1.3.0"]
 
+# chdb.durable — Durable Analytical Object: an addressable, single-writer engine
+# whose state lives in object storage you own. The S3-compatible backend
+# (AWS/MinIO/R2, and GCS via its S3 interop endpoint) needs boto3; the native
+# GCS and Azure Blob backends are separate opt-in extras.
+durable = ["boto3>=1.36"]  # IfMatch/IfNoneMatch conditional writes on PutObject
+durable-gcs = ["google-cloud-storage"]
+durable-azure = ["azure-storage-blob"]
+
 # chDB registers itself with clickhouse-connect through these entry points. clickhouse-connect
 # discovers them at runtime; it never imports chdb directly.
 [project.entry-points."clickhouse_connect.backends"]
@@ -60,7 +68,7 @@ requires = [
 build-backend = "setuptools.build_meta"
 
 [tool.setuptools.packages.find]
-include = ["datastore*", "chdb", "chdb.agents"]
+include = ["datastore*", "chdb", "chdb.agents", "chdb.durable", "chdb.durable.backends"]
 namespaces = true
 
 [tool.setuptools.exclude-package-data]

--- a/tests/test_durable.py
+++ b/tests/test_durable.py
@@ -1,0 +1,401 @@
+"""chdb.durable V1 tests — runnable as a plain script.
+
+    DAO_TEST_URL=local:/tmp/dao-test python tests/test_durable.py
+    DAO_TEST_URL=s3://dao/ns CHDB_DURABLE_S3_ENDPOINT=http://127.0.0.1:9000 \
+        AWS_ACCESS_KEY_ID=minioadmin AWS_SECRET_ACCESS_KEY=minioadmin \
+        python tests/test_durable.py
+"""
+import os
+import tempfile
+import time
+
+import json
+
+from chdb import durable as cd
+from chdb.durable.backends import make_backend
+from chdb.durable.errors import LeaseError
+
+URL = os.getenv("DAO_TEST_URL", "local:" + tempfile.mkdtemp(prefix="dao-test-"))
+
+
+def _fresh_ns():
+    ns = cd.Namespace(URL, owner="w1")
+    for oid in ("obj-a", "obj-b", "obj-f"):
+        ns.destroy(oid)
+    return ns
+
+
+def test_checkpoint_roundtrip(ns):
+    o = ns.open("obj-a")
+    assert o.query("SELECT 1", "CSV")  # engine live
+    o.execute("CREATE TABLE mem.t (n Int64) ENGINE=MergeTree ORDER BY n")
+    o.execute("INSERT INTO mem.t SELECT number FROM numbers(1000)")
+    o.checkpoint()
+    o.close()
+
+    r = ns.open("obj-a")
+    got = r.query("SELECT count() FROM mem.t", "CSV").data().strip()
+    r.close()
+    assert got == "1000", f"checkpoint restore: {got}"
+    print("  checkpoint round-trip: 1000 rows restored from base ✓")
+
+
+def test_wal_incremental(ns):
+    # append after checkpoint, flush only (no new checkpoint) -> survives via WAL
+    o = ns.open("obj-a")
+    o.execute("INSERT INTO mem.t SELECT number FROM numbers(1000, 500)")  # +500
+    seg = o.flush()
+    assert seg and seg.startswith("wal/"), seg
+    o.close()
+
+    r = ns.open("obj-a")
+    got = r.query("SELECT count() FROM mem.t", "CSV").data().strip()
+    r.close()
+    assert got == "1500", f"WAL replay: {got}"
+    print("  WAL incremental: 1500 rows (base 1000 + WAL 500 replayed) ✓")
+
+
+def test_checkpoint_folds_wal(ns):
+    o = ns.open("obj-a")
+    key = o.checkpoint()  # fold base+WAL into a new base
+    assert o.base == key and o.wal == []
+    o.close()
+    r = ns.open("obj-a")
+    got = r.query("SELECT count() FROM mem.t", "CSV").data().strip()
+    r.close()
+    assert got == "1500", got
+    print("  checkpoint folds WAL: base=1500, wal=[] ✓")
+
+
+def test_lease_exclusion(ns):
+    o = ns.open("obj-b")
+    o.execute("CREATE TABLE mem.t (n Int64) ENGINE=MergeTree ORDER BY n")
+    other = cd.Namespace(URL, owner="w2")  # a *different* writer
+    try:
+        other.open("obj-b")  # must be refused before any second session opens
+        raise AssertionError("second writer should have raised LeaseError")
+    except LeaseError:
+        pass
+    o.close()
+    print("  lease exclusion: different writer refused ✓")
+
+
+def test_fencing(ns):
+    o = ns.open("obj-f")
+    o.execute("CREATE TABLE mem.t (n Int64) ENGINE=MergeTree ORDER BY n")
+    # an external writer takes over: overwrite head at a higher generation,
+    # invalidating o's cached etag
+    b = make_backend(ns.url, "obj-f")
+    data, etag = b.get_with_etag("head.json")
+    h = json.loads(data)
+    h["lease"] = {"owner": "w2", "generation": h["lease"]["generation"] + 5,
+                  "expires_at": 9e12}
+    assert b.replace_if_match("head.json", json.dumps(h).encode(), etag) is not None
+    try:
+        o.flush()  # o's commit must fail the compare-and-set
+        raise AssertionError("o should be fenced after takeover")
+    except LeaseError:
+        pass
+    # close() must also surface the fence (buffered writes can't be persisted)
+    # rather than swallow it and return normally.
+    try:
+        o.close()
+        raise AssertionError("close() should raise when fenced with buffered writes")
+    except LeaseError:
+        pass
+    print("  fencing: superseded writer's commit rejected via head CAS ✓")
+
+
+def test_scan(ns):
+    for oid, k in (("obj-a", 1500), ("obj-b", 0)):
+        pass
+    # obj-a has 1500; give obj-b a table with 7 rows
+    o = ns.open("obj-b")
+    o.execute("INSERT INTO mem.t SELECT number FROM numbers(7)")
+    o.checkpoint()
+    o.close()
+    rows = dict(ns.scan("SELECT count() FROM mem.t", ids=["obj-a", "obj-b"]))
+    a = rows["obj-a"].strip()
+    b = rows["obj-b"].strip()
+    assert a == "1500" and b == "7", (a, b)
+    print(f"  ns.scan across objects: obj-a={a}, obj-b={b} ✓")
+
+
+def test_local_path_traversal():
+    # a caller-controlled object id must not escape the backend root
+    for bad in ("../escape", "../../etc", "/abs/escape", "a/../../escape"):
+        try:
+            make_backend("local:" + tempfile.mkdtemp(prefix="dao-root-"), bad)
+            raise AssertionError(f"expected rejection for id {bad!r}")
+        except ValueError:
+            pass
+    # a symlink id pointing outside the root must also be rejected (realpath)
+    root = tempfile.mkdtemp(prefix="dao-root-")
+    outside = tempfile.mkdtemp(prefix="dao-outside-")
+    os.symlink(outside, os.path.join(root, "link"))
+    try:
+        make_backend("local:" + root, "link")
+        raise AssertionError("symlink escaping root should be rejected")
+    except ValueError:
+        pass
+    # a normal id is fine
+    make_backend("local:" + tempfile.mkdtemp(prefix="dao-root-"), "user-123")
+    print("  local path traversal: escaping object ids (incl. symlink) rejected ✓")
+
+
+def test_sibling_isolation(ns):
+    # destroy("foo") must not delete a sibling object whose id shares the prefix
+    for oid in ("foo", "foobar"):
+        ns.destroy(oid)
+    for oid, k in (("foobar", 3), ("foo", 7)):
+        o = ns.open(oid)
+        o.execute("CREATE TABLE mem.t (n Int64) ENGINE=MergeTree ORDER BY n")
+        o.execute(f"INSERT INTO mem.t SELECT number FROM numbers({k})")
+        o.checkpoint()
+        o.close()
+    ns.destroy("foo")
+    r = ns.open("foobar", read_only=True)
+    got = r.query("SELECT count() FROM mem.t", "CSV").data().strip()
+    r.close()
+    assert got == "3", f"sibling clobbered: {got}"
+    print("  sibling isolation: destroy('foo') left 'foobar' intact ✓")
+
+
+def test_object_id_rejects_slash(ns):
+    # ids must be flat keys — no '/', empty, '.', '..', '\\' (else a short id's
+    # prefix could contain another id's, and destroy would delete both)
+    for bad in ("team/u1", "", "..", "a\\b"):
+        try:
+            ns.open(bad)
+            raise AssertionError(f"object id {bad!r} should be rejected")
+        except ValueError:
+            pass
+    print("  object id validation: rejects '/', empty, '..', '\\\\' ✓")
+
+
+def test_missing_reference_errors(ns):
+    # a head referencing a base/WAL blob that's missing from storage must fail
+    # loudly, not silently open with committed state omitted
+    ns.destroy("obj-mb")
+    b = make_backend(ns.url, "obj-mb")
+    b.put_if_absent("head.json", json.dumps({
+        "lease": {"owner": "", "generation": 1, "expires_at": 0},
+        "manifest": {"db": "mem", "base": "checkpoints/nope.tar.gz", "wal": [], "seq": 1},
+    }).encode())
+    try:
+        ns.open("obj-mb")
+        raise AssertionError("expected RuntimeError for missing base")
+    except RuntimeError as e:
+        assert "missing base" in str(e), str(e)
+
+    ns.destroy("obj-mb2")
+    b2 = make_backend(ns.url, "obj-mb2")
+    b2.put_if_absent("head.json", json.dumps({
+        "lease": {"owner": "", "generation": 1, "expires_at": 0},
+        "manifest": {"db": "mem", "base": None, "wal": ["wal/nope.jsonl"], "seq": 1},
+    }).encode())
+    try:
+        ns.open("obj-mb2")
+        raise AssertionError("expected RuntimeError for missing WAL segment")
+    except RuntimeError as e:
+        assert "missing WAL" in str(e), str(e)
+    print("  missing base/WAL reference: fails loudly ✓")
+
+
+def test_wal_keys_unique(ns):
+    # unique segment keys so a retry can't overwrite an already-published segment
+    ns.destroy("obj-uk")
+    o = ns.open("obj-uk")
+    o.execute("CREATE TABLE mem.t (n Int64) ENGINE=MergeTree ORDER BY n")
+    o.execute("INSERT INTO mem.t VALUES (1)")
+    k1 = o.flush()
+    o.execute("INSERT INTO mem.t VALUES (2)")
+    k2 = o.flush()
+    o.close()
+    assert k1 and k2 and k1 != k2, (k1, k2)
+    print("  WAL keys unique across flushes ✓")
+
+
+def test_lease_renewal(ns):
+    # a long-lived writer renews its lease before expiry (not fenced while active)
+    ns.destroy("obj-lr")
+    b = make_backend(ns.url, "obj-lr")
+    o = cd.DurableObject("obj-lr", b, owner="w1", db="mem", lease_ttl=0.4)
+    o.open()
+    o.execute("CREATE TABLE mem.t (n Int64) ENGINE=MergeTree ORDER BY n")
+    exp1 = json.loads(b.get("head.json"))["lease"]["expires_at"]
+    time.sleep(0.35)  # cross the renew threshold (ttl*0.75 = 0.3s before expiry)
+    o.execute("INSERT INTO mem.t VALUES (1)")  # should renew the lease
+    exp2 = json.loads(b.get("head.json"))["lease"]["expires_at"]
+    o.close()
+    assert exp2 > exp1, (exp1, exp2)
+    print("  lease renewal: expires_at advanced on execute near expiry ✓")
+
+
+def test_lease_ttl_validation():
+    b = make_backend("local:" + tempfile.mkdtemp(prefix="dao-ttl-"))
+    for bad in (0, -1, float("inf"), float("nan")):
+        try:
+            cd.DurableObject("x", b, lease_ttl=bad)
+            raise AssertionError(f"lease_ttl {bad} should be rejected")
+        except ValueError:
+            pass
+    print("  lease_ttl validation: rejects 0 / negative / inf / nan ✓")
+
+
+def test_readonly_restore_failure_frees_session(ns):
+    # a failed read-only restore must free the chDB session (one-per-process),
+    # so a subsequent open isn't blocked
+    ns.destroy("obj-ro")
+    b = make_backend(ns.url, "obj-ro")
+    b.put_if_absent("head.json", json.dumps({
+        "lease": {"owner": "", "instance": "", "generation": 1, "expires_at": 0},
+        "manifest": {"db": "mem", "base": "checkpoints/nope.tar.gz", "wal": [], "seq": 1},
+    }).encode())
+    o = cd.DurableObject("obj-ro", b, read_only=True, db="mem")
+    try:
+        o.open()
+        raise AssertionError("expected RuntimeError for missing base")
+    except RuntimeError:
+        pass
+    o2 = ns.open("obj-ro2")  # would fail with chDB one-session error if not freed
+    o2.query("SELECT 1")
+    o2.close()
+    print("  read-only restore failure frees the session ✓")
+
+
+def test_same_owner_second_instance_blocked(ns):
+    # a second *live* instance with the same owner string must still be refused
+    # (identity is per-instance, not per-owner) — else it would fence the first
+    ns.destroy("obj-so")
+    o = ns.open("obj-so")  # instance A, owner w1
+    o.execute("CREATE TABLE mem.t (n Int64) ENGINE=MergeTree ORDER BY n")
+    b = make_backend(ns.url, "obj-so")
+    o2 = cd.DurableObject("obj-so", b, owner=ns.owner, db="mem")  # same owner, instance B
+    try:
+        o2.open()
+        raise AssertionError("second same-owner live instance should be refused")
+    except LeaseError:
+        pass
+    o.close()
+    print("  same-owner second live instance refused ✓")
+
+
+def test_put_if_absent_returns_etag(ns):
+    # cold-create adopts this etag directly (no racy second fetch)
+    ns.destroy("obj-pia")
+    b = make_backend(ns.url, "obj-pia")
+    e = b.put_if_absent("head.json", b'{"x":1}')
+    assert e, "put_if_absent should return an etag on create"
+    assert b.put_if_absent("head.json", b'{"x":2}') is None, "should return None if it exists"
+    print("  put_if_absent returns etag on create / None if exists ✓")
+
+
+def test_reconcile_detects_committed(ns):
+    # ambiguous CAS: if the head already references our unique key, reconcile
+    # must report "committed" (so a lost-response retry doesn't double-publish)
+    ns.destroy("obj-rec")
+    o = ns.open("obj-rec")
+    o.execute("CREATE TABLE mem.t (n Int64) ENGINE=MergeTree ORDER BY n")
+    o.execute("INSERT INTO mem.t VALUES (1)")
+    k = o.flush()
+    assert o._reconcile_committed(wal_key=k) is True
+    assert o._reconcile_committed(wal_key="wal/nonexistent.jsonl") is False
+    ck = o.checkpoint()
+    assert o._reconcile_committed(base=ck) is True
+    # ownership check: if another writer took over (kept our key), reconcile
+    # must NOT adopt — a retained key proves durability, not ownership
+    b = make_backend(ns.url, "obj-rec")
+    h = json.loads(b.get("head.json"))
+    h["lease"]["instance"] = "other-instance"
+    b.put("head.json", json.dumps(h).encode())
+    assert o._reconcile_committed(base=ck) is False
+    o.close()
+    print("  reconcile detects committed key + still-owned; rejects after takeover ✓")
+
+
+def test_destroy_refuses_active_lease(ns):
+    ns.destroy("obj-de")
+    o = ns.open("obj-de")  # holds an active lease
+    o.execute("CREATE TABLE mem.t (n Int64) ENGINE=MergeTree ORDER BY n")
+    o.flush()
+    try:
+        ns.destroy("obj-de")
+        raise AssertionError("destroy should refuse an actively-leased object")
+    except LeaseError:
+        pass
+    ns.destroy("obj-de", force=True)  # force overrides
+    try:
+        o.close()  # fenced (head gone); tolerate
+    except LeaseError:
+        pass
+    print("  destroy refuses an active lease (force overrides) ✓")
+
+
+def test_force_take(ns):
+    # crash recovery: a new writer force-takes an unexpired foreign lease
+    # (held by a now-dead instance) without waiting out the TTL
+    ns.destroy("obj-ft")
+    o = ns.open("obj-ft")
+    o.execute("CREATE TABLE mem.t (n Int64) ENGINE=MergeTree ORDER BY n")
+    o.execute("INSERT INTO mem.t VALUES (9)")
+    o.checkpoint()
+    o.close()
+    b = make_backend(ns.url, "obj-ft")
+    head = json.loads(b.get("head.json"))  # forge a live-looking foreign lease
+    head["lease"] = {"owner": "w1", "instance": "dead-instance",
+                     "generation": head["lease"]["generation"] + 1, "expires_at": 9e12}
+    b.put("head.json", json.dumps(head).encode())
+    try:
+        ns.open("obj-ft")  # normal open must be blocked by the unexpired lease
+        raise AssertionError("held lease should block a normal open")
+    except LeaseError:
+        pass
+    r = ns.open("obj-ft", force=True)  # force-take + restore
+    got = r.query("SELECT n FROM mem.t", "CSV").data().strip()
+    r.close()
+    assert got == "9", got
+    print("  force-take: bypasses an unexpired foreign lease (crash recovery) ✓")
+
+
+def test_reopen_honors_persisted_db(ns):
+    # the object owns its database name; reopening with a different db arg must
+    # not rewrite it (otherwise restore builds the wrong database)
+    ns.destroy("obj-db")
+    o = ns.open("obj-db")  # ns default db = "mem"
+    o.execute("CREATE TABLE mem.t (n Int64) ENGINE=MergeTree ORDER BY n")
+    o.execute("INSERT INTO mem.t VALUES (5)")
+    o.checkpoint()
+    o.close()
+    ns2 = cd.Namespace(ns.url, owner="w1", db="other")  # different db arg
+    r = ns2.open("obj-db", read_only=True)
+    got = r.query("SELECT n FROM mem.t", "CSV").data().strip()  # persisted "mem" wins
+    r.close()
+    assert got == "5", got
+    print("  reopen honors persisted manifest db ✓")
+
+
+if __name__ == "__main__":
+    print(f"backend URL: {URL}")
+    ns = _fresh_ns()
+    test_checkpoint_roundtrip(ns)
+    test_wal_incremental(ns)
+    test_checkpoint_folds_wal(ns)
+    test_lease_exclusion(ns)
+    test_fencing(ns)
+    test_scan(ns)
+    test_local_path_traversal()
+    test_sibling_isolation(ns)
+    test_object_id_rejects_slash(ns)
+    test_missing_reference_errors(ns)
+    test_wal_keys_unique(ns)
+    test_lease_renewal(ns)
+    test_same_owner_second_instance_blocked(ns)
+    test_put_if_absent_returns_etag(ns)
+    test_reconcile_detects_committed(ns)
+    test_destroy_refuses_active_lease(ns)
+    test_force_take(ns)
+    test_reopen_honors_persisted_db(ns)
+    test_lease_ttl_validation()
+    test_readonly_restore_failure_frees_session(ns)
+    print("ALL PASS")


### PR DESCRIPTION
## What
Adds `chdb.durable` — the **Durable Analytical Object** primitive — as a subpackage, mirroring the `chdb.agents` layout. Pure Python, no engine change.

## Why
An addressable, single-writer chDB engine whose authoritative state lives in **object storage you own** (S3 / GCS / Azure Blob / any S3-compatible / a local folder). It gives chDB a portable durable-state tier: laptop → cloud, and across clouds — the on-disk format is a chDB File backup + WAL segments under a JSON manifest, i.e. a folder you can move.

## API
```python
from chdb import durable as cd
ns  = cd.Namespace("s3://bucket/prefix", owner="worker-1")
obj = ns.open("user-123")            # lease + restore (base + WAL replay)
obj.execute("INSERT INTO mem.beliefs VALUES (...)")
obj.flush()                          # cut a WAL segment (RPO boundary)
obj.checkpoint()                     # fold into a fresh base
obj.close()                          # flush + release the lease
ns.scan("SELECT count() FROM mem.beliefs", ids=["user-1", "user-2"])
```

## Design
- **Addressable / single-writer** — a lease built on the backend's conditional write; generation fencing collapsed into one head-object compare-and-set.
- **Durable** — base checkpoint (`BACKUP ... TO File`) + WAL segments, restored on open; writes flushed for RPO≈0.
- **Portable** — open-format files in a prefix; a storage-backend abstraction with S3 / GCS / Azure Blob / local drivers behind one seam. Cloud SDKs are opt-in extras: `chdb[durable]` (boto3, covers S3/MinIO/R2/GCS-interop), `chdb[durable-gcs]`, `chdb[durable-azure]`.
- **Federation** — `ns.scan()` runs one read-only query across many objects.

Layout mirrors `chdb.agents`: `chdb/durable/` subpackage + `tests/test_durable.py` + optional-deps extras + `packages.find` include.

## Testing
6 tests pass on local FS and MinIO (checkpoint round-trip, WAL incremental replay, checkpoint-folds-WAL, single-writer lease exclusion across owners, fencing after takeover, ns.scan). Cold-open measured in-region on AWS/Azure/GCP (~0.5–0.85s for 1M rows).

Native `BACKUP ... TO S3` is intentionally avoided in favor of `BACKUP ... TO File` + client-side upload — more vendor-neutral, and it also sidesteps the embedded-mode BackupsIOThreadPool issue (chdb-core #133, fixed by #134).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add `chdb.durable` subpackage for single-writer durable analytical objects
> - Introduces `chdb.durable` with a `DurableObject` class that wraps a chDB session with crash-safe WAL, checkpointing, and lease enforcement via compare-and-set on a `head.json` manifest.
> - Adds pluggable backends ([`local.py`](https://github.com/chdb-io/chdb/pull/616/files#diff-c1f24a4ce38f2d0132016868217fc8ed3a61b241cc28cba8628665925a72ec59), [`s3.py`](https://github.com/chdb-io/chdb/pull/616/files#diff-befb61ca693a34759da2255837010aff65ab1c06f56dddcd7cc0510f82b75db3), [`gcs.py`](https://github.com/chdb-io/chdb/pull/616/files#diff-3bb458e5675a433006cdcc86438672364a1ebb5579ae1654d7897355287cf8a8), [`azure.py`](https://github.com/chdb-io/chdb/pull/616/files#diff-05f563c9fe2d337ee5538aa2f345ce15b982820bc51159cbce7b39d64d7235cd)) selected by URL scheme via `make_backend`; each implements conditional put/replace for single-writer safety.
> - Adds a `Namespace` class for opening, destroying, and batch-scanning durable objects with lease-safety checks.
> - Adds optional extras (`durable`, `durable-gcs`, `durable-azure`) in [`pyproject.toml`](https://github.com/chdb-io/chdb/pull/616/files#diff-50c86b7ed8ac2cf95bd48334961bf0530cdc77b5a56f852c5c61b89d735fd711); backend packages raise `MissingDependency` if extras are not installed.
> - Risk: CAS-based lease fencing and WAL reconciliation are best-effort on local filesystem; strong single-writer guarantees require a cloud backend with atomic conditional operations.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized f259e75.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->