### PR TITLE
Replay WAL in the object's database context

### DIFF
--- a/chdb/durable/object.py
+++ b/chdb/durable/object.py
@@ -44,6 +44,14 @@ def validate_oid(oid: str) -> str:
     return oid
 
 
+def _quote_ident(name: str) -> str:
+    """Backtick-quote a ClickHouse identifier so a database name with `-` (or
+    any character needing quoting) is valid in DDL/USE, and can't break out of
+    the statement. Not imported from clickhouse_connect to keep this package
+    free of that dependency."""
+    return "`" + name.replace("\\", "\\\\").replace("`", "\\`") + "`"
+
+
 class DurableObject:
     def __init__(self, oid: str, backend: Backend, *, owner: Optional[str] = None,
                  db: str = "mem", read_only: bool = False, lease_ttl: float = 60.0):
@@ -127,7 +135,7 @@ class DurableObject:
                 self._lease_expires = now + self.ttl
             try:
                 self._start_session()
-                self.session.query(f"CREATE DATABASE IF NOT EXISTS {self.db}")
+                self.session.query(f"CREATE DATABASE IF NOT EXISTS {_quote_ident(self.db)}")
             except Exception:
                 self._abort_open()
                 raise
@@ -221,9 +229,15 @@ class DurableObject:
             local = os.path.join(self._bkp, "base.tar.gz")
             with open(local, "wb") as f:
                 f.write(base_blob)
-            self.session.query(f"RESTORE DATABASE {self.db} FROM File('{local}')", "CSV")
+            self.session.query(f"RESTORE DATABASE {_quote_ident(self.db)} FROM File('{local}')", "CSV")
         else:
-            self.session.query(f"CREATE DATABASE IF NOT EXISTS {self.db}")
+            self.session.query(f"CREATE DATABASE IF NOT EXISTS {_quote_ident(self.db)}")
+        # Replay in the object's database context: WAL statements were executed
+        # against a session whose current database the caller had set, and the
+        # manifest's db is that context (the object owns it). Without this,
+        # unqualified statements silently replay into `default` — invisible to
+        # the caller and dropped by the next `BACKUP DATABASE {db}` checkpoint.
+        self.session.query(f"USE {_quote_ident(self.db)}", "CSV")
         from .wal import replay
         for seg_key in self.wal:
             seg = self.backend.get(seg_key)
@@ -326,7 +340,7 @@ class DurableObject:
         local = os.path.join(self._bkp, f"ckpt-{self.generation}-{new_seq}-{stamp}.tar.gz")
         if os.path.exists(local):
             os.remove(local)
-        self.session.query(f"BACKUP DATABASE {self.db} TO File('{local}')", "CSV")
+        self.session.query(f"BACKUP DATABASE {_quote_ident(self.db)} TO File('{local}')", "CSV")
         with open(local, "rb") as f:
             data = f.read()
         key = f"checkpoints/{self.generation}-{new_seq}-{stamp}.tar.gz"

--- a/chdb/durable/wal.py
+++ b/chdb/durable/wal.py
@@ -21,6 +21,9 @@ result on replay as it did originally:
   - If you need a timestamp/id, compute it in the caller and log the literal.
   - Non-deterministic or bulk transformations belong in a `checkpoint()` (which
     snapshots actual state), not in WAL statements.
+  - Unqualified table names replay with the object's database (the manifest's
+    `db`) as the current database. Statements touching any *other* database
+    must qualify it explicitly.
 
 A future V2 may store row data as Parquet segments (so replay is data, not
 re-execution, and `ns.scan()` can read segments via `s3()` without restoring),

--- a/tests/test_durable.py
+++ b/tests/test_durable.py
@@ -375,9 +375,50 @@ def test_reopen_honors_persisted_db(ns):
     print("  reopen honors persisted manifest db ✓")
 
 
+def test_wal_replay_unqualified_db_context(ns):
+    # WAL statements written against the object's current database (set via
+    # `USE`) use unqualified table names; replay must restore that database as
+    # current, or the statements land in `default` and are lost on the next
+    # checkpoint. Note: all other tests qualify names (mem.t), so only this
+    # one exercises the replay database context.
+    ns.destroy("obj-uq")
+    o = ns.open("obj-uq")  # ns default db = "mem"
+    o.query("USE mem", "CSV")  # set current db; USE via query is not logged
+    o.execute("CREATE TABLE t (n Int64) ENGINE=MergeTree ORDER BY n")  # unqualified
+    o.execute("INSERT INTO t VALUES (1), (2), (3)")                    # unqualified
+    o.flush()  # persist to WAL, but do not checkpoint — force a replay on reopen
+    o.close()
+    r = ns.open("obj-uq")  # replays the WAL
+    got = r.query("SELECT count() FROM mem.t", "CSV").data().strip()
+    r.close()
+    assert got == "3", got
+    print("  WAL replay restores the object's database context ✓")
+
+
+def test_database_name_needing_quotes():
+    # a db name with '-' is only valid backtick-quoted; unquoted it parses as
+    # subtraction and every CREATE/USE/BACKUP/RESTORE would fail. Exercises the
+    # full create -> backup -> restore -> WAL-replay path under such a name.
+    ns = cd.Namespace(URL, owner="w1", db="my-mem-db")
+    ns.destroy("obj-q")
+    o = ns.open("obj-q")
+    o.query("USE `my-mem-db`", "CSV")
+    o.execute("CREATE TABLE t (n Int64) ENGINE=MergeTree ORDER BY n")
+    o.execute("INSERT INTO t VALUES (42)")
+    o.flush()
+    o.close()
+    r = ns.open("obj-q")  # restore + replay under the quoted db
+    got = r.query("SELECT n FROM `my-mem-db`.t", "CSV").data().strip()
+    r.close()
+    assert got == "42", got
+    print("  database name needing quotes (my-mem-db) round-trips ✓")
+
+
 if __name__ == "__main__":
     print(f"backend URL: {URL}")
     ns = _fresh_ns()
+    test_wal_replay_unqualified_db_context(ns)
+    test_database_name_needing_quotes()
     test_checkpoint_roundtrip(ns)
     test_wal_incremental(ns)
     test_checkpoint_folds_wal(ns)


### PR DESCRIPTION
## What

Restore the object's database as the current database before replaying the write-ahead log in `chdb.durable`.

## The bug

WAL replay ran with `default` as the current database. A durable object sets its own database (the manifest's `db`) as current, and callers write with unqualified table names against it. On reopen, those logged statements replayed into `default` instead — so the tables were invisible to the caller and dropped by the next `BACKUP DATABASE {db}` checkpoint. Net effect: **committed writes silently lost after a crash/reopen**, whenever the caller used unqualified names (the natural style once you've set a database).

## The fix

`USE {db}` before replay (one line in `_restore`), plus a note in the WAL usage rules.

## Test

Adds a regression test. Every existing durable test qualifies its table names (`mem.t`), so none exercised the replay database context; the new test uses an unqualified name and reopens. Without the fix it fails with `UNKNOWN_TABLE`; with it, the full suite passes (verified locally and against MinIO).

## Context

Found while building a memory backend on `chdb.durable` (auxten/clickmem#7), whose tables are unqualified — this fix is a correctness prerequisite for that use.


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Replay WAL in the object's database context and quote database identifiers
> - Adds `_quote_ident` helper in [object.py](https://github.com/chdb-io/chdb/pull/618/files#diff-65082cd9f06eff60433e3c7c536498cd1971cf7610af29e5ff6e7584c1aba610) to backtick-quote ClickHouse identifiers, allowing database names containing hyphens or other special characters in DDL statements.
> - Issues a `USE <db>` statement before WAL replay in `DurableObject._restore` so unqualified table references in WAL entries replay against the object's own database instead of `default`.
> - Applies `_quote_ident` consistently in `open`, `_restore`, and `checkpoint` for `CREATE DATABASE` and `BACKUP DATABASE` statements.
> - Behavioral Change: WAL replay now executes in the object's database context; previously unqualified statements would silently target `default`.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 9cd8e66.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->