### PR TITLE
durable: leave the session in the object's database after a cold open

### DIFF
--- a/chdb/durable/object.py
+++ b/chdb/durable/object.py
@@ -136,6 +136,12 @@ class DurableObject:
             try:
                 self._start_session()
                 self.session.query(f"CREATE DATABASE IF NOT EXISTS {_quote_ident(self.db)}")
+                # leave the session in the object's database, same as the restore
+                # path does before replay — so unqualified writes land in the db
+                # that checkpoint()'s `BACKUP DATABASE {db}` captures. Without this
+                # a fresh object's unqualified writes go to `default` and are lost
+                # on the next checkpoint/reopen.
+                self.session.query(f"USE {_quote_ident(self.db)}", "CSV")
             except Exception:
                 self._abort_open()
                 raise

--- a/tests/test_durable.py
+++ b/tests/test_durable.py
@@ -395,6 +395,26 @@ def test_wal_replay_unqualified_db_context(ns):
     print("  WAL replay restores the object's database context ✓")
 
 
+def test_cold_open_leaves_session_in_object_db():
+    # After a *cold* open (fresh object), the session must already be in the
+    # object's database, so unqualified writes land where checkpoint()'s
+    # `BACKUP DATABASE {db}` captures them. Uses no manual `USE` — that is the
+    # real consumer path (e.g. a store that just runs CREATE/INSERT). Before the
+    # fix these went to `default` and were dropped on reopen.
+    ns = cd.Namespace(URL, owner="w1", db="analyst")
+    ns.destroy("obj-cold")
+    o = ns.open("obj-cold")
+    o.execute("CREATE TABLE t (n Int64) ENGINE=MergeTree ORDER BY n")  # unqualified
+    o.execute("INSERT INTO t VALUES (7)")
+    o.checkpoint()  # BACKUP DATABASE analyst — must include t
+    o.close()
+    r = ns.open("obj-cold")
+    got = r.query("SELECT n FROM analyst.t", "CSV").data().strip()
+    r.close()
+    assert got == "7", got
+    print("  cold open leaves the session in the object's database ✓")
+
+
 def test_database_name_needing_quotes():
     # a db name with '-' is only valid backtick-quoted; unquoted it parses as
     # subtraction and every CREATE/USE/BACKUP/RESTORE would fail. Exercises the
@@ -418,6 +438,7 @@ if __name__ == "__main__":
     print(f"backend URL: {URL}")
     ns = _fresh_ns()
     test_wal_replay_unqualified_db_context(ns)
+    test_cold_open_leaves_session_in_object_db()
     test_database_name_needing_quotes()
     test_checkpoint_roundtrip(ns)
     test_wal_incremental(ns)


### PR DESCRIPTION
## What

Leave the session in the object's database after a **cold** open (a brand-new object), matching what the restore path already does on reopen.

## The bug

A freshly created durable object ran `CREATE DATABASE {db}` but left the session's current database on `default`. The restore path (reopen) leaves it on the object's database, so the two paths were inconsistent. A consumer that writes unqualified table names — the natural style, e.g. `chdb-serverless`'s `DurableStore` running plain `CREATE TABLE` / `INSERT` — created its tables in `default`, which `checkpoint()`'s `BACKUP DATABASE {db}` does not capture. Result: **a brand-new object silently lost its writes on the first reopen.**

## The fix

`USE {db}` right after `CREATE DATABASE` in the cold path (one line), so unqualified writes land in the database the checkpoint captures. Follow-up to #618, which fixed the same class of problem on the reopen path but not on cold create.

## Test

Adds a regression test that writes unqualified statements with **no manual `USE`**, checkpoints, and reopens — the real consumer path that none of the existing tests exercised (they all qualify names or set the database by hand). Fails without the fix (rows lost); passes with it. Full durable suite green locally and against MinIO.


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Leave session in object's database after a cold open in `DurableObject`
> In the cold-create path, after starting a session and creating the database, a `USE {db}` statement is issued so the session points to the object's database. This aligns cold-open behavior with restore/replay, meaning unqualified SQL statements target the correct database. A new test in [test_durable.py](https://github.com/chdb-io/chdb/pull/619/files#diff-61099a5feac6fd583615f2a94e5679da8123d9db22b7b104196ae7d2063c6dd4) verifies that unqualified writes on a fresh object persist correctly across a checkpoint and reopen.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized d04e2e6.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->