### PR TITLE
docs: feature chDB-Wasm prominently in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 <div align="center">
-   <a href="https://clickhouse.com/blog/chdb-joins-clickhouse-family">📢 chDB joins the ClickHouse family 🐍+🚀</a>
+   <a href="https://wasm.chdb.io"><b>🎉 New: chDB-Wasm — the complete ClickHouse engine compiled to WebAssembly. Run SQL in your browser, no server, no install → wasm.chdb.io</b></a>
 </div>
 <div align="center">
 <picture>
@@ -28,6 +28,7 @@
 ## Features
 
 * **🐼 Pandas-compatible DataStore API** - Use familiar pandas syntax with ClickHouse performance
+* **🌐 Runs in the browser via WebAssembly** - [chDB-Wasm](https://github.com/chdb-io/chdb-wasm) compiles the full engine to WASM; try it live at [wasm.chdb.io](https://wasm.chdb.io)
 * In-process SQL OLAP Engine, powered by ClickHouse
 * No need to install ClickHouse
 * Minimized data copy from C++ to Python with [python memoryview](https://docs.python.org/3/c-api/memoryview.html)
@@ -49,6 +50,8 @@ Currently, chDB supports Python 3.9+ on macOS and Linux (x86_64 and ARM64).
 ```bash
 pip install chdb
 ```
+
+No install at all: open [wasm.chdb.io](https://wasm.chdb.io) and run SQL against the WebAssembly build ([chDB-Wasm](https://github.com/chdb-io/chdb-wasm)) right in your browser.
 
 Install ADBC support with Python 3.10 or later:
 
@@ -535,6 +538,7 @@ For more examples, see [examples](examples) and [tests](tests).
 
 ## Demos and Examples
 
+- [chDB-Wasm browser SQL shell](https://wasm.chdb.io) — the full ClickHouse engine in WebAssembly, zero install ([source](https://github.com/chdb-io/chdb-wasm))
 - [Project Documentation](https://clickhouse.com/docs/en/chdb) and [Usage Examples](https://clickhouse.com/docs/en/chdb/install/python)
 - [Colab Notebooks](https://colab.research.google.com/drive/1-zKB6oKfXeptggXi0kUX87iR8ZTSr4P3?usp=sharing) and other [Script Examples](examples)
 


### PR DESCRIPTION
## What

Surface **chDB-Wasm** ([wasm.chdb.io](https://wasm.chdb.io), [chdb-io/chdb-wasm](https://github.com/chdb-io/chdb-wasm)) in the README:

- **Top banner**: replace the "chDB joins the ClickHouse family" announcement with the chDB-Wasm launch banner
- **Features**: new bullet — runs in the browser via WebAssembly
- **Installation**: zero-install option — open wasm.chdb.io and run SQL in the browser
- **Demos and Examples**: link the browser SQL shell first

## Why

The WebAssembly build was not mentioned anywhere in the README (0 occurrences of "wasm"/"WebAssembly" across 631 lines). The announcement only lives on X and Hacker News, so anyone researching chdb through the README, PyPI, or the ClickHouse blog concludes WASM support does not exist — an external competitive-research pass did exactly that this week. The README is the highest-weight surface for both people and LLMs; this makes chDB-Wasm discoverable where it matters.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Feature chDB-Wasm prominently in README
> Updates [README.md](https://github.com/chdb-io/chdb/pull/631/files#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5) to highlight WebAssembly/browser support across multiple sections: replaces the top announcement link with a bolded link to wasm.chdb.io, adds a feature bullet for browser support, notes that no install is needed for the Wasm build, and adds a browser SQL shell demo link.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized fbc72a7.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->