### PR TITLE
perf(datastore): memoize metadata probes/counts and generalize .size/empty

### DIFF
--- a/datastore/core.py
+++ b/datastore/core.py
@@ -418,6 +418,8 @@ class DataStore(PandasCompatMixin):
         self._cache_version: int = 0  # Incremented when operations are added
         self._cached_at_version: int = -1  # Version when cache was created
         self._cache_timestamp: Optional[float] = None  # For TTL support
+        # Memoized metadata probes/counts, keyed by _cache_version (see _meta_memo)
+        self._metadata_memo: Dict[Any, Any] = {}
 
         # Computed columns tracking for chained assign support
         # Maps column alias -> original Expression (before any aliasing)
@@ -584,6 +586,8 @@ class DataStore(PandasCompatMixin):
         self._cache_version: int = 0
         self._cached_at_version: int = -1
         self._cache_timestamp: Optional[float] = None
+        # Memoized metadata probes/counts, keyed by _cache_version (see _meta_memo)
+        self._metadata_memo: Dict[Any, Any] = {}
 
         # Computed columns tracking for chained assign support
         self._computed_columns: Dict[str, Expression] = {}
@@ -1315,6 +1319,10 @@ class DataStore(PandasCompatMixin):
                 if is_cache_enabled():
                     self._cached_result = df
                     self._cache_timestamp = time.time()
+                    # The plan just materialized (and _cache_version resets to 0
+                    # below); drop probe/count memos so no pre-execution entry can
+                    # be re-read. Post-execution metadata comes from _cached_result.
+                    self._metadata_memo = {}
 
                     # Checkpoint if we executed any Pandas operations or multiple SQL segments
                     # This enables incremental execution for future operations
@@ -4291,6 +4299,22 @@ class DataStore(PandasCompatMixin):
         count_base._offset_value = None
         return count_base.to_sql()
 
+    def _meta_memo(self) -> dict:
+        """Per-pipeline memo for metadata probes/counts, keyed by _cache_version.
+
+        Entries are pure functions of the pipeline definition, so they stay valid
+        until an operation is added (which bumps _cache_version) and are dropped by
+        __copy__ so a derived pipeline never inherits its parent's answers. This
+        lets repeated and cross-accessor metadata reads on the same lazy frame --
+        .shape (count + columns), then .dtypes / len() / .index / .size / .empty --
+        reuse one schema probe and one COUNT(*) instead of re-querying the engine.
+        """
+        memo = self.__dict__.get("_metadata_memo")
+        if memo is None:
+            memo = {}
+            self.__dict__["_metadata_memo"] = memo
+        return memo
+
     def _probe_schema(self, limit: int = 0) -> pd.DataFrame:
         """Return a (near-)empty DataFrame with the pipeline's columns and dtypes.
 
@@ -4303,12 +4327,26 @@ class DataStore(PandasCompatMixin):
         needs to materialize string columns as their real pandas dtype -- an
         empty (LIMIT 0) result degrades string columns to ``object`` -- so the
         ``.dtypes`` path uses ``limit=1``.
+
+        The result is memoized per _cache_version. A probe that transferred >=1 row
+        carries both correct column names and reliable dtypes, so it also satisfies
+        any lower-limit (columns-only) request -- e.g. a prior ``.dtypes`` probe
+        serves a later ``.columns`` with no extra query.
         """
+        memo = self._meta_memo()
+        ver = self._cache_version
+        cached = memo.get("probe")
+        if cached is not None and cached[0] == ver and cached[1] >= limit:
+            return cached[2]
         if self._executor is None:
             self.connect()
         subquery_sql = self.to_sql()
         probe_sql = f"SELECT * FROM ({subquery_sql}) LIMIT {int(limit)}"
-        return self._executor.execute(probe_sql).to_df()
+        df = self._executor.execute(probe_sql).to_df()
+        # Keep the probe with the most rows -- it subsumes smaller-limit requests.
+        if cached is None or cached[0] != ver or limit >= cached[1]:
+            memo["probe"] = (ver, limit, df)
+        return df
 
     def count(self):
         """
@@ -4485,6 +4523,11 @@ class DataStore(PandasCompatMixin):
             This is more efficient than len() for large datasets as it uses SQL COUNT(*)
             instead of executing the entire DataFrame.
         """
+        memo = self._meta_memo()
+        memo_key = ("count", self._cache_version)
+        if memo_key in memo:
+            return memo[memo_key]
+
         if not self._can_sql_pushdown():
             self._logger.debug(
                 "count_rows() falling back to execution due to non-SQL operations"
@@ -4549,9 +4592,9 @@ class DataStore(PandasCompatMixin):
                     "count_rows() executing flat SQL: %s", count_sql
                 )
                 result = self._executor.execute(count_sql)
-                if result.rows:
-                    return int(result.rows[0][0])
-                return 0
+                total = int(result.rows[0][0]) if result.rows else 0
+                memo[memo_key] = total
+                return total
 
         # Complex case (GROUP BY / HAVING / DISTINCT / JOINs / computed columns):
         # Remote sources cannot use nested subqueries (hangs in chDB),
@@ -4568,9 +4611,9 @@ class DataStore(PandasCompatMixin):
         self._logger.debug("count_rows() executing SQL: %s", count_sql)
         result = self._executor.execute(count_sql)
 
-        if result.rows:
-            return int(result.rows[0][0])
-        return 0
+        total = int(result.rows[0][0]) if result.rows else 0
+        memo[memo_key] = total
+        return total
 
     def info(
         self, verbose=None, buf=None, max_cols=None, memory_usage=None, show_counts=None
@@ -8891,6 +8934,12 @@ class DataStore(PandasCompatMixin):
         new_ds._update_fields = self._update_fields.copy()
         new_ds._format_settings = self._format_settings.copy()
         new_ds._lazy_ops = self._lazy_ops.copy()  # Copy lazy operations
+
+        # Metadata memo (probe/count) is keyed by _cache_version and is a pure
+        # function of THIS pipeline; a derived pipeline must start empty rather
+        # than share/inherit the parent's answers (two children of a common
+        # ancestor can otherwise collide on the same version key).
+        new_ds._metadata_memo = {}
 
         # Copy operation history
         if hasattr(self, "_operation_history"):

--- a/datastore/core.py
+++ b/datastore/core.py
@@ -1122,9 +1122,14 @@ class DataStore(PandasCompatMixin):
         """
         Invalidate the cached result.
 
-        Called when new operations are added to the pipeline.
+        Called when new operations are added to the pipeline (and by data/schema
+        mutations such as insert()/create_table()). Also drops the metadata memo:
+        bumping _cache_version already makes existing probe/count entries
+        unreachable, and clearing keeps the dict from accumulating dead entries
+        across repeated mutations.
         """
         self._cache_version += 1
+        self._metadata_memo = {}
         self._logger.debug("Cache invalidated: version now %d", self._cache_version)
 
     def clear_cache(self):
@@ -4795,6 +4800,10 @@ class DataStore(PandasCompatMixin):
         self._executor.execute(sql)
         self._schema = schema
 
+        # The table's shape just changed under any cached metadata; invalidate so
+        # count_rows()/columns/shape re-query rather than reuse a pre-create memo.
+        self._invalidate_cache()
+
         return self
 
     def insert(
@@ -4853,6 +4862,8 @@ class DataStore(PandasCompatMixin):
             # Add LazyDataFrameSource so count_rows() knows to use execution
             self._lazy_ops = [LazyDataFrameSource(df)]
             self._computed_columns = set()
+            # Schema changed (a column was added) -- drop stale metadata probes.
+            self._metadata_memo = {}
             # Handle duplicate column names - use iloc for unique column access
             self._schema = {}
             for i, col in enumerate(df.columns):
@@ -4893,6 +4904,10 @@ class DataStore(PandasCompatMixin):
         sql = f"INSERT INTO {format_identifier(self.table_name, self.quote_char)} ({columns_sql}) VALUES {values_sql}"
 
         self._executor.execute(sql)
+
+        # Row count (and any materialized result) is now stale -- drop cached
+        # metadata so a subsequent count_rows()/shape/len re-queries the engine.
+        self._invalidate_cache()
 
         return self
 

--- a/datastore/pandas_compat.py
+++ b/datastore/pandas_compat.py
@@ -558,7 +558,11 @@ class PandasCompatMixin:
         src = self._get_source_df_if_pristine()
         if src is not None:
             return src.size
-        if self._is_pristine_sql_source():
+        # Any SQL-pushdownable pipeline: rows via COUNT(*), columns via .columns
+        # (both self-correcting -- count_rows() executes on LIMIT/OFFSET, .columns
+        # executes on column-altering ops). Mirrors .shape and subsumes the
+        # pristine SQL source case, avoiding full materialization for filters etc.
+        if self._can_sql_pushdown() and self._cached_result is None:
             return self.count_rows() * len(self.columns)
         return self._get_df().size
 
@@ -568,7 +572,10 @@ class PandasCompatMixin:
         src = self._get_source_df_if_pristine()
         if src is not None:
             return len(src) == 0
-        if self._is_pristine_sql_source():
+        # Any SQL-pushdownable pipeline: emptiness from COUNT(*) (self-correcting;
+        # count_rows() falls back to execution for LIMIT/OFFSET). Mirrors .shape
+        # and subsumes the pristine SQL source case.
+        if self._can_sql_pushdown() and self._cached_result is None:
             return self.count_rows() == 0
         return self._get_df().empty
 

--- a/datastore/tests/test_lazy_metadata_pushdown.py
+++ b/datastore/tests/test_lazy_metadata_pushdown.py
@@ -113,7 +113,118 @@ class TestNonPristinePushdownMetadata:
         _ = ds2.dtypes
         _ = ds2.shape
         _ = ds2.index
+        _ = ds2.size
+        _ = ds2.empty
         assert ds2._cached_result is None, "metadata access must not materialize the result"
+
+    def test_size_uses_count_not_execute(self, filtered):
+        ds2, pd_result = filtered
+        with patch.object(ds2, "count_rows", wraps=ds2.count_rows) as mock_count, \
+                patch.object(ds2, "_execute", wraps=ds2._execute) as mock_exec:
+            size = ds2.size
+            mock_count.assert_called()
+            mock_exec.assert_not_called()
+        assert size == pd_result.size
+
+    def test_empty_uses_count_not_execute(self, filtered):
+        ds2, pd_result = filtered
+        with patch.object(ds2, "count_rows", wraps=ds2.count_rows) as mock_count, \
+                patch.object(ds2, "_execute", wraps=ds2._execute) as mock_exec:
+            empty = ds2.empty
+            mock_count.assert_called()
+            mock_exec.assert_not_called()
+        assert empty == pd_result.empty
+
+
+class TestMetadataMemoization:
+    """Repeated and cross-accessor metadata reads on the SAME lazy frame reuse a
+    single schema probe and a single COUNT(*) instead of re-querying the engine.
+
+    The memo is keyed by ``_cache_version`` and is a pure function of the pipeline
+    definition, so a derived frame (new ``__copy__``) starts empty and never
+    inherits its parent's answers, and adding an op invalidates it. Guards the
+    step-3 (memoize via ``_cache_version``) optimization.
+    """
+
+    @pytest.fixture
+    def filtered(self, tmp_path):
+        path, _ = _make_parquet(tmp_path)
+        ds = DataStore.from_file(path)
+        return ds[ds["value"] > 0]        # pushdownable filter -> non-pristine
+
+    def _capture(self, ds):
+        ds.connect()
+        sqls = []
+        original = ds._executor.execute
+        cap = patch.object(
+            ds._executor, "execute",
+            side_effect=lambda s, *a, **k: (sqls.append(s), original(s, *a, **k))[1],
+        )
+        return sqls, cap
+
+    def test_repeated_columns_probe_once(self, filtered):
+        ds = filtered
+        sqls, cap = self._capture(ds)
+        with cap:
+            first = list(ds.columns)
+            _ = ds.columns
+            _ = ds.columns
+        assert sum("LIMIT 0" in s for s in sqls) == 1, sqls
+        assert first == list(ds.columns)
+
+    def test_repeated_count_counts_once(self, filtered):
+        ds = filtered
+        sqls, cap = self._capture(ds)
+        with cap:
+            a = ds.count_rows()
+            b = ds.count_rows()
+            c = len(ds.index)              # .index resolves from the same COUNT
+        assert a == b == c
+        assert sum("count()" in s.lower() for s in sqls) == 1, sqls
+
+    def test_dtypes_probe_serves_later_columns(self, filtered):
+        # A LIMIT 1 (.dtypes) probe carries correct column NAMES too, so a later
+        # .columns needs no additional probe -- and never a LIMIT 0 one.
+        ds = filtered
+        sqls, cap = self._capture(ds)
+        with cap:
+            _ = ds.dtypes
+            cols = list(ds.columns)
+        assert sum("LIMIT 1" in s for s in sqls) == 1, sqls
+        assert not any("LIMIT 0" in s for s in sqls), sqls
+        assert cols == ["id", "value", "category"]
+
+    def test_full_metadata_sweep_collapses_queries(self, filtered):
+        # The common "inspect everything" pattern -- shape + columns + dtypes +
+        # len + index + size + empty -- collapses (regardless of access count) to
+        # ONE columns probe (LIMIT 0, shared by shape/columns/size), ONE dtypes
+        # probe (LIMIT 1, which then also serves later columns reads), and ONE
+        # COUNT(*) (shared by len/index/size/empty). Without the memo each accessor
+        # would re-hit the engine. (dtype-reliability countIf checks are neither a
+        # LIMIT probe nor a count() and don't affect these tallies.)
+        ds = filtered
+        sqls, cap = self._capture(ds)
+        with cap:
+            _ = ds.shape
+            _ = ds.columns
+            _ = ds.dtypes
+            _ = len(ds)
+            _ = ds.index
+            _ = ds.size
+            _ = ds.empty
+        assert sum("LIMIT 0" in s for s in sqls) == 1, sqls
+        assert sum("LIMIT 1" in s for s in sqls) == 1, sqls
+        assert sum("count()" in s.lower() for s in sqls) == 1, sqls
+
+    def test_derived_frame_gets_fresh_memo(self, filtered):
+        ds = filtered
+        n = ds.count_rows()
+        assert ("count", ds._cache_version) in ds._metadata_memo
+        ds2 = ds[ds["id"] >= 0]            # derive -> __copy__ -> fresh memo
+        assert ds2._metadata_memo == {}, "derived frame must not inherit parent's memo"
+        # original is unchanged and keeps its memoized answer
+        assert ("count", ds._cache_version) in ds._metadata_memo
+        assert ds.count_rows() == n
 
 
 class TestProjectionColumnsCorrectness:

--- a/datastore/tests/test_lazy_metadata_pushdown.py
+++ b/datastore/tests/test_lazy_metadata_pushdown.py
@@ -227,6 +227,43 @@ class TestMetadataMemoization:
         assert ds.count_rows() == n
 
 
+class TestMemoInvalidatedByMutation:
+    """count_rows()/shape/len memoize by _cache_version, so a data/schema
+    mutation on the SAME table-backed store (insert row-mode, create_table) must
+    invalidate the memo -- otherwise a re-count returns the pre-mutation value.
+    Regression guard: without _invalidate_cache() in insert(), count after insert
+    was stale (returned the memoized count)."""
+
+    def _table(self, name):
+        ds = DataStore(table=name)
+        ds.connect()
+        ds.create_table({"id": "UInt64", "foo": "String"}, drop_if_exists=True)
+        return ds
+
+    def test_count_reflects_row_insert_after_memoized_count(self):
+        ds = self._table("memo_insert_count")
+        try:
+            ds.insert([{"id": 1, "foo": "a"}, {"id": 2, "foo": "b"}])
+            assert ds.count_rows() == 2          # memoized
+            ds.insert([{"id": 3, "foo": "c"}])
+            assert ds.count_rows() == 3          # must re-query, not return stale 2
+            assert len(ds) == 3
+            assert ds.shape == (3, 2)
+            ds.insert([{"id": 4, "foo": "d"}, {"id": 5, "foo": "e"}])
+            assert ds.count_rows() == 5
+        finally:
+            ds.close()
+
+    def test_empty_reflects_insert(self):
+        ds = self._table("memo_insert_empty")
+        try:
+            assert ds.empty is True              # memoized empty
+            ds.insert([{"id": 1, "foo": "a"}])
+            assert ds.empty is False             # must re-query
+        finally:
+            ds.close()
+
+
 class TestProjectionColumnsCorrectness:
     """A column-reducing projection is NOT reflected in the LIMIT 0 probe SQL
     (it's a post-SQL lazy op), so the probe's columns differ from the projected


### PR DESCRIPTION
## Summary

Metadata reads on a lazy DataStore (.shape/.columns/.dtypes/len/.index/.size/.empty) now reuse a single schema probe and a single COUNT(*) per pipeline instead of re-querying the engine for each accessor, and .size/.empty no longer fully materialize for pushdownable pipelines (e.g. a filter). Same results, fewer/cheaper queries.

## Type of change

- [x] New feature
- [ ] Bug fix
- [ ] Refactor (no behavior change)
- [ ] Tests only
- [ ] Documentation only
- [ ] CI / build infrastructure
- [ ] Tooling / dependencies / housekeeping

## Linked issues

Fixes #590 

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Memoize `DataStore` metadata probes and counts, and push down `.size`/`.empty` via `count_rows`
> - Adds a `_metadata_memo` dict (keyed by `_cache_version`) to `DataStore` in [datastore/core.py](https://github.com/chdb-io/chdb/pull/617/files#diff-057aeafb37341a54da7b512f8cfd9c247833139e9bdb4f7022dd7d82e90fbc04) to cache schema probes and `COUNT(*)` results, avoiding repeated queries for `.columns`, `.dtypes`, `len`, `.shape`, `.size`, and `.empty`.
> - A LIMIT 1 probe (used by `.dtypes`) is reused to satisfy later LIMIT 0 (`.columns`) requests; a single COUNT query is shared across `count_rows()`, `len()`, `.size`, and `.empty` within the same pipeline version.
> - `.size` and `.empty` in [datastore/pandas_compat.py](https://github.com/chdb-io/chdb/pull/617/files#diff-9845c9fab6c8868000c586df009fb342cb663c720fa5f936e8a67880ca4f1780) now use `count_rows()` pushdown instead of materializing results via `_execute()`.
> - `_invalidate_cache()` and mutation paths (`insert`, `create_table`) clear the memo so subsequent metadata reflects the updated state.
> - Derived pipelines (copy/fork) start with a fresh empty memo rather than inheriting the parent's cached metadata.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 0f01767.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->