### PR TITLE
Document OrcaRouter as an OpenAI-compatible gateway for AI-assisted SQL generation

### DIFF
--- a/README-zh.md
+++ b/README-zh.md
@@ -280,7 +280,7 @@ chDB 可以将自然语言提示转换为 SQL。通过连接/会话字符串配�
 
 - `ai_provider`：`openai` 或 `anthropic`。当设置了 `ai_base_url` 时默认使用 OpenAI 兼容接口，否则自动检测。
 - `ai_api_key`：API 密钥；也可从环境变量 `AI_API_KEY`、`OPENAI_API_KEY` 或 `ANTHROPIC_API_KEY` 读取。
-- `ai_base_url`：OpenAI 兼容服务的自定义 Base URL。
+- `ai_base_url`：OpenAI 兼容服务的自定义 Base URL（或 OpenAI 兼容网关，如 [OrcaRouter](https://www.orcarouter.ai)）。
 - `ai_model`：模型名称（如 `gpt-4o-mini`、`claude-3-opus-20240229`）。
 - `ai_temperature`：生成温度，默认 `0.0`。
 - `ai_max_tokens`：最大全量生成 token 数，默认 `1000`。
@@ -317,6 +317,16 @@ with chs.Session("file::memory:?ai_provider=openai") as sess:
     sess.query("INSERT INTO users VALUES (1, 'alice'), (2, 'bob')")
     df = sess.ask("Show all users ordered by id", format="DataFrame")
     print(df)
+```
+
+任何 OpenAI 兼容网关都可以作为模型后端，例如 [OrcaRouter](https://www.orcarouter.ai)：
+
+```python
+conn = chdb.connect(
+    "file::memory:?ai_provider=openai&ai_base_url=https://api.orcarouter.ai"
+    "&ai_api_key=sk-orca-...&ai_model=openai/gpt-4o-mini"
+)
+print(conn.generate_sql("Select all rows from nums ordered by n desc"))
 ```
 
 </details>

--- a/README.md
+++ b/README.md
@@ -512,7 +512,7 @@ chDB can translate natural language prompts into SQL. Configure the AI client th
 
 - `ai_provider`: `openai` or `anthropic`. Defaults to OpenAI-compatible when `ai_base_url` is set, otherwise auto-detected.
 - `ai_api_key`: API key; falls back to `AI_API_KEY`, `OPENAI_API_KEY`, or `ANTHROPIC_API_KEY` env vars.
-- `ai_base_url`: Custom base URL for OpenAI-compatible endpoints.
+- `ai_base_url`: Custom base URL for OpenAI-compatible endpoints (or an OpenAI-compatible gateway such as [OrcaRouter](https://www.orcarouter.ai)).
 - `ai_model`: Model name (e.g., `gpt-4o-mini`, `claude-3-opus-20240229`).
 
 ```python
@@ -529,6 +529,18 @@ print(sql)  # e.g., SELECT * FROM nums ORDER BY n DESC
 # ask(): one-call generate + execute
 print(conn.ask("List the numbers table", format="Pretty"))
 ```
+
+Any OpenAI-compatible gateway can be used as the model backend, e.g. [OrcaRouter](https://www.orcarouter.ai):
+
+```python
+conn = chdb.connect(
+    "file::memory:?ai_provider=openai&ai_base_url=https://api.orcarouter.ai"
+    "&ai_api_key=sk-orca-...&ai_model=openai/gpt-4o-mini"
+)
+print(conn.generate_sql("Select all rows from nums ordered by n desc"))
+```
+
+The same connection-string parameters apply to `chdb.Session`.
 
 </details>
 


### PR DESCRIPTION
## Summary

chDB's AI-assisted SQL generation already speaks to any OpenAI-compatible endpoint through `ai_base_url`. This PR documents an OpenAI-compatible gateway — [OrcaRouter](https://www.orcarouter.ai) — as a concrete example, so users who want natural-language SQL generation through a gateway can see exactly how to configure it.

The example was verified end-to-end: with `ai_provider=openai&ai_base_url=https://api.orcarouter.ai`, `conn.generate_sql("Select all rows from nums ordered by n desc")` returns `SELECT * FROM nums ORDER BY n DESC`.

## Type of change

- [ ] New feature
- [ ] Bug fix
- [ ] Refactor (no behavior change)
- [ ] Tests only
- [x] Documentation only
- [ ] CI / build infrastructure
- [ ] Tooling / dependencies / housekeeping

## Linked issues

No related issue.

## How to verify

The example added in this PR was run live against the OrcaRouter gateway:

```bash
ORCAROUTER_API_KEY=... python - <<'PY'
import chdb
conn = chdb.connect(
    "file::memory:?ai_provider=openai&ai_base_url=https://api.orcarouter.ai"
    "&ai_api_key=sk-orca-...&ai_model=openai/gpt-4o-mini"
)
print(conn.generate_sql("Select all rows from nums ordered by n desc"))
PY
```

Output:

```
[chdb] AI SQL generator using provider=openai, model=openai/gpt-4o-mini, base_url=https://api.orcarouter.ai
SELECT * FROM nums ORDER BY n DESC
```

Full local validation (per CONTRIBUTING "Before opening a PR"):

```bash
ruff check datastore --statistics   # no issues
cd datastore && python -m pytest tests/ -q --tb=short
# 11268 passed, 104 skipped, 79 xfailed, 6 xpassed in 210.47s
```

## Checklist

- [ ] Tests added or updated for the behavior change (regression test for bug fixes)
- [x] `ruff check datastore --statistics` passes locally
- [ ] If the change touches DataStore semantics: ran the relevant pytest module on **both** `pandas<3.0` and `pandas>=3.0` (Python ≥ 3.11)
- [x] User-facing API or behavior changes have updated docs (`docs/`, docstrings, `examples/`)
- [ ] No new dependencies added to `requirements.txt` without prior discussion

## Notes for reviewers

About the gateway being documented: OrcaRouter is an OpenAI-compatible AI gateway built for both models and agents. Like OpenRouter, it exposes a provider/model namespace across many models — but it also combines adaptive routing, automatic failover, zero-markup inference, observability, guardrails, and agent-tool governance behind the same endpoint. Adding orcarouter as a first-class provider means this project's users can use that stack directly, without treating OrcaRouter as an anonymous custom base URL.

It also runs gateway-level, zero-trust security for AI agents on the same endpoint — screening every prompt/response and governing every tool call on a default-deny basis, with no application code changes.

chDB routes this through the same `ai_provider=openai` + `ai_base_url` path it already documents — no engine change is required, which is why this is a documentation-only PR.

Questions or feedback are welcome — reach us on Discord: discord.gg/YEubt8enRA · X: https://x.com/OrcaRouter

I'm an engineer on the OrcaRouter team.


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Document OrcaRouter as an OpenAI-compatible gateway for `ai_base_url`
> Expands the `ai_base_url` parameter docs in [README.md](https://github.com/chdb-io/chdb/pull/632/files#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5) and [README-zh.md](https://github.com/chdb-io/chdb/pull/632/files#diff-2b8d2db04fe3277c3a06cbdf5da2ba7659f95e19e31f59d5382b40ac81a1a98d) to note it can point to an OpenAI-compatible gateway, mentioning OrcaRouter by name. Adds a Python example using `ai_provider=openai`, a custom `ai_base_url`, an example `ai_api_key`, and `ai_model=openai/gpt-4o-mini` before calling `generate_sql`, with a note that the same parameters apply to `chdb.Session`.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 7f4badb.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->