### PR TITLE
Fix release version bump path

### DIFF
--- a/.bumpversion.toml
+++ b/.bumpversion.toml
@@ -22,6 +22,6 @@ filename = "pyproject.toml"
 filename = "datastore/__init__.py"
 
 [[tool.bumpversion.files]]
-filename = "docs/conf.py"
+filename = "sphinx/conf.py"
 search = "version = release = '{current_version}'"
 replace = "version = release = '{new_version}'"

--- a/.github/workflows/build_linux_arm64_wheels-gh.yml
+++ b/.github/workflows/build_linux_arm64_wheels-gh.yml
@@ -43,20 +43,30 @@ jobs:
           curl https://pyenv.run | bash
           export PATH="$HOME/.pyenv/bin:$PATH"
           eval "$(pyenv init -)"
+          plain_pyenv_version() {
+            local pattern="${1//./\\.}"
+            pyenv versions --bare 2>/dev/null | grep -E "^${pattern}\.[0-9]+$" | tail -1
+          }
           INSTALLED=""
           set +e
           for v in 3.9 3.10 3.11 3.12 3.13 3.14; do
             echo "=== Installing Python $v ==="
             if pyenv install "$v:latest"; then
-              INSTALLED="$INSTALLED $v"
+              installed_version="$(plain_pyenv_version "$v")"
+              if [ -n "$installed_version" ]; then
+                INSTALLED="$INSTALLED $installed_version"
+              else
+                echo "WARNING: pyenv installed no non-free-threaded Python $v, skipping"
+              fi
             else
               echo "Normal install failed, retrying without ensurepip..."
               installed_ver=$(pyenv latest "$v" 2>/dev/null)
               if [ -n "$installed_ver" ]; then pyenv uninstall -f "$installed_ver" 2>/dev/null; fi
               PYTHON_CONFIGURE_OPTS="--without-ensurepip" pyenv install "$v:latest" || true
-              if pyenv versions --bare | grep -q "^$v\."; then
-                INSTALLED="$INSTALLED $v"
-                echo "Python $v binary installed (pip bootstrap deferred)"
+              installed_version="$(plain_pyenv_version "$v")"
+              if [ -n "$installed_version" ]; then
+                INSTALLED="$INSTALLED $installed_version"
+                echo "Python $installed_version binary installed (pip bootstrap deferred)"
               else
                 echo "WARNING: Python $v install failed completely, skipping"
               fi
@@ -72,10 +82,15 @@ jobs:
         run: |
           export PATH="$HOME/.pyenv/bin:$PATH"
           eval "$(pyenv init -)"
+          plain_pyenv_version() {
+            local pattern="${1//./\\.}"
+            pyenv versions --bare 2>/dev/null | grep -E "^${pattern}\.[0-9]+$" | tail -1
+          }
           for version in 3.9 3.10 3.11 3.12 3.13 3.14; do
-            if ! pyenv versions --bare | grep -q "^$version"; then continue; fi
-            echo "Installing dependencies for Python $version"
-            pyenv shell $version
+            PYTHON_VERSION="$(plain_pyenv_version "$version")"
+            if [ -z "$PYTHON_VERSION" ]; then continue; fi
+            echo "Installing dependencies for Python $PYTHON_VERSION"
+            pyenv shell "$PYTHON_VERSION"
             if ! python -m pip --version 2>/dev/null; then
               echo "pip missing, bootstrapping..."
               curl -sS https://bootstrap.pypa.io/get-pip.py -o /tmp/get-pip.py
@@ -93,7 +108,13 @@ jobs:
         run: |
           export PATH="$HOME/.pyenv/bin:$PATH"
           eval "$(pyenv init -)"
-          pyenv shell 3.9
+          plain_pyenv_version() {
+            local pattern="${1//./\\.}"
+            pyenv versions --bare 2>/dev/null | grep -E "^${pattern}\.[0-9]+$" | tail -1
+          }
+          PYTHON_VERSION="$(plain_pyenv_version 3.9)"
+          if [ -z "$PYTHON_VERSION" ]; then echo "Python 3.9 not available"; exit 1; fi
+          pyenv shell "$PYTHON_VERSION"
           make wheel
       - name: Show files
         run: |
@@ -103,9 +124,14 @@ jobs:
         run: |
           export PATH="$HOME/.pyenv/bin:$PATH"
           eval "$(pyenv init -)"
+          plain_pyenv_version() {
+            local pattern="${1//./\\.}"
+            pyenv versions --bare 2>/dev/null | grep -E "^${pattern}\.[0-9]+$" | tail -1
+          }
 
           for version in 3.9 3.10 3.11 3.12 3.13 3.14; do
-            if ! pyenv versions --bare | grep -q "^$version"; then
+            PYTHON_VERSION="$(plain_pyenv_version "$version")"
+            if [ -z "$PYTHON_VERSION" ]; then
               echo "Python $version not available, skipping"
               continue
             fi
@@ -117,22 +143,22 @@ jobs:
             fi
             for PANDAS_CONSTRAINT in "${PANDAS_CONSTRAINTS[@]}"; do
               echo "=============================================="
-              echo "Testing DataStore on Python $version with $PANDAS_CONSTRAINT"
+              echo "Testing DataStore on Python $PYTHON_VERSION with $PANDAS_CONSTRAINT"
               echo "=============================================="
 
-              pyenv shell $version
+              pyenv shell "$PYTHON_VERSION"
               python -m pip install dist/*.whl --force-reinstall
               # pyarrow 25.0.0 corrupts parquet reads on linux-aarch64; remove this pin once a fixed pyarrow release is out
               python -m pip install pytest pytest-cov hypothesis ray "$PANDAS_CONSTRAINT" "pyarrow<25"
               echo "Installed pandas version:"
               python -c "import pandas; print(pandas.__version__)"
 
-              echo "Running DataStore tests on Python $version with $PANDAS_CONSTRAINT ..."
+              echo "Running DataStore tests on Python $PYTHON_VERSION with $PANDAS_CONSTRAINT ..."
               cd datastore
               python -m pytest tests/ -v --tb=short -x
               cd ..
               echo "=============================================="
-              echo "DataStore tests PASSED on Python $version with $PANDAS_CONSTRAINT"
+              echo "DataStore tests PASSED on Python $PYTHON_VERSION with $PANDAS_CONSTRAINT"
               echo "=============================================="
               pyenv shell --unset
             done

--- a/.github/workflows/build_linux_x86_wheels.yml
+++ b/.github/workflows/build_linux_x86_wheels.yml
@@ -54,20 +54,30 @@ jobs:
           curl https://pyenv.run | bash
           export PATH="$HOME/.pyenv/bin:$PATH"
           eval "$(pyenv init -)"
+          plain_pyenv_version() {
+            local pattern="${1//./\\.}"
+            pyenv versions --bare 2>/dev/null | grep -E "^${pattern}\.[0-9]+$" | tail -1
+          }
           INSTALLED=""
           set +e
           for v in 3.9 3.10 3.11 3.12 3.13 3.14; do
             echo "=== Installing Python $v ==="
             if pyenv install "$v:latest"; then
-              INSTALLED="$INSTALLED $v"
+              installed_version="$(plain_pyenv_version "$v")"
+              if [ -n "$installed_version" ]; then
+                INSTALLED="$INSTALLED $installed_version"
+              else
+                echo "WARNING: pyenv installed no non-free-threaded Python $v, skipping"
+              fi
             else
               echo "Normal install failed, retrying without ensurepip..."
               installed_ver=$(pyenv latest "$v" 2>/dev/null)
               if [ -n "$installed_ver" ]; then pyenv uninstall -f "$installed_ver" 2>/dev/null; fi
               PYTHON_CONFIGURE_OPTS="--without-ensurepip" pyenv install "$v:latest" || true
-              if pyenv versions --bare | grep -q "^$v\."; then
-                INSTALLED="$INSTALLED $v"
-                echo "Python $v binary installed (pip bootstrap deferred)"
+              installed_version="$(plain_pyenv_version "$v")"
+              if [ -n "$installed_version" ]; then
+                INSTALLED="$INSTALLED $installed_version"
+                echo "Python $installed_version binary installed (pip bootstrap deferred)"
               else
                 echo "WARNING: Python $v install failed completely, skipping"
               fi
@@ -83,10 +93,15 @@ jobs:
         run: |
           export PATH="$HOME/.pyenv/bin:$PATH"
           eval "$(pyenv init -)"
+          plain_pyenv_version() {
+            local pattern="${1//./\\.}"
+            pyenv versions --bare 2>/dev/null | grep -E "^${pattern}\.[0-9]+$" | tail -1
+          }
           for version in 3.9 3.10 3.11 3.12 3.13 3.14; do
-            if ! pyenv versions --bare | grep -q "^$version"; then continue; fi
-            echo "Installing dependencies for Python $version"
-            pyenv shell $version
+            PYTHON_VERSION="$(plain_pyenv_version "$version")"
+            if [ -z "$PYTHON_VERSION" ]; then continue; fi
+            echo "Installing dependencies for Python $PYTHON_VERSION"
+            pyenv shell "$PYTHON_VERSION"
             if ! python -m pip --version 2>/dev/null; then
               echo "pip missing, bootstrapping..."
               curl -sS https://bootstrap.pypa.io/get-pip.py -o /tmp/get-pip.py
@@ -104,7 +119,13 @@ jobs:
         run: |
           export PATH="$HOME/.pyenv/bin:$PATH"
           eval "$(pyenv init -)"
-          pyenv shell 3.9
+          plain_pyenv_version() {
+            local pattern="${1//./\\.}"
+            pyenv versions --bare 2>/dev/null | grep -E "^${pattern}\.[0-9]+$" | tail -1
+          }
+          PYTHON_VERSION="$(plain_pyenv_version 3.9)"
+          if [ -z "$PYTHON_VERSION" ]; then echo "Python 3.9 not available"; exit 1; fi
+          pyenv shell "$PYTHON_VERSION"
 
           python -m pip install bump-my-version
           TAG_NAME=${GITHUB_REF#refs/tags/v}
@@ -115,7 +136,13 @@ jobs:
         run: |
           export PATH="$HOME/.pyenv/bin:$PATH"
           eval "$(pyenv init -)"
-          pyenv shell 3.9
+          plain_pyenv_version() {
+            local pattern="${1//./\\.}"
+            pyenv versions --bare 2>/dev/null | grep -E "^${pattern}\.[0-9]+$" | tail -1
+          }
+          PYTHON_VERSION="$(plain_pyenv_version 3.9)"
+          if [ -z "$PYTHON_VERSION" ]; then echo "Python 3.9 not available"; exit 1; fi
+          pyenv shell "$PYTHON_VERSION"
           make wheel
       - name: Show files
         run: |
@@ -125,9 +152,14 @@ jobs:
         run: |
           export PATH="$HOME/.pyenv/bin:$PATH"
           eval "$(pyenv init -)"
+          plain_pyenv_version() {
+            local pattern="${1//./\\.}"
+            pyenv versions --bare 2>/dev/null | grep -E "^${pattern}\.[0-9]+$" | tail -1
+          }
 
           for version in 3.9 3.10 3.11 3.12 3.13 3.14; do
-            if ! pyenv versions --bare | grep -q "^$version"; then
+            PYTHON_VERSION="$(plain_pyenv_version "$version")"
+            if [ -z "$PYTHON_VERSION" ]; then
               echo "Python $version not available, skipping"
               continue
             fi
@@ -139,21 +171,21 @@ jobs:
             fi
             for PANDAS_CONSTRAINT in "${PANDAS_CONSTRAINTS[@]}"; do
               echo "=============================================="
-              echo "Testing DataStore on Python $version with $PANDAS_CONSTRAINT"
+              echo "Testing DataStore on Python $PYTHON_VERSION with $PANDAS_CONSTRAINT"
               echo "=============================================="
 
-              pyenv shell $version
+              pyenv shell "$PYTHON_VERSION"
               python -m pip install dist/*.whl --force-reinstall
               python -m pip install pytest pytest-cov hypothesis ray "$PANDAS_CONSTRAINT"
               echo "Installed pandas version:"
               python -c "import pandas; print(pandas.__version__)"
 
-              echo "Running DataStore tests on Python $version with $PANDAS_CONSTRAINT ..."
+              echo "Running DataStore tests on Python $PYTHON_VERSION with $PANDAS_CONSTRAINT ..."
               cd datastore
               python -m pytest tests/ -v --tb=short -x
               cd ..
               echo "=============================================="
-              echo "DataStore tests PASSED on Python $version with $PANDAS_CONSTRAINT"
+              echo "DataStore tests PASSED on Python $PYTHON_VERSION with $PANDAS_CONSTRAINT"
               echo "=============================================="
               pyenv shell --unset
             done
@@ -175,7 +207,13 @@ jobs:
         run: |
           export PATH="$HOME/.pyenv/bin:$PATH"
           eval "$(pyenv init -)"
-          pyenv shell 3.9
+          plain_pyenv_version() {
+            local pattern="${1//./\\.}"
+            pyenv versions --bare 2>/dev/null | grep -E "^${pattern}\.[0-9]+$" | tail -1
+          }
+          PYTHON_VERSION="$(plain_pyenv_version 3.9)"
+          if [ -z "$PYTHON_VERSION" ]; then echo "Python 3.9 not available"; exit 1; fi
+          pyenv shell "$PYTHON_VERSION"
           python -m twine upload dist/*.whl
         env:
           TWINE_USERNAME: __token__

--- a/.github/workflows/build_macos_arm64_wheels.yml
+++ b/.github/workflows/build_macos_arm64_wheels.yml
@@ -43,11 +43,23 @@ jobs:
           export PATH="$HOME/.pyenv/bin:$PATH"
           eval "$(pyenv init -)"
 
+          plain_pyenv_version() {
+            local pattern="${1//./\\.}"
+            pyenv versions --bare 2>/dev/null | grep -E "^${pattern}\.[0-9]+$" | tail -1
+          }
+
+          INSTALLED=""
           for v in 3.9 3.10 3.11 3.12 3.13 3.14; do
             echo "=== Installing Python $v ==="
             pyenv install "$v:latest"
+            installed_version="$(plain_pyenv_version "$v")"
+            if [ -z "$installed_version" ]; then
+              echo "pyenv installed no non-free-threaded Python $v"
+              exit 1
+            fi
+            INSTALLED="$INSTALLED $installed_version"
           done
-          pyenv global $(pyenv versions --bare)
+          pyenv global $INSTALLED
 
           echo "Installed versions:"
           pyenv versions
@@ -55,10 +67,15 @@ jobs:
         run: |
           export PATH="$HOME/.pyenv/bin:$PATH"
           eval "$(pyenv init -)"
+          plain_pyenv_version() {
+            local pattern="${1//./\\.}"
+            pyenv versions --bare 2>/dev/null | grep -E "^${pattern}\.[0-9]+$" | tail -1
+          }
           for version in 3.9 3.10 3.11 3.12 3.13 3.14; do
-            if ! pyenv versions --bare | grep -q "^$version"; then continue; fi
-            echo "Installing dependencies for Python $version"
-            pyenv shell $version
+            PYTHON_VERSION="$(plain_pyenv_version "$version")"
+            if [ -z "$PYTHON_VERSION" ]; then continue; fi
+            echo "Installing dependencies for Python $PYTHON_VERSION"
+            pyenv shell "$PYTHON_VERSION"
             python -m pip install --upgrade pip
             python -m pip install setuptools tox pandas pyarrow wheel pytest pytest-cov
             pyenv shell --unset
@@ -70,7 +87,13 @@ jobs:
         run: |
           export PATH="$HOME/.pyenv/bin:$PATH"
           eval "$(pyenv init -)"
-          pyenv shell 3.9
+          plain_pyenv_version() {
+            local pattern="${1//./\\.}"
+            pyenv versions --bare 2>/dev/null | grep -E "^${pattern}\.[0-9]+$" | tail -1
+          }
+          PYTHON_VERSION="$(plain_pyenv_version 3.9)"
+          if [ -z "$PYTHON_VERSION" ]; then echo "Python 3.9 not available"; exit 1; fi
+          pyenv shell "$PYTHON_VERSION"
           make wheel
       - name: Show files
         run: |
@@ -80,9 +103,14 @@ jobs:
         run: |
           export PATH="$HOME/.pyenv/bin:$PATH"
           eval "$(pyenv init -)"
+          plain_pyenv_version() {
+            local pattern="${1//./\\.}"
+            pyenv versions --bare 2>/dev/null | grep -E "^${pattern}\.[0-9]+$" | tail -1
+          }
 
           for version in 3.9 3.10 3.11 3.12 3.13 3.14; do
-            if ! pyenv versions --bare | grep -q "^$version"; then
+            PYTHON_VERSION="$(plain_pyenv_version "$version")"
+            if [ -z "$PYTHON_VERSION" ]; then
               echo "Python $version not available, skipping"
               continue
             fi
@@ -94,21 +122,21 @@ jobs:
             fi
             for PANDAS_CONSTRAINT in "${PANDAS_CONSTRAINTS[@]}"; do
               echo "=============================================="
-              echo "Testing DataStore on Python $version with $PANDAS_CONSTRAINT"
+              echo "Testing DataStore on Python $PYTHON_VERSION with $PANDAS_CONSTRAINT"
               echo "=============================================="
 
-              pyenv shell $version
+              pyenv shell "$PYTHON_VERSION"
               python -m pip install dist/*.whl --force-reinstall
               python -m pip install pytest pytest-cov hypothesis "$PANDAS_CONSTRAINT"
               echo "Installed pandas version:"
               python -c "import pandas; print(pandas.__version__)"
 
-              echo "Running DataStore tests on Python $version with $PANDAS_CONSTRAINT ..."
+              echo "Running DataStore tests on Python $PYTHON_VERSION with $PANDAS_CONSTRAINT ..."
               cd datastore
               python -m pytest tests/ -v --tb=short -x
               cd ..
               echo "=============================================="
-              echo "DataStore tests PASSED on Python $version with $PANDAS_CONSTRAINT"
+              echo "DataStore tests PASSED on Python $PYTHON_VERSION with $PANDAS_CONSTRAINT"
               echo "=============================================="
               pyenv shell --unset
             done

--- a/.github/workflows/build_macos_x86_wheels.yml
+++ b/.github/workflows/build_macos_x86_wheels.yml
@@ -43,20 +43,31 @@ jobs:
           export PATH="$HOME/.pyenv/bin:$PATH"
           eval "$(pyenv init -)"
 
+          plain_pyenv_version() {
+            local pattern="${1//./\\.}"
+            pyenv versions --bare 2>/dev/null | grep -E "^${pattern}\.[0-9]+$" | tail -1
+          }
+
           INSTALLED=""
           set +e
           for v in 3.10 3.11 3.12 3.13 3.14; do
             echo "=== Installing Python $v ==="
             if pyenv install "$v:latest"; then
-              INSTALLED="$INSTALLED $v"
+              installed_version="$(plain_pyenv_version "$v")"
+              if [ -n "$installed_version" ]; then
+                INSTALLED="$INSTALLED $installed_version"
+              else
+                echo "WARNING: pyenv installed no non-free-threaded Python $v, skipping"
+              fi
             else
               echo "Normal install failed, retrying without ensurepip..."
               installed_ver=$(pyenv latest "$v" 2>/dev/null)
               if [ -n "$installed_ver" ]; then pyenv uninstall -f "$installed_ver" 2>/dev/null; fi
               PYTHON_CONFIGURE_OPTS="--without-ensurepip" pyenv install "$v:latest" || true
-              if pyenv versions --bare | grep -q "^$v\."; then
-                INSTALLED="$INSTALLED $v"
-                echo "Python $v binary installed (pip bootstrap deferred)"
+              installed_version="$(plain_pyenv_version "$v")"
+              if [ -n "$installed_version" ]; then
+                INSTALLED="$INSTALLED $installed_version"
+                echo "Python $installed_version binary installed (pip bootstrap deferred)"
               else
                 echo "WARNING: Python $v install failed completely, skipping"
               fi
@@ -72,10 +83,15 @@ jobs:
         run: |
           export PATH="$HOME/.pyenv/bin:$PATH"
           eval "$(pyenv init -)"
+          plain_pyenv_version() {
+            local pattern="${1//./\\.}"
+            pyenv versions --bare 2>/dev/null | grep -E "^${pattern}\.[0-9]+$" | tail -1
+          }
           for version in 3.10 3.11 3.12 3.13 3.14; do
-            if ! pyenv versions --bare | grep -q "^$version"; then continue; fi
-            echo "Installing dependencies for Python $version"
-            pyenv shell $version
+            PYTHON_VERSION="$(plain_pyenv_version "$version")"
+            if [ -z "$PYTHON_VERSION" ]; then continue; fi
+            echo "Installing dependencies for Python $PYTHON_VERSION"
+            pyenv shell "$PYTHON_VERSION"
             if ! python -m pip --version 2>/dev/null; then
               echo "pip missing, bootstrapping..."
               curl -sS https://bootstrap.pypa.io/get-pip.py -o /tmp/get-pip.py
@@ -92,7 +108,13 @@ jobs:
         run: |
           export PATH="$HOME/.pyenv/bin:$PATH"
           eval "$(pyenv init -)"
-          pyenv shell 3.10
+          plain_pyenv_version() {
+            local pattern="${1//./\\.}"
+            pyenv versions --bare 2>/dev/null | grep -E "^${pattern}\.[0-9]+$" | tail -1
+          }
+          PYTHON_VERSION="$(plain_pyenv_version 3.10)"
+          if [ -z "$PYTHON_VERSION" ]; then echo "Python 3.10 not available"; exit 1; fi
+          pyenv shell "$PYTHON_VERSION"
           make wheel
       - name: Show files
         run: |
@@ -102,9 +124,14 @@ jobs:
         run: |
           export PATH="$HOME/.pyenv/bin:$PATH"
           eval "$(pyenv init -)"
+          plain_pyenv_version() {
+            local pattern="${1//./\\.}"
+            pyenv versions --bare 2>/dev/null | grep -E "^${pattern}\.[0-9]+$" | tail -1
+          }
 
           for version in 3.10 3.11 3.12 3.13 3.14; do
-            if ! pyenv versions --bare | grep -q "^$version"; then
+            PYTHON_VERSION="$(plain_pyenv_version "$version")"
+            if [ -z "$PYTHON_VERSION" ]; then
               echo "Python $version not available, skipping"
               continue
             fi
@@ -116,21 +143,21 @@ jobs:
             fi
             for PANDAS_CONSTRAINT in "${PANDAS_CONSTRAINTS[@]}"; do
               echo "=============================================="
-              echo "Testing DataStore on Python $version with $PANDAS_CONSTRAINT"
+              echo "Testing DataStore on Python $PYTHON_VERSION with $PANDAS_CONSTRAINT"
               echo "=============================================="
 
-              pyenv shell $version
+              pyenv shell "$PYTHON_VERSION"
               python -m pip install dist/*.whl --force-reinstall
               python -m pip install pytest pytest-cov hypothesis "$PANDAS_CONSTRAINT"
               echo "Installed pandas version:"
               python -c "import pandas; print(pandas.__version__)"
 
-              echo "Running DataStore tests on Python $version with $PANDAS_CONSTRAINT ..."
+              echo "Running DataStore tests on Python $PYTHON_VERSION with $PANDAS_CONSTRAINT ..."
               cd datastore
               python -m pytest tests/ -v --tb=short -x
               cd ..
               echo "=============================================="
-              echo "DataStore tests PASSED on Python $version with $PANDAS_CONSTRAINT"
+              echo "DataStore tests PASSED on Python $PYTHON_VERSION with $PANDAS_CONSTRAINT"
               echo "=============================================="
               pyenv shell --unset
             done

--- a/.github/workflows/external_clickhouse_integration.yaml
+++ b/.github/workflows/external_clickhouse_integration.yaml
@@ -90,13 +90,20 @@ jobs:
           export PATH="$HOME/.pyenv/bin:$PATH"
           eval "$(pyenv init -)"
 
-          # A *working* 3.14 must import the C extensions the wheel build /
-          # pytest need. A prior from-source build that lacked the headers
-          # leaves a broken 3.14.x dir behind (_ssl/_bz2/_ctypes/... missing),
-          # so don't trust the version's mere presence — probe it.
+          plain_pyenv_version() {
+            local pattern="${1//./\\.}"
+            pyenv versions --bare 2>/dev/null | grep -E "^${pattern}\.[0-9]+$" | tail -1
+          }
+
+          # chdb-core PyPI wheels are regular ABI wheels; avoid free-threaded
+          # pyenv builds such as 3.14.7t. A *working* 3.14 must also import
+          # the C extensions the wheel build / pytest need. A prior from-source
+          # build that lacked the headers leaves a broken 3.14.x dir behind
+          # (_ssl/_bz2/_ctypes/... missing), so don't trust the version's mere
+          # presence -- probe it.
           probe='import ssl, bz2, ctypes, curses, lzma, sqlite3'
           WORKING=""
-          for v in $(pyenv versions --bare 2>/dev/null | grep '^3\.14\.' || true); do
+          for v in $(pyenv versions --bare 2>/dev/null | grep -E '^3\.14\.[0-9]+$' || true); do
             if "$HOME/.pyenv/versions/$v/bin/python" -c "$probe" 2>/dev/null; then
               WORKING="$v"; break
             fi
@@ -118,7 +125,11 @@ jobs:
             fi
             # -f overwrites any broken partial build of the same version.
             pyenv install -f 3.14:latest
-            WORKING=$(pyenv versions --bare | grep '^3\.14\.' | tail -1)
+            WORKING=$(plain_pyenv_version 3.14)
+            if [ -z "$WORKING" ]; then
+              echo "No non-free-threaded Python 3.14 found; chdb-core PyPI wheels do not support Python 3.14t"
+              exit 1
+            fi
           fi
           pyenv global "$WORKING"
           python --version


### PR DESCRIPTION
Fix the release version bump config after the legacy Sphinx docs moved from `docs/` to `sphinx/`.

Without this, the release workflow `bump-my-version replace --new-version <tag>` step still looks for `docs/conf.py` and fails before building the wheel.

Validated with:
- `uv run --no-project --with bump-my-version bump-my-version replace --new-version 4.3.0 --dry-run --verbose`
- `.venv/bin/python -m pytest datastore/tests/test_chdb_optional_dependencies.py tests/test_no_pandas_pyarrow.py -q`
- `uv run --no-project --with build python -m build --wheel`

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix version bump path and resolve concrete non-free-threaded Python versions in CI workflows
> - Updates [.bumpversion.toml](https://github.com/chdb-io/chdb/pull/623/files#diff-c157bf6a4fcea5e19ccb39979beb75b999c94a5e950492d7e423760fd4320208) to point at `sphinx/conf.py` instead of `docs/conf.py` for version replacement.
> - Adds a `plain_pyenv_version` helper across all CI wheel-build and integration workflows to resolve the latest non-free-threaded (non-`t`) patch version for a given major.minor, replacing loose major.minor aliases.
> - Dependency install, build, and test steps now skip versions that cannot be resolved and log the concrete version used.
> - Behavioral Change: Release-critical steps (wheel build, twine upload, version bump) now hard-fail if the required concrete Python version (e.g. 3.9 or 3.10) is unavailable, and free-threaded builds are explicitly excluded.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized d0a17fb.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->