### PR TITLE
docs: clarify sync label timing

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -14,12 +14,13 @@ directory.
 3. Open a pull request. `.github/workflows/docs_verify.yml` validates this
    directory against the current ClickHouse documentation site configuration.
 
-After a documentation pull request is merged, add the `sync-docs` label when
-the change should be published immediately. A published chDB release or a
-manual workflow dispatch also triggers `.github/workflows/docs_sync.yml`.
-That workflow opens or refreshes an automated pull request which mirrors these
-pages into `ClickHouse/ClickHouse/docs/chdb`; merging that pull request deploys
-the content through the normal ClickHouse documentation pipeline.
+To publish a documentation change immediately, add the `sync-docs` label to
+its pull request before merging it. The merged pull request then triggers
+`.github/workflows/docs_sync.yml`; a published chDB release or a manual
+workflow dispatch also triggers it. The workflow opens or refreshes an
+automated pull request which mirrors these pages into
+`ClickHouse/ClickHouse/docs/chdb`; merging that pull request deploys the content
+through the normal ClickHouse documentation pipeline.
 
 `README.md` and `_static/` are repository-only files and are excluded from the
 published mirror. `_static/` contains images referenced by frozen public URLs


### PR DESCRIPTION
## Summary

- clarify that `sync-docs` must be added to a documentation PR before it is merged
- keep the published-release and manual-dispatch paths documented

## Why

The sync workflow listens for the pull request `closed` event and checks the
labels present at merge time. Adding `sync-docs` after merge does not trigger
the workflow.

## Validation

- `git diff --check`


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Clarify `sync-docs` label timing in documentation publishing instructions
> Updates [docs/README.md](https://github.com/chdb-io/chdb/pull/620/files#diff-0b5ca119d2be595aa307d34512d9679e49186307ef94201e4b3dfa079aa89938) to clarify that the `sync-docs` label must be added before merging to trigger immediate publication. Also notes that the merged PR triggers `.github/workflows/docs_sync.yml`, and that a chDB release or manual dispatch can trigger it as well.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized aa284e8.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->