### PR TITLE
Bring chdb.durable onto the frozen Durable V1 contract

### DIFF
--- a/.github/workflows/build_linux_arm64_wheels-gh.yml
+++ b/.github/workflows/build_linux_arm64_wheels-gh.yml
@@ -164,3 +164,40 @@ jobs:
             done
           done
         continue-on-error: false
+      - name: Test chdb.durable (Durable V1 conformance)
+        run: |
+          export PATH="$HOME/.pyenv/bin:$PATH"
+          eval "$(pyenv init -)"
+          plain_pyenv_version() {
+            local pattern="${1//./\\.}"
+            pyenv versions --bare 2>/dev/null | grep -E "^${pattern}\.[0-9]+$" | tail -1
+          }
+
+          # One Python is enough: this suite exercises the protocol and the
+          # filesystem primitives under it (flock, hard-link create, atomic
+          # rename), not the Python matrix, and it is the platform differences
+          # that are worth the four jobs.
+          PYTHON_VERSION=""
+          for version in 3.12 3.11 3.13 3.10 3.9 3.14; do
+            candidate="$(plain_pyenv_version "$version")"
+            if [ -n "$candidate" ]; then
+              PYTHON_VERSION="$candidate"
+              break
+            fi
+          done
+          if [ -z "$PYTHON_VERSION" ]; then
+            echo "No suitable Python found; skipping the durable suite"
+            exit 0
+          fi
+
+          pyenv shell "$PYTHON_VERSION"
+          python -m pip install dist/*.whl --force-reinstall
+          python -m pip install pytest
+
+          # Durable V1 needs chdb-core's backup / restore / query-analysis ABI.
+          # Until a chdb-core carrying it is what pip resolves by default, the
+          # module skips itself — and that skip is as much the thing under test
+          # as the checks are, so this step is green either way and turns into
+          # real coverage the day the dependency catches up.
+          python -m pytest tests/test_durable.py -v --tb=short
+        continue-on-error: false

--- a/.github/workflows/build_linux_arm64_wheels-gh.yml
+++ b/.github/workflows/build_linux_arm64_wheels-gh.yml
@@ -199,5 +199,24 @@ jobs:
           # module skips itself — and that skip is as much the thing under test
           # as the checks are, so this step is green either way and turns into
           # real coverage the day the dependency catches up.
+          set +e
           python -m pytest tests/test_durable.py -v --tb=short
+          code=$?
+          set -e
+          if [ "$code" -eq 5 ]; then
+            # Exit 5 is pytest's "collected nothing", which is what a
+            # module-level skip looks like from outside. Accepting it blindly
+            # would also swallow a suite that stopped being collected for some
+            # unrelated reason, so make it prove why it skipped.
+            python - <<'PY'
+          import sys
+          from chdb.durable.engine import engine_has_v1_abi
+          if engine_has_v1_abi():
+              sys.exit("collected nothing even though this chdb-core has the "
+                       "Durable V1 ABI — the suite is no longer running")
+          print("durable suite skipped: this chdb-core has no Durable V1 ABI")
+          PY
+          elif [ "$code" -ne 0 ]; then
+            exit "$code"
+          fi
         continue-on-error: false

--- a/.github/workflows/build_linux_x86_wheels.yml
+++ b/.github/workflows/build_linux_x86_wheels.yml
@@ -191,6 +191,43 @@ jobs:
             done
           done
         continue-on-error: false
+      - name: Test chdb.durable (Durable V1 conformance)
+        run: |
+          export PATH="$HOME/.pyenv/bin:$PATH"
+          eval "$(pyenv init -)"
+          plain_pyenv_version() {
+            local pattern="${1//./\\.}"
+            pyenv versions --bare 2>/dev/null | grep -E "^${pattern}\.[0-9]+$" | tail -1
+          }
+
+          # One Python is enough: this suite exercises the protocol and the
+          # filesystem primitives under it (flock, hard-link create, atomic
+          # rename), not the Python matrix, and it is the platform differences
+          # that are worth the four jobs.
+          PYTHON_VERSION=""
+          for version in 3.12 3.11 3.13 3.10 3.9 3.14; do
+            candidate="$(plain_pyenv_version "$version")"
+            if [ -n "$candidate" ]; then
+              PYTHON_VERSION="$candidate"
+              break
+            fi
+          done
+          if [ -z "$PYTHON_VERSION" ]; then
+            echo "No suitable Python found; skipping the durable suite"
+            exit 0
+          fi
+
+          pyenv shell "$PYTHON_VERSION"
+          python -m pip install dist/*.whl --force-reinstall
+          python -m pip install pytest
+
+          # Durable V1 needs chdb-core's backup / restore / query-analysis ABI.
+          # Until a chdb-core carrying it is what pip resolves by default, the
+          # module skips itself — and that skip is as much the thing under test
+          # as the checks are, so this step is green either way and turns into
+          # real coverage the day the dependency catches up.
+          python -m pytest tests/test_durable.py -v --tb=short
+        continue-on-error: false
       - name: Upload wheels to release
         if: startsWith(github.ref, 'refs/tags/v')
         run: |

--- a/.github/workflows/build_linux_x86_wheels.yml
+++ b/.github/workflows/build_linux_x86_wheels.yml
@@ -226,7 +226,26 @@ jobs:
           # module skips itself — and that skip is as much the thing under test
           # as the checks are, so this step is green either way and turns into
           # real coverage the day the dependency catches up.
+          set +e
           python -m pytest tests/test_durable.py -v --tb=short
+          code=$?
+          set -e
+          if [ "$code" -eq 5 ]; then
+            # Exit 5 is pytest's "collected nothing", which is what a
+            # module-level skip looks like from outside. Accepting it blindly
+            # would also swallow a suite that stopped being collected for some
+            # unrelated reason, so make it prove why it skipped.
+            python - <<'PY'
+          import sys
+          from chdb.durable.engine import engine_has_v1_abi
+          if engine_has_v1_abi():
+              sys.exit("collected nothing even though this chdb-core has the "
+                       "Durable V1 ABI — the suite is no longer running")
+          print("durable suite skipped: this chdb-core has no Durable V1 ABI")
+          PY
+          elif [ "$code" -ne 0 ]; then
+            exit "$code"
+          fi
         continue-on-error: false
       - name: Upload wheels to release
         if: startsWith(github.ref, 'refs/tags/v')

--- a/.github/workflows/build_macos_arm64_wheels.yml
+++ b/.github/workflows/build_macos_arm64_wheels.yml
@@ -142,3 +142,40 @@ jobs:
             done
           done
         continue-on-error: false
+      - name: Test chdb.durable (Durable V1 conformance)
+        run: |
+          export PATH="$HOME/.pyenv/bin:$PATH"
+          eval "$(pyenv init -)"
+          plain_pyenv_version() {
+            local pattern="${1//./\\.}"
+            pyenv versions --bare 2>/dev/null | grep -E "^${pattern}\.[0-9]+$" | tail -1
+          }
+
+          # One Python is enough: this suite exercises the protocol and the
+          # filesystem primitives under it (flock, hard-link create, atomic
+          # rename), not the Python matrix, and it is the platform differences
+          # that are worth the four jobs.
+          PYTHON_VERSION=""
+          for version in 3.12 3.11 3.13 3.10 3.9 3.14; do
+            candidate="$(plain_pyenv_version "$version")"
+            if [ -n "$candidate" ]; then
+              PYTHON_VERSION="$candidate"
+              break
+            fi
+          done
+          if [ -z "$PYTHON_VERSION" ]; then
+            echo "No suitable Python found; skipping the durable suite"
+            exit 0
+          fi
+
+          pyenv shell "$PYTHON_VERSION"
+          python -m pip install dist/*.whl --force-reinstall
+          python -m pip install pytest
+
+          # Durable V1 needs chdb-core's backup / restore / query-analysis ABI.
+          # Until a chdb-core carrying it is what pip resolves by default, the
+          # module skips itself — and that skip is as much the thing under test
+          # as the checks are, so this step is green either way and turns into
+          # real coverage the day the dependency catches up.
+          python -m pytest tests/test_durable.py -v --tb=short
+        continue-on-error: false

--- a/.github/workflows/build_macos_arm64_wheels.yml
+++ b/.github/workflows/build_macos_arm64_wheels.yml
@@ -177,5 +177,24 @@ jobs:
           # module skips itself — and that skip is as much the thing under test
           # as the checks are, so this step is green either way and turns into
           # real coverage the day the dependency catches up.
+          set +e
           python -m pytest tests/test_durable.py -v --tb=short
+          code=$?
+          set -e
+          if [ "$code" -eq 5 ]; then
+            # Exit 5 is pytest's "collected nothing", which is what a
+            # module-level skip looks like from outside. Accepting it blindly
+            # would also swallow a suite that stopped being collected for some
+            # unrelated reason, so make it prove why it skipped.
+            python - <<'PY'
+          import sys
+          from chdb.durable.engine import engine_has_v1_abi
+          if engine_has_v1_abi():
+              sys.exit("collected nothing even though this chdb-core has the "
+                       "Durable V1 ABI — the suite is no longer running")
+          print("durable suite skipped: this chdb-core has no Durable V1 ABI")
+          PY
+          elif [ "$code" -ne 0 ]; then
+            exit "$code"
+          fi
         continue-on-error: false

--- a/.github/workflows/build_macos_x86_wheels.yml
+++ b/.github/workflows/build_macos_x86_wheels.yml
@@ -163,3 +163,40 @@ jobs:
             done
           done
         continue-on-error: false
+      - name: Test chdb.durable (Durable V1 conformance)
+        run: |
+          export PATH="$HOME/.pyenv/bin:$PATH"
+          eval "$(pyenv init -)"
+          plain_pyenv_version() {
+            local pattern="${1//./\\.}"
+            pyenv versions --bare 2>/dev/null | grep -E "^${pattern}\.[0-9]+$" | tail -1
+          }
+
+          # One Python is enough: this suite exercises the protocol and the
+          # filesystem primitives under it (flock, hard-link create, atomic
+          # rename), not the Python matrix, and it is the platform differences
+          # that are worth the four jobs.
+          PYTHON_VERSION=""
+          for version in 3.12 3.11 3.13 3.10 3.9 3.14; do
+            candidate="$(plain_pyenv_version "$version")"
+            if [ -n "$candidate" ]; then
+              PYTHON_VERSION="$candidate"
+              break
+            fi
+          done
+          if [ -z "$PYTHON_VERSION" ]; then
+            echo "No suitable Python found; skipping the durable suite"
+            exit 0
+          fi
+
+          pyenv shell "$PYTHON_VERSION"
+          python -m pip install dist/*.whl --force-reinstall
+          python -m pip install pytest
+
+          # Durable V1 needs chdb-core's backup / restore / query-analysis ABI.
+          # Until a chdb-core carrying it is what pip resolves by default, the
+          # module skips itself — and that skip is as much the thing under test
+          # as the checks are, so this step is green either way and turns into
+          # real coverage the day the dependency catches up.
+          python -m pytest tests/test_durable.py -v --tb=short
+        continue-on-error: false

--- a/.github/workflows/build_macos_x86_wheels.yml
+++ b/.github/workflows/build_macos_x86_wheels.yml
@@ -198,5 +198,24 @@ jobs:
           # module skips itself — and that skip is as much the thing under test
           # as the checks are, so this step is green either way and turns into
           # real coverage the day the dependency catches up.
+          set +e
           python -m pytest tests/test_durable.py -v --tb=short
+          code=$?
+          set -e
+          if [ "$code" -eq 5 ]; then
+            # Exit 5 is pytest's "collected nothing", which is what a
+            # module-level skip looks like from outside. Accepting it blindly
+            # would also swallow a suite that stopped being collected for some
+            # unrelated reason, so make it prove why it skipped.
+            python - <<'PY'
+          import sys
+          from chdb.durable.engine import engine_has_v1_abi
+          if engine_has_v1_abi():
+              sys.exit("collected nothing even though this chdb-core has the "
+                       "Durable V1 ABI — the suite is no longer running")
+          print("durable suite skipped: this chdb-core has no Durable V1 ABI")
+          PY
+          elif [ "$code" -ne 0 ]; then
+            exit "$code"
+          fi
         continue-on-error: false

--- a/chdb/durable/__init__.py
+++ b/chdb/durable/__init__.py
@@ -1,35 +1,77 @@
-"""chdb.durable — Durable Analytical Object.
+"""chdb.durable — a chDB database that lives in object storage you own.
 
-An addressable, single-writer chDB engine whose authoritative state lives in
-object storage you own (S3 / GCS / Azure Blob / any S3-compatible / a local
-folder). Restore is fast, the lease makes single-writer a guarantee not an
-assumption, and the on-disk format is portable — your object is a folder you
-can move between clouds.
+An addressable, single-writer chDB engine whose authoritative state is in S3 /
+GCS / Azure Blob / any S3-compatible store / a local folder. Restore is fast,
+the lease makes single-writer a guarantee rather than an assumption, and the
+layout is open format — an object is a folder you can move between clouds.
 
     from chdb import durable as cd
     ns = cd.Namespace("s3://bucket/prefix", owner="worker-1")
     obj = ns.open("user-123")            # lease + restore (base + WAL replay)
-    obj.execute("INSERT INTO mem.beliefs VALUES (...)")
-    obj.flush()                          # cut a WAL segment (RPO boundary)
+    obj.execute("INSERT INTO beliefs VALUES (...)")   # local; buffered
+    obj.flush()                          # publish a WAL segment (the RPO boundary)
     obj.checkpoint()                     # fold into a fresh base
-    obj.close()                          # flush + release lease
-    ns.scan("SELECT count() FROM mem.beliefs", ids=["user-1", "user-2"])
+    obj.close()                          # flush + release the lease
+    ns.scan("SELECT count() FROM beliefs", ids=["user-1", "user-2"])
+
+This implements **Durable V1** as frozen in `dev-docs/CHDB_DURABLE_V1_CONTRACT.md`:
+one database per object, one writer plus any number of read-only openers, one
+statement per public call, a statement WAL, full checkpoints, and the lease /
+CAS / fencing rules every binding shares. Objects it writes are readable by the
+Node, Go and Rust bindings of the same protocol version, and vice versa.
+
+`execute()` is *not* a durability barrier. It runs the statement locally and
+buffers it; `flush()` is what makes it recoverable elsewhere. A service that
+promises a completed request survives a crash has to await `flush()` before it
+answers.
+
+Requires a chdb-core with the Durable V1 ABI (26.7.2-rc.2 or newer): backup,
+restore and statement classification are the engine's job, and this package
+builds no `BACKUP`/`RESTORE` SQL and runs no regex over a caller's statement.
 
 Security scope: chdb.durable provides single-writer *coordination* (the lease
-+ compare-and-set fence), not security. Access control is entirely your object
-store's IAM — anyone who can write the object's prefix can read, modify, or
-take its lock. There is no application-level auth, no client-side encryption,
-and no tamper protection: head/WAL/checkpoints are stored as-is (rely on the
-bucket's server-side encryption if you need at-rest encryption). For
-multi-tenant use, give each tenant credentials scoped to its own prefix.
+plus the compare-and-set fence), not security. Access control is entirely your
+object store's IAM — anyone who can write the object's prefix can read,
+modify, or take its lease. There is no application-level auth, no client-side
+encryption, and no tamper protection: head, WAL and checkpoints are stored as
+written (use the bucket's server-side encryption if you need encryption at
+rest). For multi-tenant use, scope each tenant's credentials to its own prefix.
 """
-from .errors import DurableError, LeaseError, MissingDependency
+from .backends import Backend, make_backend
+from .errors import (
+    BackendError,
+    ClassificationRefused,
+    Closed,
+    CommitAmbiguous,
+    Corrupt,
+    DurableError,
+    EngineError,
+    EngineIncompatible,
+    LeaseError,
+    LeaseFenced,
+    LeaseHeld,
+    LimitExceeded,
+    MissingDependency,
+    NotFound,
+    ProtocolUnsupported,
+    SecretRefused,
+    Timeout,
+    V1_CATEGORIES,
+)
+from .head import EngineInfo, Head, Lease, Manifest, ObjectRef, ProtocolInfo
 from .namespace import Namespace
 from .object import DurableObject
-from .backends import Backend, make_backend
+from .protocol import BACKUP_FORMAT, PROTOCOL_VERSION
 
 __all__ = [
     "Namespace", "DurableObject", "Backend", "make_backend",
-    "DurableError", "LeaseError", "MissingDependency",
+    "Head", "Lease", "Manifest", "ObjectRef", "EngineInfo", "ProtocolInfo",
+    "PROTOCOL_VERSION", "BACKUP_FORMAT", "V1_CATEGORIES",
+    "DurableError", "NotFound", "LeaseError", "LeaseHeld", "LeaseFenced",
+    "EngineIncompatible", "ProtocolUnsupported", "Corrupt",
+    "ClassificationRefused", "SecretRefused", "EngineError", "BackendError",
+    "Timeout", "CommitAmbiguous", "LimitExceeded", "Closed", "MissingDependency",
 ]
-__version__ = "0.1.0"
+
+#: The protocol this package implements, not the package's own release number.
+__version__ = "1.0"

--- a/chdb/durable/backends/__init__.py
+++ b/chdb/durable/backends/__init__.py
@@ -1,12 +1,33 @@
-"""Storage-backend abstraction — the seam that makes a Durable Analytical
-Object's home vendor-neutral.
+"""The storage seam — what a durable object needs from a provider, and no more.
 
-A backend is a tiny key/value store scoped to one object's prefix, with a
-*conditional create* (`put_if_absent`) and *conditional replace*
-(`replace_if_match`) — the two primitives the single-writer lease is built on.
-Every provider implements the same `Backend` protocol; the on-disk *format*
-(a chDB File backup + WAL segments + JSON manifest) is identical everywhere,
-so moving an object between clouds is a byte copy.
+A backend is a small key/value store scoped to one object's prefix. Two of its
+six operations carry the whole protocol (§5.1):
+
+* **conditional create** (`put_bytes_if_absent` / `put_file_if_absent`), which
+  publishes an immutable WAL segment or checkpoint under a key nobody else can
+  take;
+* **conditional replace** (`replace_if_match`), which is both the head commit
+  and the lease fence — a superseded writer's next commit fails the
+  compare-and-set.
+
+Both must be the provider's own atomic conditional operation. A HEAD followed
+by a PUT is not a substitute: two writers can pass the same HEAD.
+
+Three more rules the implementations here follow:
+
+* an ETag is an opaque CAS token, never assumed to be an MD5 of the content;
+* a checkpoint is uploaded from a file and downloaded to a file, so a full
+  backup never has to be held in memory in one piece;
+* a download lands on a unique temporary path and is only renamed into place
+  once it verifies, so a partial transfer is never mistaken for the object.
+
+**Indeterminate responses.** A timeout is not a failure — the server may have
+committed. A backend raises `BackendAmbiguous` when it cannot tell, and the
+state machine reconciles it (§5.8) into success, `lease_fenced`, or
+`commit_ambiguous`. It never guesses on the backend's behalf.
+
+`delete_prefix` is not part of V1: V1 has no destroy and no GC. It is here for
+`Namespace.destroy`, which is a development convenience outside the protocol.
 
 `make_backend(url, sub)` maps a URL to a backend scoped to `<base>/<sub>`:
     local:/path/to/root
@@ -24,12 +45,18 @@ from urllib.parse import urlparse
 @runtime_checkable
 class Backend(Protocol):
     def get(self, key: str) -> Optional[bytes]: ...
+
     def get_with_etag(self, key: str): ...  # -> (Optional[bytes], Optional[str])
-    def put(self, key: str, data: bytes) -> None: ...
-    def put_if_absent(self, key: str, data: bytes): ...  # -> Optional[str] etag, or None if it exists
-    def head_etag(self, key: str) -> Optional[str]: ...
+
+    def put_bytes_if_absent(self, key: str, data: bytes) -> Optional[str]: ...
+
+    def put_file_if_absent(self, key: str, local_path: str) -> Optional[str]: ...
+
     def replace_if_match(self, key: str, data: bytes, etag: str) -> Optional[str]: ...
-    def delete_prefix(self, prefix: str = "") -> None: ...
+
+    def download_to_file(self, key: str, local_path: str) -> bool: ...
+
+    def delete_prefix(self, prefix: str = "") -> None: ...  # not V1
 
 
 def make_backend(url: str, sub: str = "") -> Backend:

--- a/chdb/durable/backends/azure.py
+++ b/chdb/durable/backends/azure.py
@@ -1,10 +1,16 @@
-"""Native Azure Blob backend. Lease primitive = `overwrite=False` create
-(ResourceExists), Azure's single-writer primitive; no S3 API needed."""
+"""Native Azure Blob backend.
+
+Conditional primitives: `overwrite=False` to create (a `ResourceExistsError`
+is the precondition failing) and an `IfNotModified` ETag match to replace. No
+S3 compatibility layer is involved.
+"""
 from __future__ import annotations
 
+import os
+import uuid
 from typing import Optional
 
-from ..errors import MissingDependency
+from ..errors import BackendAmbiguous, BackendError, MissingDependency
 
 
 class AzureBlobBackend:
@@ -24,6 +30,27 @@ class AzureBlobBackend:
     def _n(self, key: str) -> str:
         return f"{self.prefix}/{key}" if self.prefix else key
 
+    def _conditional(self, op, what: str):
+        from azure.core.exceptions import (
+            ResourceExistsError,
+            ResourceModifiedError,
+            ResourceNotFoundError,
+            ServiceRequestError,
+            ServiceResponseError,
+            HttpResponseError,
+        )
+        try:
+            return op()
+        except (ResourceExistsError, ResourceModifiedError, ResourceNotFoundError):
+            return None  # the precondition failed: a lost CAS, not an error
+        except (ServiceRequestError, ServiceResponseError) as e:
+            # The response never arrived; the service may still have applied it.
+            raise BackendAmbiguous(f"{what}: response indeterminate") from e
+        except HttpResponseError as e:
+            if e.status_code and 500 <= e.status_code < 600:
+                raise BackendAmbiguous(f"{what}: response indeterminate ({e.status_code})") from e
+            raise BackendError(f"{what}: {e}") from e
+
     def get(self, key: str) -> Optional[bytes]:
         return self.get_with_etag(key)[0]
 
@@ -35,35 +62,50 @@ class AzureBlobBackend:
         except ResourceNotFoundError:
             return (None, None)
 
-    def put(self, key: str, data: bytes) -> None:
-        self.cc.upload_blob(self._n(key), data, overwrite=True)
+    def put_bytes_if_absent(self, key: str, data: bytes) -> Optional[str]:
+        r = self._conditional(
+            lambda: self.cc.upload_blob(self._n(key), data, overwrite=False), f"create {key}")
+        return None if r is None else r.get("etag")
 
-    def put_if_absent(self, key: str, data: bytes) -> Optional[str]:
-        from azure.core.exceptions import ResourceExistsError
-        try:
-            r = self.cc.upload_blob(self._n(key), data, overwrite=False)
-            return r.get("etag")  # etag of the blob we just created
-        except ResourceExistsError:
-            return None
+    def put_file_if_absent(self, key: str, local_path: str) -> Optional[str]:
+        # Hand the SDK a file object so it chunks the upload itself, rather
+        # than materialising a whole checkpoint in memory (§5.1).
+        def op():
+            with open(local_path, "rb") as body:
+                return self.cc.upload_blob(self._n(key), body, overwrite=False)
 
-    def head_etag(self, key: str) -> Optional[str]:
-        from azure.core.exceptions import ResourceNotFoundError
-        try:
-            return self.cc.get_blob_client(self._n(key)).get_blob_properties().etag
-        except ResourceNotFoundError:
-            return None
+        r = self._conditional(op, f"create {key}")
+        return None if r is None else r.get("etag")
 
     def replace_if_match(self, key: str, data: bytes, etag: str) -> Optional[str]:
         from azure.core import MatchConditions
-        from azure.core.exceptions import ResourceModifiedError, ResourceNotFoundError
+        r = self._conditional(
+            lambda: self.cc.upload_blob(self._n(key), data, overwrite=True, etag=etag,
+                                        match_condition=MatchConditions.IfNotModified),
+            f"replace {key}")
+        return None if r is None else r.get("etag")
+
+    def download_to_file(self, key: str, local_path: str) -> bool:
+        from azure.core.exceptions import ResourceNotFoundError
+        os.makedirs(os.path.dirname(local_path) or ".", exist_ok=True)
+        tmp = f"{local_path}.{uuid.uuid4().hex}.part"
         try:
-            r = self.cc.upload_blob(self._n(key), data, overwrite=True,
-                                    etag=etag, match_condition=MatchConditions.IfNotModified)
-            return r.get("etag")  # returned by the upload; no extra round-trip
-        except (ResourceModifiedError, ResourceNotFoundError):
-            return None  # etag mismatch or target gone — CAS did not match
+            stream = self.cc.download_blob(self._n(key))
+            with open(tmp, "wb") as handle:
+                stream.readinto(handle)
+        except ResourceNotFoundError:
+            if os.path.exists(tmp):
+                os.unlink(tmp)
+            return False
+        except BaseException:
+            if os.path.exists(tmp):
+                os.unlink(tmp)
+            raise
+        os.replace(tmp, local_path)  # publish only a complete transfer
+        return True
 
     def delete_prefix(self, prefix: str = "") -> None:
+        """Not V1 — see the note in `backends/__init__.py`."""
         # trailing "/" bounds the match to this object (not sibling "foobar/...");
         # empty scope (both empty) = the whole container.
         stripped = f"{self.prefix}/{prefix}".strip("/")

--- a/chdb/durable/backends/gcs.py
+++ b/chdb/durable/backends/gcs.py
@@ -1,10 +1,17 @@
-"""Native GCS backend. Lease primitive = generation-match conditional write
-(`if_generation_match=0` to create), GCS's own single-writer primitive."""
+"""Native GCS backend.
+
+Conditional primitives: `if_generation_match=0` to create, and
+`if_generation_match=<generation>` to replace. A GCS generation *is* a CAS
+token, so the object's ETag is the generation number as a string — opaque to
+everything above this file, exactly as the protocol requires.
+"""
 from __future__ import annotations
 
+import os
+import uuid
 from typing import Optional
 
-from ..errors import MissingDependency
+from ..errors import BackendAmbiguous, BackendError, MissingDependency
 
 
 class GCSBackend:
@@ -29,6 +36,25 @@ class GCSBackend:
     def _b(self, key: str):
         return self.bucket.blob(f"{self.prefix}/{key}" if self.prefix else key)
 
+    def _conditional(self, op, what: str) -> bool:
+        """True if the conditional write applied, False if the precondition
+        failed. `upload_*` returns None either way, so the answer cannot come
+        from its return value.
+        """
+        from google.api_core import exceptions as gexc
+        try:
+            op()
+            return True
+        except gexc.PreconditionFailed:
+            return False  # the generation moved: a lost CAS, not a failure
+        except gexc.NotFound:
+            return False  # replace target is gone: also a lost CAS
+        except (gexc.ServiceUnavailable, gexc.InternalServerError, gexc.GatewayTimeout,
+                gexc.TooManyRequests, gexc.RetryError, gexc.DeadlineExceeded) as e:
+            raise BackendAmbiguous(f"{what}: response indeterminate ({e.__class__.__name__})") from e
+        except gexc.GoogleAPICallError as e:
+            raise BackendError(f"{what}: {e}") from e
+
     def get(self, key: str) -> Optional[bytes]:
         return self.get_with_etag(key)[0]
 
@@ -45,37 +71,47 @@ class GCSBackend:
             gen = b.generation
         return (data, str(gen))
 
-    def put(self, key: str, data: bytes) -> None:
-        self._b(key).upload_from_string(data)
-
-    def put_if_absent(self, key: str, data: bytes) -> Optional[str]:
-        from google.api_core.exceptions import PreconditionFailed
+    def put_bytes_if_absent(self, key: str, data: bytes) -> Optional[str]:
         b = self._b(key)
-        try:
-            b.upload_from_string(data, if_generation_match=0)
-            return str(b.generation)  # generation of the object we just created
-        except PreconditionFailed:
-            return None
+        applied = self._conditional(
+            lambda: b.upload_from_string(data, if_generation_match=0), f"create {key}")
+        return str(b.generation) if applied else None
 
-    def head_etag(self, key: str) -> Optional[str]:
-        from google.cloud.exceptions import NotFound
+    def put_file_if_absent(self, key: str, local_path: str) -> Optional[str]:
+        # upload_from_filename streams the file, so a full checkpoint is never
+        # read into memory whole (§5.1).
         b = self._b(key)
-        try:
-            b.reload()
-        except NotFound:
-            return None
-        return str(b.generation)
+        applied = self._conditional(
+            lambda: b.upload_from_filename(local_path, if_generation_match=0), f"create {key}")
+        return str(b.generation) if applied else None
 
     def replace_if_match(self, key: str, data: bytes, etag: str) -> Optional[str]:
-        from google.api_core.exceptions import PreconditionFailed
         b = self._b(key)
+        applied = self._conditional(
+            lambda: b.upload_from_string(data, if_generation_match=int(etag)), f"replace {key}")
+        # The upload sets the new generation on the blob it wrote, so the next
+        # CAS token comes free — no extra round-trip to read it back.
+        return str(b.generation) if applied else None
+
+    def download_to_file(self, key: str, local_path: str) -> bool:
+        from google.cloud.exceptions import NotFound
+        os.makedirs(os.path.dirname(local_path) or ".", exist_ok=True)
+        tmp = f"{local_path}.{uuid.uuid4().hex}.part"
         try:
-            b.upload_from_string(data, if_generation_match=int(etag))
-            return str(b.generation)  # updated by the upload; no extra round-trip
-        except PreconditionFailed:
-            return None
+            self._b(key).download_to_filename(tmp)
+        except NotFound:
+            if os.path.exists(tmp):
+                os.unlink(tmp)
+            return False
+        except BaseException:
+            if os.path.exists(tmp):
+                os.unlink(tmp)
+            raise
+        os.replace(tmp, local_path)  # publish only a complete transfer
+        return True
 
     def delete_prefix(self, prefix: str = "") -> None:
+        """Not V1 — see the note in `backends/__init__.py`."""
         # trailing "/" bounds the match to this object (not sibling "foobar/...");
         # empty scope (both empty) = the whole bucket.
         stripped = f"{self.prefix}/{prefix}".strip("/")

--- a/chdb/durable/backends/local.py
+++ b/chdb/durable/backends/local.py
@@ -1,19 +1,23 @@
 """Local filesystem backend — the most vendor-neutral home of all: a folder.
 
 **Scope: development, tests, and single-writer/single-host use.** The strong
-concurrency guarantees a Durable Analytical Object relies on — atomic
-conditional writes for the lease/head CAS — belong to the object-store
-backends (S3 `IfMatch`/`IfNoneMatch`, GCS generation-match, Azure ETag), which
-provide them natively. This backend approximates them on a POSIX filesystem
+concurrency guarantees a durable object relies on — atomic conditional writes
+for the lease and head CAS — belong to the object-store backends (S3
+`IfMatch`/`IfNoneMatch`, GCS generation-match, Azure ETag), which provide them
+natively. This backend approximates them on a POSIX filesystem
 (`O_CREAT|O_EXCL` for create, `flock` for compare-and-set, path containment in
-`_p`) as a best effort so tests are realistic, but it is not intended for
-multi-host or production concurrent access. Point `durable:` at a cloud (or
-S3-compatible) backend for that.
+`_p`) so tests are realistic, but it is not multi-host safe. Point a namespace
+at a cloud (or S3-compatible) backend for that.
+
+A local write either happens or raises, so this backend never reports an
+ambiguous conditional write — the reconcile path (§5.8) exists for the network
+backends and is exercised there.
 """
 from __future__ import annotations
 
 import os
 import shutil
+import uuid
 from typing import Optional
 
 
@@ -29,6 +33,13 @@ class LocalFSBackend:
         if full != root and not full.startswith(root + os.sep):
             raise ValueError(f"key escapes backend root: {key!r}")
         return full
+
+    def _etag(self, path: str) -> Optional[str]:
+        try:
+            st = os.stat(path)
+        except FileNotFoundError:
+            return None
+        return f"{st.st_mtime_ns}-{st.st_size}"
 
     def get(self, key: str) -> Optional[bytes]:
         try:
@@ -57,15 +68,7 @@ class LocalFSBackend:
             raise
         return (data, f"{st.st_mtime_ns}-{st.st_size}")
 
-    def put(self, key: str, data: bytes) -> None:
-        p = self._p(key)
-        os.makedirs(os.path.dirname(p), exist_ok=True)
-        tmp = f"{p}.tmp"
-        with open(tmp, "wb") as f:
-            f.write(data)
-        os.replace(tmp, p)  # atomic
-
-    def put_if_absent(self, key: str, data: bytes) -> Optional[str]:
+    def put_bytes_if_absent(self, key: str, data: bytes) -> Optional[str]:
         p = self._p(key)
         os.makedirs(os.path.dirname(p), exist_ok=True)
         try:
@@ -78,26 +81,52 @@ class LocalFSBackend:
             st = os.fstat(f.fileno())  # etag of exactly what we created
         return f"{st.st_mtime_ns}-{st.st_size}"
 
-    def head_etag(self, key: str) -> Optional[str]:
+    def put_file_if_absent(self, key: str, local_path: str) -> Optional[str]:
+        # Stage beside the target, then link it into place: the link is the
+        # atomic create, so a large archive is never visible half-copied and
+        # two writers cannot both believe they created the key.
+        p = self._p(key)
+        os.makedirs(os.path.dirname(p), exist_ok=True)
+        staged = f"{p}.{uuid.uuid4().hex}.staging"
         try:
-            st = os.stat(self._p(key))
-        except FileNotFoundError:
-            return None
-        return f"{st.st_mtime_ns}-{st.st_size}"
+            shutil.copyfile(local_path, staged)
+            try:
+                os.link(staged, p)
+            except FileExistsError:
+                return None
+        finally:
+            if os.path.exists(staged):
+                os.unlink(staged)
+        return self._etag(p)
 
     def replace_if_match(self, key: str, data: bytes, etag: str) -> Optional[str]:
         import fcntl
         # serialize check-then-act across processes so two writers can't both
         # observe the same etag and both write (which would defeat the CAS).
-        lockpath = self._p(key) + ".lock"
+        p = self._p(key)
+        lockpath = p + ".lock"
         os.makedirs(os.path.dirname(lockpath), exist_ok=True)
         with open(lockpath, "w") as lf:
             fcntl.flock(lf, fcntl.LOCK_EX)
-            if self.head_etag(key) != etag:
+            if self._etag(p) != etag:
                 return None
-            self.put(key, data)
-            return self.head_etag(key)
+            tmp = f"{p}.{uuid.uuid4().hex}.tmp"
+            with open(tmp, "wb") as f:
+                f.write(data)
+            os.replace(tmp, p)  # atomic
+            return self._etag(p)
+
+    def download_to_file(self, key: str, local_path: str) -> bool:
+        src = self._p(key)
+        if not os.path.exists(src):
+            return False
+        os.makedirs(os.path.dirname(local_path) or ".", exist_ok=True)
+        tmp = f"{local_path}.{uuid.uuid4().hex}.part"
+        shutil.copyfile(src, tmp)
+        os.replace(tmp, local_path)
+        return True
 
     def delete_prefix(self, prefix: str = "") -> None:
+        """Not V1 — see the note in `backends/__init__.py`."""
         target = self._p(prefix) if prefix else self.root
         shutil.rmtree(target, ignore_errors=True)

--- a/chdb/durable/backends/s3.py
+++ b/chdb/durable/backends/s3.py
@@ -1,11 +1,28 @@
-"""S3-compatible backend: AWS S3, MinIO, Cloudflare R2, Backblaze, Tigris,
-and GCS via its S3-interoperability endpoint — one code path, `endpoint_url`
-picks the provider. Lease primitive = conditional PUT (`IfNoneMatch` / `IfMatch`)."""
+"""S3-compatible backend: AWS S3, MinIO, Cloudflare R2, Backblaze, Tigris, and
+GCS through its S3-interoperability endpoint — one code path, `endpoint_url`
+picks the provider.
+
+Conditional primitives: `IfNoneMatch: *` to create, `IfMatch: <etag>` to
+replace. Both are real S3 preconditions, which is what makes the lease a lease
+and not a convention.
+"""
 from __future__ import annotations
 
+import os
+import uuid
 from typing import Optional
 
-from ..errors import MissingDependency
+from ..errors import BackendAmbiguous, BackendError, MissingDependency
+
+#: Codes that mean "the precondition was not met" — a lost CAS, not an error.
+_CAS_MISS = ("PreconditionFailed", "412", "NoSuchKey", "404")
+
+#: Codes that mean "we do not know whether the server applied this". A 409 on a
+#: conditional write is S3 telling us another conditional write raced ours; a
+#: 5xx or a dropped connection may or may not have committed. Either way the
+#: state machine has to look, not assume (§5.8).
+_AMBIGUOUS = ("409", "ConditionalRequestConflict", "OperationAborted",
+              "InternalError", "ServiceUnavailable", "SlowDown", "500", "503")
 
 
 class S3Backend:
@@ -25,6 +42,28 @@ class S3Backend:
     def _k(self, key: str) -> str:
         return f"{self.prefix}/{key}" if self.prefix else key
 
+    @staticmethod
+    def _code(exc) -> str:
+        err = getattr(exc, "response", {}).get("Error", {})
+        return str(err.get("Code", ""))
+
+    def _conditional(self, op, what: str):
+        """Run a conditional write, sorting the three outcomes apart."""
+        import botocore
+        try:
+            return op()
+        except botocore.exceptions.ClientError as e:
+            code = self._code(e)
+            status = str(e.response.get("ResponseMetadata", {}).get("HTTPStatusCode", ""))
+            if code in _CAS_MISS or status == "412":
+                return None
+            if code in _AMBIGUOUS or status.startswith("5") or status == "409":
+                raise BackendAmbiguous(f"{what}: response indeterminate ({code or status})") from e
+            raise BackendError(f"{what}: {e}") from e
+        except (botocore.exceptions.ConnectionError, botocore.exceptions.HTTPClientError) as e:
+            # The request left; whether it landed is exactly what we do not know.
+            raise BackendAmbiguous(f"{what}: connection lost before a response") from e
+
     def get(self, key: str) -> Optional[bytes]:
         return self.get_with_etag(key)[0]
 
@@ -34,50 +73,58 @@ class S3Backend:
             r = self.s3.get_object(Bucket=self.bucket, Key=self._k(key))
             return (r["Body"].read(), r["ETag"])  # bytes + etag in one round-trip
         except botocore.exceptions.ClientError as e:
-            if e.response["Error"]["Code"] in ("NoSuchKey", "404", "NoSuchBucket"):
+            if self._code(e) in ("NoSuchKey", "404", "NoSuchBucket"):
                 return (None, None)
-            raise
+            raise BackendError(f"get {key}: {e}") from e
 
-    def put(self, key: str, data: bytes) -> None:
-        self.s3.put_object(Bucket=self.bucket, Key=self._k(key), Body=data)
+    def put_bytes_if_absent(self, key: str, data: bytes) -> Optional[str]:
+        r = self._conditional(
+            lambda: self.s3.put_object(Bucket=self.bucket, Key=self._k(key), Body=data,
+                                       IfNoneMatch="*"),
+            f"create {key}")
+        return None if r is None else r["ETag"]
 
-    def put_if_absent(self, key: str, data: bytes) -> Optional[str]:
-        import botocore
-        try:
-            r = self.s3.put_object(Bucket=self.bucket, Key=self._k(key), Body=data,
-                                   IfNoneMatch="*")
-            return r["ETag"]  # etag of the object we just created
-        except botocore.exceptions.ClientError as e:
-            if e.response["Error"]["Code"] in ("PreconditionFailed", "412"):
-                return None
-            raise
+    def put_file_if_absent(self, key: str, local_path: str) -> Optional[str]:
+        # A file object, not bytes: boto3 streams it, so a multi-gigabyte
+        # checkpoint is never resident in one piece (§5.1).
+        def op():
+            with open(local_path, "rb") as body:
+                return self.s3.put_object(Bucket=self.bucket, Key=self._k(key), Body=body,
+                                          IfNoneMatch="*")
 
-    def head_etag(self, key: str) -> Optional[str]:
-        import botocore
-        try:
-            return self.s3.head_object(Bucket=self.bucket, Key=self._k(key))["ETag"]
-        except botocore.exceptions.ClientError as e:
-            # only "absent" maps to None — transient errors (throttling, 5xx,
-            # access denied) must propagate, not masquerade as a missing key.
-            if e.response["Error"]["Code"] in ("404", "NoSuchKey", "NoSuchBucket"):
-                return None
-            raise
+        r = self._conditional(op, f"create {key}")
+        return None if r is None else r["ETag"]
 
     def replace_if_match(self, key: str, data: bytes, etag: str) -> Optional[str]:
+        r = self._conditional(
+            lambda: self.s3.put_object(Bucket=self.bucket, Key=self._k(key), Body=data,
+                                       IfMatch=etag),
+            f"replace {key}")
+        return None if r is None else r["ETag"]
+
+    def download_to_file(self, key: str, local_path: str) -> bool:
         import botocore
+        os.makedirs(os.path.dirname(local_path) or ".", exist_ok=True)
+        tmp = f"{local_path}.{uuid.uuid4().hex}.part"
         try:
-            r = self.s3.put_object(Bucket=self.bucket, Key=self._k(key), Body=data,
-                                   IfMatch=etag)
-            return r["ETag"]
+            self.s3.download_file(self.bucket, self._k(key), tmp)
         except botocore.exceptions.ClientError as e:
-            # precondition failed, or the target is gone (deleted) — either way
-            # the compare-and-set did not match.
-            if e.response["Error"]["Code"] in ("PreconditionFailed", "412",
-                                               "NoSuchKey", "404"):
-                return None
+            if os.path.exists(tmp):
+                os.unlink(tmp)
+            if self._code(e) in ("NoSuchKey", "404", "NoSuchBucket"):
+                return False
+            raise BackendError(f"download {key}: {e}") from e
+        except BaseException:
+            if os.path.exists(tmp):
+                os.unlink(tmp)
             raise
+        # Publish only once the whole transfer is on disk, so a caller can
+        # never verify a partial download against the manifest.
+        os.replace(tmp, local_path)
+        return True
 
     def delete_prefix(self, prefix: str = "") -> None:
+        """Not V1 — see the note in `backends/__init__.py`."""
         # trailing "/" bounds the match to this object — without it, destroying
         # "foo" would also delete sibling keys under "foobar/...". An empty
         # scope (prefix and self.prefix both empty) means the whole bucket.
@@ -90,5 +137,5 @@ class S3Backend:
                 resp = self.s3.delete_objects(Bucket=self.bucket, Delete={"Objects": objs})
                 errs = resp.get("Errors") or []
                 if errs:  # S3 reports per-key failures here even on a 200
-                    raise RuntimeError(
+                    raise BackendError(
                         f"delete_prefix: {len(errs)} object(s) not deleted, e.g. {errs[0]}")

--- a/chdb/durable/digest.py
+++ b/chdb/durable/digest.py
@@ -1,0 +1,56 @@
+"""Length and SHA-256, the two things a manifest says about an immutable object.
+
+Both are checked before the bytes are used (§4.5). They fail on different
+things — a truncated upload has the right prefix, a replaced object has the
+right length — so neither is redundant.
+
+Checkpoints are hashed by streaming: a full backup must never have to sit in
+memory in one piece just to be measured (§5.1).
+"""
+from __future__ import annotations
+
+import hashlib
+import os
+from typing import Tuple
+
+from .errors import Corrupt
+
+_CHUNK = 1024 * 1024
+
+
+def bytes_digest(data: bytes) -> Tuple[int, str]:
+    return len(data), hashlib.sha256(data).hexdigest()
+
+
+def file_digest(path: str) -> Tuple[int, str]:
+    digest = hashlib.sha256()
+    size = 0
+    with open(path, "rb") as handle:
+        while True:
+            chunk = handle.read(_CHUNK)
+            if not chunk:
+                break
+            size += len(chunk)
+            digest.update(chunk)
+    return size, digest.hexdigest()
+
+
+def verify_bytes(data: bytes, ref, *, what: str) -> None:
+    size, sha256 = bytes_digest(data)
+    _compare(size, sha256, ref, what)
+
+
+def verify_file(path: str, ref, *, what: str) -> None:
+    if not os.path.exists(path):
+        raise Corrupt(f"{what} {ref.key} was not downloaded")
+    size, sha256 = file_digest(path)
+    _compare(size, sha256, ref, what)
+
+
+def _compare(size: int, sha256: str, ref, what: str) -> None:
+    if size != ref.size:
+        raise Corrupt(
+            f"{what} {ref.key} is {size} bytes, the manifest says {ref.size}")
+    if sha256 != ref.sha256:
+        raise Corrupt(
+            f"{what} {ref.key} has SHA-256 {sha256}, the manifest says {ref.sha256}")

--- a/chdb/durable/engine.py
+++ b/chdb/durable/engine.py
@@ -1,0 +1,345 @@
+"""The managed chdb-core connection a durable object owns.
+
+Three things live here, and nothing else does:
+
+* the **capability check** — this binding needs the Durable V1 ABI
+  (`backup_database`, `restore_database`, `classify_query`) that chdb-core
+  exports from `programs/local/chdb.h`. An older engine is refused at open
+  with a message that says what to install, not a missing-attribute traceback;
+* the **query analysis** the entry gates are built on, as a value type instead
+  of the raw dict the extension returns;
+* the **one place** that reaches through `chdb.state.sqlitelike.Connection` to
+  the extension object, because the three ABI methods are bound on it and not
+  on the Python wrapper.
+
+Contract §3 forbids a binding from building `BACKUP` / `RESTORE` SQL or
+guessing at a statement's class with a regex, so no SQL text for those three
+operations is written anywhere in `chdb.durable` — the engine quotes its own
+identifiers and paths.
+"""
+from __future__ import annotations
+
+import os
+from dataclasses import dataclass
+from typing import Optional
+
+from .errors import EngineError, EngineIncompatible
+
+#: The three methods the Durable V1 ABI adds to a connection. Named here so the
+#: refusal can list what is missing rather than fail on first use.
+_REQUIRED_ABI = ("backup_database", "restore_database", "classify_query")
+
+_ABI_HINT = (
+    "chdb.durable needs a chdb-core with the Durable V1 ABI "
+    "(backup_database / restore_database / classify_query), i.e. 26.7.2-rc.2 "
+    "or newer: pip install -U chdb-core"
+)
+
+#: Settings pinned on the managed connection. A durable object promises that a
+#: statement `execute()` returned from has actually been applied locally, so
+#: nothing may complete asynchronously behind the call (§5.3). The public entry
+#: gate refuses statement settings that would relax these, because chdb-core
+#: classifies them as CONTROL.
+_SYNCHRONOUS_SETTINGS = {
+    "async_insert": "0",
+    "wait_for_async_insert": "1",
+    "mutations_sync": "2",
+    "alter_sync": "2",
+}
+
+
+def engine_has_v1_abi() -> bool:
+    """Does the loaded chdb-core bind the Durable V1 ABI?
+
+    Answered from the extension's connection *class*, so it costs nothing: no
+    engine is started, and on a process that already holds a data path this
+    cannot conflict with it.
+    """
+    try:
+        import chdb
+
+        raw = getattr(chdb, "_chdb", None)
+        connection = getattr(raw, "connect", None)
+        return connection is not None and all(hasattr(connection, n) for n in _REQUIRED_ABI)
+    except Exception:
+        return False
+
+
+def require_v1_abi() -> None:
+    """Refuse early, with a message that names the fix."""
+    if not engine_has_v1_abi():
+        raise EngineIncompatible(_ABI_HINT)
+
+
+#: `chdb_version()` is a compile-time constant, so one reading holds for the
+#: life of the process. Cached because the cheapest way to read it needs a
+#: connection, and a durable object should not open one just to ask.
+_ENGINE_VERSION: Optional[str] = None
+
+#: How many managed connections are live. chdb-core allows one active data path
+#: per process (§3.6), so the throwaway connection below must not be opened
+#: while an object holds one.
+_LIVE_CONNECTIONS = 0
+
+
+def _select_chdb_version(query) -> Optional[str]:
+    """`SELECT chdb()` returns `CHDB_VERSION` — the same compile-time string
+    the C `chdb_version()` returns, reachable without a Python binding for it.
+
+    Note it is *not* `SELECT version()`, which is the ClickHouse version
+    (chDB 26.7.2-rc.2 carries ClickHouse 26.7.2.1). The contract's engine
+    identity is the chDB one.
+    """
+    try:
+        result = query("SELECT chdb()", "CSV")
+        text = result.data() if hasattr(result, "data") else str(result)
+    except Exception:
+        return None
+    text = text.strip().strip('"').strip()
+    return text or None
+
+
+def _probe_engine_version() -> Optional[str]:
+    """Read the version from a throwaway in-memory engine.
+
+    Only reached before any durable object has started its own engine — with
+    one live, a second data path would be refused, so the probe is skipped
+    rather than allowed to fail.
+    """
+    if _LIVE_CONNECTIONS:
+        return None
+    try:
+        import chdb
+
+        connection = getattr(getattr(chdb, "_chdb", None), "connect", None)
+        if connection is None:
+            return None
+        conn = connection()
+    except Exception:
+        return None
+    try:
+        return _select_chdb_version(conn.query)
+    finally:
+        try:
+            conn.close()
+        except Exception:
+            pass
+
+
+def engine_version() -> str:
+    """The running engine's version, for `head.engine.version` and the
+    `min_reader` gate.
+
+    `chdb_version()` is the contract's source of truth (§3.1). The C ABI
+    exports it and both export allow-lists carry it, but no Python binding
+    calls it, so this reads the same constant by the routes that exist, in
+    order of how directly they answer the question:
+
+    1. `_chdb.chdb_version()`, if a later chdb-core binds it — the C answer;
+    2. `SELECT chdb()`, which returns that same `CHDB_VERSION` constant. Taken
+       from a managed connection when one is open, otherwise from a throwaway
+       in-memory engine, and cached either way;
+    3. the ClickHouse version the engine reports. A different numbering, but
+       measured from the engine actually loaded and sharing the chDB tag's
+       numeric prefix, so it still orders against a `min_reader`;
+    4. the chdb-core distribution version, which is the tag for a released
+       wheel but a placeholder in a source checkout — last, for that reason.
+
+    Every form orders under `protocol.parse_version`.
+    """
+    global _ENGINE_VERSION
+    import chdb
+
+    raw = getattr(chdb, "_chdb", None)
+    fn = getattr(raw, "chdb_version", None)
+    if callable(fn):
+        try:
+            return str(fn())
+        except Exception:
+            pass
+    if _ENGINE_VERSION is None:
+        _ENGINE_VERSION = _probe_engine_version()
+    if _ENGINE_VERSION:
+        return _ENGINE_VERSION
+    reported = str(getattr(chdb, "engine_version", "") or "")
+    from .protocol import parse_version
+
+    if parse_version(reported) is not None:
+        return reported
+    try:
+        import importlib.metadata
+
+        return importlib.metadata.version("chdb-core")
+    except Exception:
+        pass
+    return reported
+
+
+@dataclass(frozen=True)
+class QueryAnalysis:
+    """What chdb-core says a statement would do, without running it.
+
+    `query_class` is the enum member's name rather than the enum itself, so a
+    conformance runner can compare it to the same string every other binding
+    reports.
+    """
+
+    query_class: str
+    statement_count: int
+    has_secrets: bool
+    writes_only_target_database: bool
+    changes_database_lifecycle: bool
+
+
+class ManagedConnection:
+    """A chDB connection scoped to one durable object's scratch directory.
+
+    The connection is not handed to callers (§5.3): its current database is
+    pinned to the object's, its synchronous-write settings are part of the
+    durability promise, and its backup path is confined to the object's own
+    scratch.
+    """
+
+    def __init__(self, data_path: str, backups_path: str):
+        global _ENGINE_VERSION, _LIVE_CONNECTIONS
+        from chdb.state import sqlitelike
+
+        self._counted = False
+        args = dict(_SYNCHRONOUS_SETTINGS)
+        # `backups.allowed_path` is what makes backup/restore possible at all:
+        # chdb-core refuses an archive path outside it, and a connection that
+        # never set it cannot back anything up. Scoping it to this object's
+        # scratch also means a restore cannot read an archive some other
+        # object left on disk.
+        args["backups.allowed_path"] = backups_path
+        conn_str = data_path + "?" + "&".join(f"{k}={v}" for k, v in args.items())
+        try:
+            self._conn = sqlitelike.Connection(conn_str)
+        except Exception as exc:
+            raise EngineError(f"could not start the chDB engine: {exc}") from exc
+        _LIVE_CONNECTIONS += 1
+        self._counted = True
+        self._raw = getattr(self._conn, "_conn", None)
+        missing = [n for n in _REQUIRED_ABI if not hasattr(self._raw, n)]
+        if missing:
+            self.close()
+            raise EngineIncompatible(f"{_ABI_HINT} (missing: {', '.join(missing)})")
+        # Read the engine identity off the connection we already have, which is
+        # both cheaper and more accurate than the fallbacks in engine_version().
+        if _ENGINE_VERSION is None:
+            _ENGINE_VERSION = _select_chdb_version(self._conn.query)
+
+    def engine_version(self) -> str:
+        """This engine's version, measured from this connection where possible."""
+        global _ENGINE_VERSION
+        if _ENGINE_VERSION is None:
+            _ENGINE_VERSION = _select_chdb_version(self._conn.query)
+        return _ENGINE_VERSION or engine_version()
+
+    # -- statements -------------------------------------------------------
+    def query(self, sql: str, fmt: str = "CSV", *, redact: bool = False):
+        """Run `sql`. `redact=True` keeps a failed statement's text out of the
+        exception, for SQL the analysis flagged as carrying a credential."""
+        try:
+            return self._conn.query(sql, fmt)
+        except Exception as exc:
+            if redact:
+                raise EngineError("statement failed (text withheld: it carries a credential)") from None
+            raise EngineError(str(exc)) from exc
+
+    def use_database(self, database: str) -> None:
+        """Pin the current database, so unqualified names in a caller's SQL
+        resolve to the object's database — both when chdb-core resolves them
+        during analysis and when the statement runs."""
+        # The identifier goes through a parameter rather than into the SQL
+        # text, so a database name holding a backtick cannot change what runs.
+        try:
+            self._conn.query("USE {db:Identifier}", "CSV", params={"db": database})
+        except Exception as exc:
+            raise EngineError(f"could not select database {database!r}: {exc}") from exc
+
+    def create_database(self, database: str) -> None:
+        try:
+            self._conn.query(
+                "CREATE DATABASE IF NOT EXISTS {db:Identifier}", "CSV", params={"db": database}
+            )
+        except Exception as exc:
+            raise EngineError(f"could not create database {database!r}: {exc}") from exc
+
+    # -- Durable V1 ABI ---------------------------------------------------
+    def analyze(self, sql: str, target_database: str) -> QueryAnalysis:
+        try:
+            report = self._raw.classify_query(sql, target_database)
+        except Exception as exc:
+            raise EngineError(f"query analysis failed: {exc}") from exc
+        return QueryAnalysis(
+            query_class=getattr(report["query_class"], "name", str(report["query_class"])),
+            statement_count=int(report["statement_count"]),
+            has_secrets=bool(report["has_secrets"]),
+            writes_only_target_database=bool(report["writes_only_target_database"]),
+            changes_database_lifecycle=bool(report["changes_database_lifecycle"]),
+        )
+
+    def backup(self, database: str, file_path: str) -> None:
+        """Full backup of `database` into `file_path`.
+
+        `base_file_path` is deliberately never passed: an incremental archive
+        records the base's *local path*, which does not survive the trip
+        through object storage, so V1 publishes full checkpoints only (§3.2).
+        """
+        if not os.path.isabs(file_path):
+            raise EngineError(f"backup path must be absolute: {file_path!r}")
+        try:
+            self._raw.backup_database(database, file_path)
+        except Exception as exc:
+            raise EngineError(f"backup of database {database!r} failed: {exc}") from exc
+
+    def restore(self, database: str, file_path: str) -> None:
+        if not os.path.isabs(file_path):
+            raise EngineError(f"restore path must be absolute: {file_path!r}")
+        try:
+            self._raw.restore_database(database, file_path)
+        except Exception as exc:
+            raise EngineError(f"restore of database {database!r} failed: {exc}") from exc
+
+    # -- lifecycle --------------------------------------------------------
+    def close(self) -> None:
+        global _LIVE_CONNECTIONS
+        conn, self._conn, self._raw = getattr(self, "_conn", None), None, None
+        if getattr(self, "_counted", False):
+            _LIVE_CONNECTIONS -= 1
+            self._counted = False
+        if conn is not None:
+            try:
+                conn.close()
+            except Exception:
+                pass
+
+
+def require_engine_compatible(
+    *, engine_name: str, backup_format: int, min_reader: str, running: Optional[str] = None
+) -> None:
+    """The §4.3 open gate: format generation first, then reader version.
+
+    Note what is *not* compared: whether `head.engine.version` equals the
+    running version. An object written by 26.7.2-rc.2 stays open to every
+    later core that supports the same archive generation — that is the whole
+    point of carrying `backup_format` and `min_reader` separately.
+    """
+    from .protocol import BACKUP_FORMAT, ENGINE_NAME, version_lt
+
+    if engine_name != ENGINE_NAME:
+        raise EngineIncompatible(
+            f"object was written by engine {engine_name!r}, not {ENGINE_NAME!r}")
+    if backup_format > BACKUP_FORMAT:
+        raise EngineIncompatible(
+            f"object uses backup format {backup_format}; this engine restores up to {BACKUP_FORMAT}")
+    running = engine_version() if running is None else running
+    older = version_lt(running, min_reader)
+    if older is None:
+        raise EngineIncompatible(
+            f"cannot order running engine {running!r} against the object's min_reader "
+            f"{min_reader!r}; refusing rather than assuming compatibility")
+    if older:
+        raise EngineIncompatible(
+            f"object needs chDB {min_reader} or newer to restore; this engine is {running}")

--- a/chdb/durable/errors.py
+++ b/chdb/durable/errors.py
@@ -1,14 +1,151 @@
-"""Exceptions for chdb.durable."""
+"""The V1 error categories, as Python exception types.
+
+The contract (`dev-docs/CHDB_DURABLE_V1_CONTRACT.md` §6) freezes a set of
+categories every binding must let a caller tell apart programmatically. Python
+spells them as exception classes; `category` carries the frozen name, so a
+cross-binding conformance runner can compare what was raised against the table
+without knowing Python's class names.
+
+`LeaseError` is the one grouping type: `lease_held` and `lease_fenced` are
+distinct categories, but "I do not own this object" is the question callers
+usually ask, and one `except` should answer it.
+"""
 from __future__ import annotations
 
 
 class DurableError(RuntimeError):
-    """Base class for all chdb.durable errors."""
+    """Base class for every chdb.durable error."""
+
+    category = "durable"
+
+
+class NotFound(DurableError):
+    """A read-only open (or an existing-only open) found no object."""
+
+    category = "not_found"
 
 
 class LeaseError(DurableError):
-    """The single-writer lease could not be acquired or was lost."""
+    """Grouping type for the two lease categories; never raised directly."""
+
+    category = "lease"
+
+
+class LeaseHeld(LeaseError):
+    """Another writer holds an unexpired lease."""
+
+    category = "lease_held"
+
+
+class LeaseFenced(LeaseError):
+    """This instance lost generation/ETag ownership of the object."""
+
+    category = "lease_fenced"
+
+
+class EngineIncompatible(DurableError):
+    """The object's backup format is newer than this engine can restore, this
+    engine is older than the object's `min_reader`, or the engine is not chDB."""
+
+    category = "engine_incompatible"
+
+
+class ProtocolUnsupported(DurableError):
+    """The object's protocol version or a declared feature is not supported."""
+
+    category = "protocol_unsupported"
+
+
+class Corrupt(DurableError):
+    """A head that fails schema validation, or an immutable object that is
+    missing, the wrong length, or the wrong SHA-256."""
+
+    category = "corrupt"
+
+
+class ClassificationRefused(DurableError):
+    """Statement count, class, or write target did not satisfy the entry gate."""
+
+    category = "classification_refused"
+
+
+class SecretRefused(DurableError):
+    """A mutation carries a credential, so it cannot be written to the WAL."""
+
+    category = "secret_refused"
+
+
+class EngineError(DurableError):
+    """A chdb-core query, backup, or restore failed."""
+
+    category = "engine"
+
+
+class BackendError(DurableError):
+    """A provider network, authentication, or non-conditional failure."""
+
+    category = "backend"
+
+
+class BackendAmbiguous(BackendError):
+    """A conditional write whose response was lost or indeterminate.
+
+    Internal to the backend seam: the state machine catches this and runs the
+    §5.8 reconcile, which resolves it into success, `lease_fenced`, or
+    `commit_ambiguous`. It is never the final answer given to a caller.
+    """
+
+    category = "backend"
+
+
+class Timeout(DurableError):
+    """An operation is known not to have committed and passed its deadline."""
+
+    category = "timeout"
+
+
+class CommitAmbiguous(DurableError):
+    """Reconcile could not prove whether the remote committed."""
+
+    category = "commit_ambiguous"
+
+
+class LimitExceeded(DurableError):
+    """SQL, a WAL segment, or the head passed a limit V1 freezes."""
+
+    category = "limit_exceeded"
+
+
+class Closed(DurableError):
+    """An operation on an object whose close() has completed."""
+
+    category = "closed"
 
 
 class MissingDependency(DurableError):
-    """A backend extra (boto3 / google-cloud-storage / azure-storage-blob) is not installed."""
+    """A backend extra (boto3 / google-cloud-storage / azure-storage-blob) is
+    not installed. Not a V1 category — it is an install problem, raised before
+    any object is touched."""
+
+    category = "backend"
+
+
+#: Every frozen V1 category, mapped to the exception raised for it. Useful to a
+#: conformance runner; `LeaseError` and `MissingDependency` are deliberately
+#: absent, being a grouping type and an install-time error respectively.
+V1_CATEGORIES = {
+    "not_found": NotFound,
+    "lease_held": LeaseHeld,
+    "lease_fenced": LeaseFenced,
+    "engine_incompatible": EngineIncompatible,
+    "protocol_unsupported": ProtocolUnsupported,
+    "corrupt": Corrupt,
+    "classification_refused": ClassificationRefused,
+    "secret_refused": SecretRefused,
+    "engine": EngineError,
+    "backend": BackendError,
+    "timeout": Timeout,
+    "commit_ambiguous": CommitAmbiguous,
+    "limit_exceeded": LimitExceeded,
+    "closed": Closed,
+}

--- a/chdb/durable/head.py
+++ b/chdb/durable/head.py
@@ -1,0 +1,341 @@
+"""`head.json` — the object's whole mutable state, in one CAS-able document.
+
+The lease and the manifest share a single object on purpose: taking the lease,
+publishing a WAL segment, and replacing the base are all one conditional
+replace, so a cold open costs a couple of round-trips and there is no window
+in which the lease says one thing and the manifest another.
+
+What this module is strict about, and why:
+
+* **Schema.** §4.5 requires a head that fails validation to be `corrupt`, not
+  coerced. A manifest that "mostly parses" is how a reader ends up restoring a
+  base it cannot verify.
+* **Unknown fields.** §4.2 requires a writer to preserve keys it does not
+  recognise at the top level and inside `protocol`, `engine`, `lease` and
+  `manifest`. A future field must survive a round-trip through a writer that
+  predates it, so the document is rebuilt from the one it was read from.
+* **Byte-for-byte equality.** Not required, and not attempted. Key order and
+  whitespace are free; the *semantics* are frozen, which is what lets Node,
+  Go and Python read each other's objects.
+"""
+from __future__ import annotations
+
+import copy
+import json
+from dataclasses import dataclass, field
+from typing import Any, Dict, List, Optional
+
+from .errors import Corrupt, LimitExceeded
+from .protocol import (
+    BACKUP_FORMAT,
+    ENGINE_NAME,
+    MAX_HEAD_BYTES,
+    PROTOCOL_VERSION,
+    validate_object_key,
+    validate_safe_int,
+    validate_sha256,
+)
+
+
+def _require_dict(value: object, where: str) -> Dict[str, Any]:
+    if not isinstance(value, dict):
+        raise Corrupt(f"{where}: expected an object, got {type(value).__name__}")
+    return value
+
+
+def _require_str(value: object, where: str, *, allow_empty: bool = False) -> str:
+    if not isinstance(value, str) or (not allow_empty and not value):
+        raise Corrupt(f"{where}: expected a non-empty string, got {value!r}")
+    return value
+
+
+def _require_str_list(value: object, where: str) -> List[str]:
+    if not isinstance(value, list) or any(not isinstance(v, str) for v in value):
+        raise Corrupt(f"{where}: expected a list of strings, got {value!r}")
+    return list(value)
+
+
+def _unknown(source: Dict[str, Any], known: tuple) -> Dict[str, Any]:
+    return {k: v for k, v in source.items() if k not in known}
+
+
+@dataclass
+class ObjectRef:
+    """A reference to one immutable object: where it is, and what it must be.
+
+    `size` and `sha256` are not belt-and-braces. §4.5 requires both to be
+    checked before the bytes are used, because the two failures they catch are
+    different: a truncated upload has the right prefix, and a replaced object
+    has the right length.
+    """
+
+    key: str
+    size: int
+    sha256: str
+    extra: Dict[str, Any] = field(default_factory=dict, compare=False)
+
+    @classmethod
+    def parse(cls, value: object, where: str) -> "ObjectRef":
+        raw = _require_dict(value, where)
+        return cls(
+            key=validate_object_key(raw.get("key"), f"{where}.key"),
+            size=validate_safe_int(raw.get("size"), f"{where}.size"),
+            sha256=validate_sha256(raw.get("sha256"), f"{where}.sha256"),
+            extra=_unknown(raw, ("key", "size", "sha256")),
+        )
+
+    def to_json(self) -> Dict[str, Any]:
+        out = dict(self.extra)
+        out.update({"key": self.key, "size": self.size, "sha256": self.sha256})
+        return out
+
+
+@dataclass
+class Lease:
+    """Who owns the object, and until when.
+
+    `generation` only ever moves forward, and only on a real change of owner
+    (§4.2): acquiring from released, taking over an expired lease, or a force
+    takeover. A heartbeat renews `expires_at` and leaves the generation alone,
+    which is what lets a fenced writer tell "I was superseded" from "my clock
+    and the head disagree".
+    """
+
+    generation: int
+    owner: Optional[str] = None
+    instance: Optional[str] = None
+    expires_at: Optional[float] = None
+    extra: Dict[str, Any] = field(default_factory=dict, compare=False)
+
+    @property
+    def released(self) -> bool:
+        return self.owner is None
+
+    def held_at(self, now: float, *, clock_skew: float = 0.0) -> bool:
+        """Is this lease still someone's at `now`, allowing for clock skew?
+
+        A held lease with no expiry never expires, so it can only be taken by
+        an explicit force takeover — which is the safe reading of a head we
+        cannot date.
+        """
+        if self.released:
+            return False
+        if self.expires_at is None:
+            return True
+        return now <= self.expires_at + clock_skew
+
+    @classmethod
+    def parse(cls, value: object, where: str) -> "Lease":
+        raw = _require_dict(value, where)
+        generation = validate_safe_int(raw.get("generation"), f"{where}.generation")
+        owner, instance, expires_at = raw.get("owner"), raw.get("instance"), raw.get("expires_at")
+        if owner is None:
+            # §4.2 fixes one representation for a released lease. A head that
+            # nulls the owner but keeps an expiry is not it, and guessing which
+            # half to believe is how a live writer gets fenced by a reader.
+            if instance is not None or expires_at is not None:
+                raise Corrupt(
+                    f"{where}: a released lease must null owner, instance and expires_at together")
+        else:
+            _require_str(owner, f"{where}.owner")
+            _require_str(instance, f"{where}.instance")
+            if isinstance(expires_at, bool) or not isinstance(expires_at, (int, float)):
+                raise Corrupt(f"{where}.expires_at: expected a number, got {expires_at!r}")
+            expires_at = float(expires_at)
+        return cls(
+            generation=generation,
+            owner=owner,
+            instance=instance,
+            expires_at=expires_at,
+            extra=_unknown(raw, ("generation", "owner", "instance", "expires_at")),
+        )
+
+    def to_json(self) -> Dict[str, Any]:
+        out = dict(self.extra)
+        out.update({
+            "generation": self.generation,
+            "owner": self.owner,
+            "instance": self.instance,
+            "expires_at": self.expires_at,
+        })
+        return out
+
+
+@dataclass
+class Manifest:
+    """The database's name, its base checkpoint, and the WAL to replay onto it.
+
+    `wal` is in replay order, and `seq` advances on every published reference —
+    which is what makes a lost CAS response resolvable: the key is unique, so
+    finding it in the manifest proves the commit landed.
+    """
+
+    db: str
+    base: Optional[ObjectRef] = None
+    wal: List[ObjectRef] = field(default_factory=list)
+    seq: int = 0
+    extra: Dict[str, Any] = field(default_factory=dict, compare=False)
+
+    @classmethod
+    def parse(cls, value: object, where: str) -> "Manifest":
+        raw = _require_dict(value, where)
+        base = raw.get("base")
+        wal = raw.get("wal", [])
+        if not isinstance(wal, list):
+            raise Corrupt(f"{where}.wal: expected a list, got {wal!r}")
+        return cls(
+            db=_require_str(raw.get("db"), f"{where}.db"),
+            base=None if base is None else ObjectRef.parse(base, f"{where}.base"),
+            wal=[ObjectRef.parse(v, f"{where}.wal[{i}]") for i, v in enumerate(wal)],
+            seq=validate_safe_int(raw.get("seq"), f"{where}.seq"),
+            extra=_unknown(raw, ("db", "base", "wal", "seq")),
+        )
+
+    def to_json(self) -> Dict[str, Any]:
+        out = dict(self.extra)
+        out.update({
+            "db": self.db,
+            "base": None if self.base is None else self.base.to_json(),
+            "wal": [ref.to_json() for ref in self.wal],
+            "seq": self.seq,
+        })
+        return out
+
+
+@dataclass
+class EngineInfo:
+    """Which engine wrote the object, and which engines can read it.
+
+    `version` is diagnostic — "who wrote this last" — and is deliberately not
+    an equality gate. `backup_format` and `min_reader` are the gate (§4.3), so
+    a later core opens an earlier object instead of refusing it for having a
+    different version string.
+    """
+
+    name: str = ENGINE_NAME
+    version: str = ""
+    backup_format: int = BACKUP_FORMAT
+    min_reader: str = ""
+    extra: Dict[str, Any] = field(default_factory=dict, compare=False)
+
+    @classmethod
+    def parse(cls, value: object, where: str) -> "EngineInfo":
+        raw = _require_dict(value, where)
+        return cls(
+            name=_require_str(raw.get("name"), f"{where}.name"),
+            version=_require_str(raw.get("version"), f"{where}.version"),
+            backup_format=validate_safe_int(raw.get("backup_format"), f"{where}.backup_format"),
+            min_reader=_require_str(raw.get("min_reader"), f"{where}.min_reader"),
+            extra=_unknown(raw, ("name", "version", "backup_format", "min_reader")),
+        )
+
+    def to_json(self) -> Dict[str, Any]:
+        out = dict(self.extra)
+        out.update({
+            "name": self.name,
+            "version": self.version,
+            "backup_format": self.backup_format,
+            "min_reader": self.min_reader,
+        })
+        return out
+
+
+@dataclass
+class ProtocolInfo:
+    version: int = PROTOCOL_VERSION
+    reader_features: List[str] = field(default_factory=list)
+    writer_features: List[str] = field(default_factory=list)
+    extra: Dict[str, Any] = field(default_factory=dict, compare=False)
+
+    @classmethod
+    def parse(cls, value: object, where: str) -> "ProtocolInfo":
+        raw = _require_dict(value, where)
+        return cls(
+            version=validate_safe_int(raw.get("version"), f"{where}.version", minimum=1),
+            reader_features=_require_str_list(
+                raw.get("reader_features", []), f"{where}.reader_features"),
+            writer_features=_require_str_list(
+                raw.get("writer_features", []), f"{where}.writer_features"),
+            extra=_unknown(raw, ("version", "reader_features", "writer_features")),
+        )
+
+    def to_json(self) -> Dict[str, Any]:
+        out = dict(self.extra)
+        out.update({
+            "version": self.version,
+            "reader_features": list(self.reader_features),
+            "writer_features": list(self.writer_features),
+        })
+        return out
+
+
+@dataclass
+class Head:
+    protocol: ProtocolInfo
+    engine: EngineInfo
+    lease: Lease
+    manifest: Manifest
+    #: The document as it was read, so keys this version does not know about
+    #: are written back unchanged.
+    raw: Dict[str, Any] = field(default_factory=dict, compare=False)
+
+    @classmethod
+    def parse(cls, data: bytes) -> "Head":
+        if len(data) > MAX_HEAD_BYTES:
+            raise LimitExceeded(
+                f"head.json is {len(data)} bytes, over the V1 limit of {MAX_HEAD_BYTES}")
+        try:
+            doc = json.loads(data.decode("utf-8"))
+        except (UnicodeDecodeError, ValueError) as exc:
+            raise Corrupt(f"head.json is not valid UTF-8 JSON: {exc}") from exc
+        raw = _require_dict(doc, "head")
+        if "protocol" not in raw and "engine" not in raw and "manifest" in raw:
+            # The shape chdb.durable wrote before V1 was frozen: a lease and a
+            # manifest whose base/WAL are bare key strings, with no protocol or
+            # engine section and no checksums. Say that, rather than report a
+            # missing key and leave the reader guessing which key.
+            raise Corrupt(
+                "head.json has no 'protocol' or 'engine' section, which is the shape the "
+                "pre-V1 chdb.durable prototype wrote. A V1 reader cannot verify its "
+                "checkpoints (they carry no length or SHA-256) and will not restore them; "
+                "export the data with the prototype version and load it into a new object")
+        for required in ("protocol", "engine", "lease", "manifest"):
+            if required not in raw:
+                raise Corrupt(f"head.json is missing {required!r}")
+        return cls(
+            protocol=ProtocolInfo.parse(raw["protocol"], "head.protocol"),
+            engine=EngineInfo.parse(raw["engine"], "head.engine"),
+            lease=Lease.parse(raw["lease"], "head.lease"),
+            manifest=Manifest.parse(raw["manifest"], "head.manifest"),
+            raw=copy.deepcopy(raw),
+        )
+
+    @classmethod
+    def cold(cls, *, db: str, engine_version: str, lease: Lease) -> "Head":
+        """The head a writer creates for an object that does not exist yet."""
+        return cls(
+            protocol=ProtocolInfo(),
+            engine=EngineInfo(
+                name=ENGINE_NAME,
+                version=engine_version,
+                backup_format=BACKUP_FORMAT,
+                min_reader=engine_version,
+            ),
+            lease=lease,
+            manifest=Manifest(db=db),
+        )
+
+    def to_bytes(self) -> bytes:
+        doc = copy.deepcopy(self.raw) if self.raw else {}
+        doc["protocol"] = self.protocol.to_json()
+        doc["engine"] = self.engine.to_json()
+        doc["lease"] = self.lease.to_json()
+        doc["manifest"] = self.manifest.to_json()
+        body = json.dumps(doc, ensure_ascii=False).encode("utf-8")
+        if len(body) > MAX_HEAD_BYTES:
+            # §4.5: the writer is the one that has to notice, while it still
+            # has the option of checkpointing the WAL list away.
+            raise LimitExceeded(
+                f"head.json would be {len(body)} bytes, over the V1 limit of "
+                f"{MAX_HEAD_BYTES}; checkpoint to shorten the WAL list")
+        return body

--- a/chdb/durable/namespace.py
+++ b/chdb/durable/namespace.py
@@ -1,59 +1,91 @@
 """Namespace — addressable objects on one backend, and cross-object query.
 
-`ns.open(id)` mints (or reopens) the object at `<base>/<id>`. `ns.scan()`
-runs the same read-only query across many objects and unions the rows.
-It restores each object in turn (cost is O(number of objects)); it suits
-small fan-outs, not large cross-object analytics.
+`ns.open(id)` mints (or reopens) the object at `<base>/<id>`.
+
+`ns.scan()` runs the same read-only query across several objects and returns
+the rows per object. It restores each one in turn, so the cost is linear in the
+number of objects: it suits a small fan-out, not cross-object analytics. It is
+also *necessarily* sequential — chdb-core allows one active data path per
+process (contract §3.6), so two objects cannot be open here at once. Lifting
+that is engine work; a registry in the binding would only hide it.
 """
 from __future__ import annotations
 
-import json
 import time
-from typing import Iterable, List, Tuple
+from typing import Iterable, List, Optional, Tuple
 
 from .backends import make_backend
-from .errors import LeaseError
-from .object import validate_oid
-from .object import DurableObject
+from .errors import LeaseHeld, NotFound
+from .head import Head
+from .object import DurableObject, validate_oid
+from .protocol import HEAD_KEY
 
 
 class Namespace:
-    def __init__(self, url: str, *, owner: str = None, db: str = "mem"):
+    def __init__(self, url: str, *, owner: Optional[str] = None, db: str = "mem", **object_kwargs):
+        """`object_kwargs` are passed to every `DurableObject` this namespace
+        opens — `lease_ttl`, `clock_skew`, `heartbeat_interval`,
+        `commit_deadline`."""
         self.url = url
         self.owner = owner
         self.db = db
+        self.object_kwargs = dict(object_kwargs)
 
     def open(self, oid: str, *, read_only: bool = False,
              force: bool = False) -> DurableObject:
         backend = make_backend(self.url, oid)
         obj = DurableObject(oid, backend, owner=self.owner, db=self.db,
-                            read_only=read_only)
+                            read_only=read_only, **self.object_kwargs)
         try:
-            obj.open(force=force)  # force=True: crash-recovery takeover (fence-safe)
+            # force=True is the administrative takeover of an unexpired lease;
+            # see DurableObject.open.
+            obj.open(force=force)
         except BaseException:
-            obj.close()  # reclaim the temp dir if open() failed (e.g. lease held)
+            obj.close()  # reclaim the scratch directory if open() failed
             raise
         return obj
 
     def destroy(self, oid: str, *, force: bool = False) -> None:
+        """Delete an object outright.
+
+        **Not part of Durable V1**, which has no destroy and no GC — the
+        protocol deliberately leaves deletion to a later design with orphan
+        grace periods and concurrent-reader protection (contract §8.1). This
+        exists for development and tests; on a shared object it can pull state
+        out from under a reader that is mid-restore.
+        """
         validate_oid(oid)  # a hierarchical/empty id would delete unrelated objects
         backend = make_backend(self.url, oid)
         if not force:
-            # refuse to delete out from under a live writer — that would lose
+            # Refuse to delete out from under a live writer — that would lose
             # its head/checkpoints/WAL and fail its next commit.
-            raw = backend.get("head.json")
+            raw = backend.get(HEAD_KEY)
             if raw:
-                lease = json.loads(raw).get("lease", {})
-                if lease.get("owner") and lease.get("expires_at", 0) >= time.time():
-                    raise LeaseError(
+                try:
+                    lease = Head.parse(raw).lease
+                except Exception:
+                    lease = None
+                if lease is not None and lease.held_at(time.time()):
+                    raise LeaseHeld(
                         f"{oid!r} has an active lease; pass force=True to destroy anyway")
         backend.delete_prefix("")
 
-    def scan(self, sql: str, ids: Iterable[str], fmt: str = "CSV") -> List[Tuple[str, str]]:
-        """Run `sql` read-only against each object; return [(id, result)]."""
+    def scan(self, sql: str, ids: Iterable[str], fmt: str = "CSV",
+             *, missing_ok: bool = False) -> List[Tuple[str, str]]:
+        """Run `sql` read-only against each object; return [(id, result)].
+
+        A missing object raises `not_found`, the same as opening it would.
+        Pass `missing_ok=True` to skip ids that do not exist yet, which is what
+        a fan-out over a tenant list usually wants.
+        """
         out: List[Tuple[str, str]] = []
         for oid in ids:
-            obj = self.open(oid, read_only=True)
+            try:
+                obj = self.open(oid, read_only=True)
+            except NotFound:
+                if missing_ok:
+                    continue
+                raise
             try:
                 out.append((oid, obj.query(sql, fmt).data()))
             finally:

--- a/chdb/durable/object.py
+++ b/chdb/durable/object.py
@@ -1,38 +1,82 @@
-"""The Durable Analytical Object.
+"""The durable object: a chDB database whose authoritative state is in object
+storage, and the state machine that keeps the two honest.
 
-An addressable chDB engine whose authoritative state lives in object storage:
-a base checkpoint (a chDB File backup) plus WAL segments. The lease and the
-manifest live in a *single* `head.json` object so the cold path is few
-round-trips, which is what dominates in-region open latency:
+State lives as a full checkpoint plus a statement WAL under one prefix, with
+the lease and the manifest in a single `head.json`. Putting them together is
+what makes the cold path cheap and the fence exact:
 
-  open (warm) = 1 read (head, with etag) + [ take-lease PUT ‖ base GET ]
-              + restore + 1 re-assert PUT (confirm the lease survived restore)
+  open (warm) = 1 read (head + etag) + [ take-lease CAS ‖ base download ]
+              + restore + 1 re-assert CAS (the lease survived the restore)
 
-The lease is the head's `lease` field; taking it is a conditional replace on
-the head's etag, which *is* the generation fence — a superseded writer's next
-commit fails the compare-and-set. Local MergeTree is the hot working copy;
-the object is a portable folder of open-format files.
+Taking the lease is a conditional replace on the head's ETag, and that CAS
+*is* the generation fence — a superseded writer's next commit fails it. Local
+MergeTree is the hot working copy; the object is a portable folder of
+open-format files.
+
+Three invariants are worth stating outright, because most of the code below
+exists to hold them:
+
+* **Nothing is claimed durable until a CAS says so.** `execute()` runs a
+  statement locally and buffers it. `flush()` publishes it. A caller who
+  promises a request is recoverable elsewhere has to wait for `flush()`.
+* **A lost response is not a failure.** An indeterminate conditional write is
+  reconciled by looking (§5.8), and only reported as `commit_ambiguous` when
+  looking cannot settle it. Reporting success we cannot prove is the one
+  outcome that is never allowed.
+* **Every public statement goes through chdb-core's parser.** The entry gates
+  in `_gate_query` and `_gate_execute` are built on `classify_query`, not on
+  prefixes or regexes over SQL text (§3.3).
+
+See `dev-docs/CHDB_DURABLE_V1_CONTRACT.md` for the contract these implement.
 """
 from __future__ import annotations
 
 import concurrent.futures
-import json
 import math
 import os
 import re
 import shutil
 import tempfile
+import threading
 import time
 import uuid
+import warnings
 from typing import List, Optional
-from xml.sax.saxutils import escape as _xml_escape
 
-from chdb import session as chs
+from .digest import bytes_digest, file_digest, verify_bytes, verify_file
+from .engine import ManagedConnection, engine_version, require_engine_compatible, require_v1_abi
+from .errors import (
+    BackendAmbiguous,
+    BackendError,
+    ClassificationRefused,
+    Closed,
+    CommitAmbiguous,
+    Corrupt,
+    DurableError,
+    LeaseFenced,
+    LeaseHeld,
+    LimitExceeded,
+    NotFound,
+    ProtocolUnsupported,
+    SecretRefused,
+)
+from .head import Head, Lease, ObjectRef
+from .protocol import (
+    BACKUP_FORMAT,
+    COMMIT_BACKOFF_BASE,
+    COMMIT_MAX_ATTEMPTS,
+    DEFAULT_CLOCK_SKEW,
+    DEFAULT_COMMIT_DEADLINE,
+    DEFAULT_LEASE_TTL,
+    HEAD_KEY,
+    HEARTBEAT_TTL_FRACTION,
+    PROTOCOL_VERSION,
+    SUPPORTED_READER_FEATURES,
+    SUPPORTED_WRITER_FEATURES,
+)
+from .wal import WalBuffer, replay
 
-from .backends import Backend
-from .errors import LeaseError
-
-_HEAD = "head.json"
+_NEW, _OPEN, _CLOSING, _CLOSED = "new", "open", "closing", "closed"
 
 
 def validate_oid(oid: str) -> str:
@@ -44,350 +88,815 @@ def validate_oid(oid: str) -> str:
     return oid
 
 
-def _quote_ident(name: str) -> str:
-    """Backtick-quote a ClickHouse identifier so a database name with `-` (or
-    any character needing quoting) is valid in DDL/USE, and can't break out of
-    the statement. Not imported from clickhouse_connect to keep this package
-    free of that dependency."""
-    return "`" + name.replace("\\", "\\\\").replace("`", "\\`") + "`"
+def _positive_finite(value: float, name: str) -> float:
+    if not isinstance(value, (int, float)) or isinstance(value, bool):
+        raise ValueError(f"{name} must be a number of seconds")
+    value = float(value)
+    if not (value > 0) or not math.isfinite(value):
+        # 0/negative/NaN/inf would put expires_at in the past (or never),
+        # breaking single-writer exclusion.
+        raise ValueError(f"{name} must be a positive, finite number of seconds")
+    return value
 
 
 class DurableObject:
-    def __init__(self, oid: str, backend: Backend, *, owner: Optional[str] = None,
-                 db: str = "mem", read_only: bool = False, lease_ttl: float = 60.0):
+    """One addressable durable object. Not shared between processes.
+
+    All public operations serialize on a single per-object lock, together with
+    the heartbeat's head CAS (§5.3). The contract is explicit that "the runtime
+    is single-threaded" and "the native call is synchronous" are not
+    serialization guarantees, so the lock is real rather than notional.
+    """
+
+    def __init__(self, oid: str, backend, *, owner: Optional[str] = None,
+                 db: str = "mem", read_only: bool = False,
+                 lease_ttl: float = DEFAULT_LEASE_TTL,
+                 clock_skew: float = DEFAULT_CLOCK_SKEW,
+                 heartbeat_interval: Optional[float] = None,
+                 commit_deadline: float = DEFAULT_COMMIT_DEADLINE):
         validate_oid(oid)
-        if not (lease_ttl > 0) or not math.isfinite(lease_ttl):
-            # 0/negative/NaN/inf would set expires_at in the past (or never),
-            # breaking single-writer exclusion.
-            raise ValueError("lease_ttl must be a positive, finite number of seconds")
         self.oid = oid
         self.backend = backend
         self.owner = owner or uuid.uuid4().hex[:8]
         self.db = db
         self.read_only = read_only
-        self.ttl = lease_ttl
-        # sanitize the id for the temp-dir prefix — a "/" (e.g. "tenant/user")
-        # would make mkdtemp reference a nonexistent subdir and fail.
-        _safe = re.sub(r"[^A-Za-z0-9._-]", "_", oid)[:64] or "obj"
-        self._work = tempfile.mkdtemp(prefix=f"dao-{_safe}-")
-        self._bkp = os.path.join(self._work, "backup")
-        os.makedirs(self._bkp, exist_ok=True)
-        self._cfg = os.path.join(self._work, "conf.xml")
-        with open(self._cfg, "w") as f:
-            # XML-escape the path — a TMPDIR containing & or < would otherwise
-            # produce malformed config and fail session startup.
-            f.write(f"<clickhouse><backups><allowed_path>{_xml_escape(self._bkp)}"
-                    f"</allowed_path></backups></clickhouse>")
-        self.session: Optional[chs.Session] = None
-        # manifest fields live inside head.json
-        self.base: Optional[str] = None
-        self.wal: List[str] = []
-        self.seq = 0
-        self.generation = 0
+        self.ttl = _positive_finite(lease_ttl, "lease_ttl")
+        self.commit_deadline = _positive_finite(commit_deadline, "commit_deadline")
+        if not isinstance(clock_skew, (int, float)) or isinstance(clock_skew, bool) \
+                or clock_skew < 0 or not math.isfinite(clock_skew):
+            raise ValueError("clock_skew must be a non-negative, finite number of seconds")
+        self.clock_skew = float(clock_skew)
+        if heartbeat_interval is None:
+            heartbeat_interval = self.ttl * HEARTBEAT_TTL_FRACTION
+        self.heartbeat_interval = _positive_finite(heartbeat_interval, "heartbeat_interval")
+        if self.heartbeat_interval > self.ttl * HEARTBEAT_TTL_FRACTION + 1e-9:
+            # §5.7: a heartbeat slower than a third of the TTL cannot survive a
+            # single lost renewal, which is the case it exists for.
+            raise ValueError(
+                f"heartbeat_interval {self.heartbeat_interval}s exceeds a third of "
+                f"lease_ttl {self.ttl}s")
+
+        #: This live instance. The owner string may repeat across processes; a
+        #: lease is only ours if the instance matches too.
+        self._instance = uuid.uuid4().hex
+        self._lock = threading.RLock()
+        self._state = _NEW
+        self._fenced = False
+        self._head: Optional[Head] = None
         self._head_etag: Optional[str] = None
-        self._buf: List[str] = []  # unflushed write statements
         self._lease_expires = 0.0  # our local view of the lease deadline
-        self._instance = uuid.uuid4().hex  # this live instance (owner string may repeat)
+        self._buf = WalBuffer()
+        self._engine: Optional[ManagedConnection] = None
+        self._work: Optional[str] = None
+        self._scratch: Optional[str] = None
+        self._hb_thread: Optional[threading.Thread] = None
+        self._hb_stop: Optional[threading.Event] = None
+
+    # -- introspection ----------------------------------------------------
+    @property
+    def generation(self) -> int:
+        return 0 if self._head is None else self._head.lease.generation
+
+    @property
+    def seq(self) -> int:
+        return 0 if self._head is None else self._head.manifest.seq
+
+    @property
+    def base(self) -> Optional[ObjectRef]:
+        return None if self._head is None else self._head.manifest.base
+
+    @property
+    def wal(self) -> List[ObjectRef]:
+        return [] if self._head is None else list(self._head.manifest.wal)
+
+    @property
+    def pending(self) -> int:
+        """Statements executed locally but not yet published by `flush()`."""
+        return len(self._buf)
+
+    @property
+    def fenced(self) -> bool:
+        return self._fenced
+
+    @property
+    def closed(self) -> bool:
+        return self._state == _CLOSED
+
+    def __enter__(self) -> "DurableObject":
+        return self
+
+    def __exit__(self, exc_type, exc, tb) -> None:
+        self.close()
+
+    def __del__(self):
+        """Reclaim local resources only — never a stand-in for `close()`.
+
+        §5.6 allows a destructor to tidy up but not to impersonate a
+        durability barrier, so this touches no network: it will not flush, and
+        it will not release the lease (which then expires on its own TTL). It
+        exists so a forgotten `close()` does not leave a multi-gigabyte scratch
+        directory and an open engine behind.
+        """
+        try:
+            if self._state != _CLOSED:
+                self._teardown_local()
+        except Exception:
+            pass
 
     def _now(self) -> float:
         return time.time()
 
-    def _head_body(self, now: float) -> bytes:
-        return json.dumps({
-            "lease": {"owner": self.owner, "instance": self._instance,
-                      "generation": self.generation, "expires_at": now + self.ttl},
-            "manifest": {"db": self.db, "base": self.base,
-                         "wal": self.wal, "seq": self.seq},
-        }).encode()
+    # -- head I/O ---------------------------------------------------------
+    def _read_head(self):
+        data, etag = self.backend.get_with_etag(HEAD_KEY)
+        if data is None:
+            return None, None
+        return Head.parse(data), etag
 
-    def _write_head(self) -> None:
-        """Commit the head via compare-and-set on our etag. The CAS *is* the
-        fence: if a newer writer took the lease, our etag is stale and this
-        raises instead of clobbering their state."""
-        now = self._now()
-        new_etag = self.backend.replace_if_match(_HEAD, self._head_body(now), self._head_etag)
-        if new_etag is None:
-            raise LeaseError(f"fenced: object {self.oid} was taken by another writer")
-        self._head_etag = new_etag
-        # same instant as the persisted expires_at (not now+RTT), so renewal
-        # isn't scheduled past the real deadline.
-        self._lease_expires = now + self.ttl
+    def _owns(self, lease: Lease) -> bool:
+        return lease.instance == self._instance and lease.generation == self.generation
 
-    def _start_session(self) -> None:
-        self.session = chs.Session(f"{self._work}?config-file={self._cfg}")
+    def _fence(self) -> None:
+        self._fenced = True
+
+    def _check_protocol(self, head: Head, *, for_writer: bool) -> None:
+        if head.protocol.version > PROTOCOL_VERSION:
+            raise ProtocolUnsupported(
+                f"object declares protocol version {head.protocol.version}; "
+                f"this implementation speaks {PROTOCOL_VERSION}")
+        unknown_reader = sorted(set(head.protocol.reader_features) - SUPPORTED_READER_FEATURES)
+        if unknown_reader:
+            raise ProtocolUnsupported(
+                f"object requires reader feature(s) {unknown_reader} this implementation "
+                f"does not have; refusing to read it")
+        unknown_writer = sorted(set(head.protocol.writer_features) - SUPPORTED_WRITER_FEATURES)
+        if unknown_writer and for_writer:
+            # §4.3: the object is still readable — only writing it would risk
+            # dropping semantics we do not implement.
+            raise ProtocolUnsupported(
+                f"object requires writer feature(s) {unknown_writer} this implementation "
+                f"does not have; open it read-only instead")
+
+    def _check_engine(self, head: Head) -> None:
+        require_engine_compatible(
+            engine_name=head.engine.name,
+            backup_format=head.engine.backup_format,
+            min_reader=head.engine.min_reader,
+        )
 
     # -- lifecycle --------------------------------------------------------
     def open(self, force: bool = False) -> bool:
-        # Read the head first — no chDB session yet, so a held object raises
-        # LeaseError before we hit chDB's one-session-per-process limit.
-        data, etag = self.backend.get_with_etag(_HEAD)
+        """Acquire the object. Returns True if it already existed.
 
-        if data is None:                       # cold: object does not exist yet
-            if not self.read_only:
-                self.generation = 1
-                now = self._now()
-                etag = self.backend.put_if_absent(_HEAD, self._head_body(now))
-                if not etag:
-                    raise LeaseError("object created concurrently by another writer")
-                # adopt the etag from the create itself — a separate head_etag()
-                # could race a concurrent open(force=True) and pick up its etag.
-                self._head_etag = etag
-                self._lease_expires = now + self.ttl
+        `force=True` is the administrative takeover of §5.7: it takes a lease
+        that has *not* expired, which is only correct when the holder is known
+        to be gone. It is safe against a live holder in the sense that the CAS
+        fences them, but their unflushed writes are lost — never reach for it
+        as a retry.
+        """
+        with self._lock:
+            if self._state != _NEW:
+                raise DurableError(f"object {self.oid!r} has already been opened")
+            # Before any storage round-trip: an engine without the Durable V1
+            # ABI cannot serve this object at all, and saying so here beats
+            # failing halfway through an open.
+            require_v1_abi()
+            head, etag = self._read_head()
+
+            if self.read_only:
+                if head is None:
+                    # §5.2: a reader never creates the object it came to read.
+                    raise NotFound(f"object {self.oid!r} does not exist")
+                self._check_protocol(head, for_writer=False)
+                self._check_engine(head)
+                self._head, self._head_etag = head, etag
+                self.db = head.manifest.db  # the object owns its database name
+                try:
+                    self._start_engine()
+                    self._restore()
+                except BaseException:
+                    self._abort_open()
+                    raise
+                self._state = _OPEN
+                return True
+
+            existed = head is not None
+            if head is None:
+                self._create_cold()
+            else:
+                self._check_protocol(head, for_writer=True)
+                self._check_engine(head)
+                # The object owns its database name. Keeping a caller-supplied
+                # one would rewrite the manifest and make the restore build a
+                # database the WAL statements do not name.
+                self.db = head.manifest.db
+                self._take_lease(head, etag, force=force)
+
             try:
-                self._start_session()
-                self.session.query(f"CREATE DATABASE IF NOT EXISTS {_quote_ident(self.db)}")
-                # leave the session in the object's database, same as the restore
-                # path does before replay — so unqualified writes land in the db
-                # that checkpoint()'s `BACKUP DATABASE {db}` captures. Without this
-                # a fresh object's unqualified writes go to `default` and are lost
-                # on the next checkpoint/reopen.
-                self.session.query(f"USE {_quote_ident(self.db)}", "CSV")
-            except Exception:
+                self._start_engine()
+                self._restore()
+                if existed:
+                    # A slow restore can outlast the TTL. Re-assert before
+                    # handing back a writable object, so we never return one
+                    # whose lease already expired and was taken (§5.2 step 7).
+                    self._cas_head()
+                self._engine.use_database(self.db)
+            except BaseException:
                 self._abort_open()
                 raise
-            return False
+            self._state = _OPEN
+            self._start_heartbeat()
+            return existed
 
-        head = json.loads(data)
-        m = head["manifest"]
-        # honor the persisted database name — the object owns it. Keeping a
-        # caller-supplied self.db would rewrite the manifest and make _restore
-        # build the wrong database (WAL replay then fails).
-        self.db = m.get("db", self.db)
-        self.base, self.wal, self.seq = m.get("base"), list(m.get("wal", [])), m.get("seq", 0)
-
-        if self.read_only:
-            base_blob = self.backend.get(self.base) if self.base else None
-            try:
-                self._start_session()
-                self._restore(base_blob)
-            except Exception:
-                self._abort_open()  # free the chDB session on a failed restore
-                raise
-            return True
-
-        lease = head.get("lease", {})
-        owner, exp = lease.get("owner", ""), lease.get("expires_at", 0)
-        inst = lease.get("instance", "")
-        # Held iff a *different live instance* still owns it. An unexpired lease
-        # blocks even the same owner string — it may be another live instance,
-        # so same-owner is NOT a free pass (that would fence the live holder and,
-        # via chDB's one-session limit, abort to owner="" and let a third writer
-        # in). Only released (owner=""), expired, or our own instance is free.
-        # force=True is the crash-recovery takeover: skip the held check and
-        # take the lease anyway. It's safe because the head CAS fences the old
-        # holder — its next commit fails — so we don't need to wait out the TTL.
-        if not force and owner != "" and exp >= self._now() and inst != self._instance:
-            raise LeaseError(
-                f"object held by {owner!r}/{inst[:8]} (gen {lease.get('generation')})")
-        self.generation = lease.get("generation", 0) + 1
-
-        # overlap the lease-take (CAS PUT) with the base download — independent
-        # once we know the base key, so wall-clock ≈ one round-trip not two.
+    def _create_cold(self) -> None:
+        """Create the object with one conditional PUT, or lose the race."""
         now = self._now()
-        with concurrent.futures.ThreadPoolExecutor(max_workers=2) as ex:
-            f_lease = ex.submit(self.backend.replace_if_match, _HEAD, self._head_body(now), etag)
-            f_base = ex.submit(self.backend.get, self.base) if self.base else None
-            new_etag = f_lease.result()
-            base_blob = f_base.result() if f_base else None
-        if new_etag is None:
-            raise LeaseError("lease taken by another writer during open")
-        self._head_etag = new_etag
+        version = engine_version()
+        head = Head.cold(
+            db=self.db,
+            engine_version=version,
+            lease=Lease(generation=1, owner=self.owner, instance=self._instance,
+                        expires_at=now + self.ttl),
+        )
+        etag = self.backend.put_bytes_if_absent(HEAD_KEY, head.to_bytes())
+        if etag is None:
+            raise LeaseHeld(f"object {self.oid!r} was created concurrently by another writer")
+        # Adopt the etag the create itself returned: a follow-up read could
+        # pick up a *different* writer's head and let us CAS over them.
+        self._head, self._head_etag = head, etag
         self._lease_expires = now + self.ttl
-        try:
-            self._start_session()
-            self._restore(base_blob)
-            # A slow restore can outlast lease_ttl; re-assert the lease so we
-            # never return a writable session whose lease already expired and
-            # was taken by another writer. The CAS fails if we were superseded.
-            self._write_head()
-        except Exception:
-            self._abort_open()  # release the just-taken lease so we don't block others
-            raise
-        return True
+
+    def _take_lease(self, head: Head, etag: str, *, force: bool) -> None:
+        now = self._now()
+        lease = head.lease
+        # Held iff a *different live instance* still owns it, allowing for the
+        # clock skew between whoever wrote the expiry and us (§5.7). An
+        # unexpired lease blocks even the same owner *string*: it may be
+        # another live instance, and fencing a live holder is exactly what the
+        # lease exists to prevent.
+        if lease.instance != self._instance and lease.held_at(now, clock_skew=self.clock_skew):
+            if not force:
+                raise LeaseHeld(
+                    f"object {self.oid!r} is held by {lease.owner!r}/{(lease.instance or '')[:8]} "
+                    f"(generation {lease.generation})")
+            # §5.7: taking a lease that has not expired is an administrative
+            # act with a cost, and the cost has to be said out loud — the
+            # previous writer's buffered, unflushed statements are gone.
+            warnings.warn(
+                f"force takeover of {self.oid!r}: the lease held by {lease.owner!r}/"
+                f"{(lease.instance or '')[:8]} had not expired, and any writes it had "
+                f"executed but not flushed are lost",
+                RuntimeWarning, stacklevel=3)
+        head.lease = Lease(
+            generation=lease.generation + 1,  # every takeover moves the fence
+            owner=self.owner,
+            instance=self._instance,
+            expires_at=now + self.ttl,
+            extra=lease.extra,
+        )
+        head.engine.version = engine_version()  # who wrote this object last
+        self._head = head
+
+        # Overlap the lease CAS with the base download: independent once the
+        # base key is known, so the wall clock is one round-trip, not two.
+        base = head.manifest.base
+        body = head.to_bytes()
+        with concurrent.futures.ThreadPoolExecutor(max_workers=2) as pool:
+            cas = pool.submit(self.backend.replace_if_match, HEAD_KEY, body, etag)
+            fetch = pool.submit(self._prefetch_base, base) if base else None
+            try:
+                try:
+                    new_etag = cas.result()
+                except BackendAmbiguous:
+                    # We do not know whether we hold the lease. Re-read: our
+                    # own instance in the head is proof, anything else is a
+                    # refusal.
+                    new_etag = self._confirm_lease_taken()
+            finally:
+                # Harvest the download even when the lease attempt failed, or
+                # its temporary directory — holding a whole base archive —
+                # would be left behind with nobody holding its name.
+                if fetch is not None:
+                    try:
+                        self._prefetched = fetch.result()
+                    except Exception:
+                        self._prefetched = None
+        if new_etag is None:
+            raise LeaseHeld(f"lease on {self.oid!r} was taken by another writer during open")
+        self._head_etag = new_etag
+        self._lease_expires = self._head.lease.expires_at or 0.0
+
+    def _prefetch_base(self, ref: ObjectRef) -> Optional[str]:
+        """Download the base while the lease CAS is in flight.
+
+        The download goes to the object's own scratch, which does not exist
+        yet at this point, so it lands in a private temporary directory and is
+        moved into scratch by `_restore`.
+        """
+        # Keep the key's own basename: ClickHouse decides "archive or
+        # directory" from the file extension, so a `.tar.gz` archive restored
+        # from a path without it is reported as simply not being a backup.
+        path = os.path.join(
+            tempfile.mkdtemp(prefix="chdb-durable-base-"), os.path.basename(ref.key))
+        if not self.backend.download_to_file(ref.key, path):
+            return None
+        return path
+
+    def _confirm_lease_taken(self) -> Optional[str]:
+        current, etag = self._read_head()
+        if current is None:
+            return None
+        if current.lease.instance == self._instance \
+                and current.lease.generation == self._head.lease.generation:
+            self._head = current
+            return etag
+        return None
+
+    def _start_engine(self) -> None:
+        # A private, unique, empty scratch directory per open (§5.2 step 4):
+        # the engine's data path, the archives we download, and the archives we
+        # produce all live under it and are removed on close.
+        safe = re.sub(r"[^A-Za-z0-9._-]", "_", self.oid)[:64] or "obj"
+        self._work = tempfile.mkdtemp(prefix=f"chdb-durable-{safe}-")
+        data = os.path.join(self._work, "data")
+        self._scratch = os.path.join(self._work, "objects")
+        os.makedirs(data, exist_ok=True)
+        os.makedirs(self._scratch, exist_ok=True)
+        self._engine = ManagedConnection(data, self._scratch)
+
+    def _restore(self) -> None:
+        manifest = self._head.manifest
+        base = manifest.base
+        if base is None:
+            self._engine.create_database(self.db)
+        else:
+            local = os.path.join(self._scratch, os.path.basename(base.key))
+            incoming = local + ".incoming"
+            prefetched = getattr(self, "_prefetched", None)
+            self._prefetched = None
+            if prefetched:
+                shutil.move(prefetched, incoming)
+                shutil.rmtree(os.path.dirname(prefetched), ignore_errors=True)
+            elif not self.backend.download_to_file(base.key, incoming):
+                # The manifest committed this key, so its absence is not an
+                # empty object — it is incomplete state. §4.5 forbids falling
+                # back to an older base or opening without it.
+                raise Corrupt(
+                    f"missing base checkpoint {base.key} — durable state incomplete")
+            verify_file(incoming, base, what="base checkpoint")
+            # Only what verified is published under the name the engine will
+            # read (§5.1): a half-transferred archive never occupies it.
+            os.replace(incoming, local)
+            # Restore into the brand-new scratch: RESTORE appends to existing
+            # tables, so V1 only ever restores into an empty target (§3.2).
+            self._engine.restore(self.db, local)
+            os.unlink(local)
+        # Replay in the object's own database. The manifest owns the name, and
+        # unqualified statements were classified against it, so anything else
+        # would silently replay into `default` — invisible to the caller and
+        # dropped by the next `BACKUP DATABASE`.
+        self._engine.use_database(self.db)
+        for ref in manifest.wal:
+            segment = self.backend.get(ref.key)
+            if segment is None:
+                raise Corrupt(f"missing WAL segment {ref.key} — durable state incomplete")
+            verify_bytes(segment, ref, what="WAL segment")
+            # Replay is the internal path, never public execute(): these
+            # statements were classified and logged once already (§4.4).
+            replay(segment, ref.key, lambda sql: self._engine.query(sql, "CSV"))
 
     def _abort_open(self) -> None:
-        """A failure after the lease was taken must not strand it until TTL:
-        release it via CAS (owner="") and drop the partial session."""
-        if not self.read_only and self._head_etag is not None:
-            saved = self.owner
-            try:
-                self.owner = ""  # serialize an empty owner into the release write only
-                self._write_head()
-            except Exception:
-                pass
-            finally:
-                self.owner = saved  # don't leave the instance owner-less for a retry
-            self._head_etag = None  # released here; close() must not release again
-        if self.session is not None:
-            try:
-                self.session.close()
-            except Exception:
-                pass
-            self.session = None
+        """Undo a partial open: release the lease we just took, drop the engine.
 
-    def _restore(self, base_blob: Optional[bytes]) -> None:
-        if self.base and base_blob is None:
-            # the manifest references a base checkpoint but it's gone from
-            # storage — fail loudly rather than silently opening empty and
-            # replacing committed state (same policy as missing WAL segments).
-            raise RuntimeError(f"missing base checkpoint {self.base} — durable state incomplete")
-        if base_blob is not None:
-            local = os.path.join(self._bkp, "base.tar.gz")
-            with open(local, "wb") as f:
-                f.write(base_blob)
-            self.session.query(f"RESTORE DATABASE {_quote_ident(self.db)} FROM File('{local}')", "CSV")
-        else:
-            self.session.query(f"CREATE DATABASE IF NOT EXISTS {_quote_ident(self.db)}")
-        # Replay in the object's database context: WAL statements were executed
-        # against a session whose current database the caller had set, and the
-        # manifest's db is that context (the object owns it). Without this,
-        # unqualified statements silently replay into `default` — invisible to
-        # the caller and dropped by the next `BACKUP DATABASE {db}` checkpoint.
-        self.session.query(f"USE {_quote_ident(self.db)}", "CSV")
-        from .wal import replay
-        for seg_key in self.wal:
-            seg = self.backend.get(seg_key)
-            if seg is None:
-                # every WAL key was committed in the head manifest — a missing
-                # object means incomplete/corrupt state; fail loudly, don't
-                # silently open with committed writes omitted.
-                raise RuntimeError(f"missing WAL segment {seg_key} — durable state incomplete")
-            replay(seg, lambda sql: self.session.query(sql, "CSV"))
+        Leaving a lease stranded until its TTL would block the next writer for
+        no reason — the object was never opened.
+        """
+        if not self.read_only and self._head is not None and self._head_etag is not None:
+            self._head.lease = Lease(generation=self._head.lease.generation,
+                                     extra=self._head.lease.extra)
+            try:
+                self.backend.replace_if_match(HEAD_KEY, self._head.to_bytes(), self._head_etag)
+            except Exception:
+                pass
+            self._head_etag = None  # released here; close() must not release again
+        self._teardown_local()
+
+    def _teardown_local(self) -> None:
+        if self._engine is not None:
+            self._engine.close()
+            self._engine = None
+        prefetched = getattr(self, "_prefetched", None)
+        if prefetched:
+            shutil.rmtree(os.path.dirname(prefetched), ignore_errors=True)
+            self._prefetched = None
+        if self._work:
+            shutil.rmtree(self._work, ignore_errors=True)
+            self._work = self._scratch = None
+
+    # -- guards -----------------------------------------------------------
+    def _require_open(self) -> None:
+        if self._state in (_CLOSED, _CLOSING):
+            raise Closed(f"object {self.oid!r} is closed")
+        if self._state != _OPEN:
+            raise DurableError(f"object {self.oid!r} is not open")
+
+    def _require_writable(self) -> None:
+        self._require_open()
+        if self.read_only:
+            raise ClassificationRefused(
+                f"object {self.oid!r} was opened read-only; only read-only statements are allowed")
+        if self._fenced:
+            raise LeaseFenced(
+                f"object {self.oid!r} lost its lease; this writer is fenced and accepts no writes")
 
     # -- read / write -----------------------------------------------------
+    def _gate_query(self, sql: str):
+        analysis = self._engine.analyze(sql, self.db)
+        # UNKNOWN first: text that did not parse also counts zero statements,
+        # and "could not classify" is the useful half of that answer.
+        if analysis.query_class == "UNKNOWN":
+            raise ClassificationRefused(
+                "chdb-core could not classify this statement; refusing rather than running "
+                "something whose effect is unknown")
+        if analysis.statement_count != 1:
+            raise ClassificationRefused(
+                f"query() takes exactly one statement; chdb-core counted "
+                f"{analysis.statement_count}")
+        if analysis.query_class != "READ_ONLY":
+            raise ClassificationRefused(
+                f"query() takes a read-only statement; chdb-core classified this one as "
+                f"{analysis.query_class}")
+        return analysis
+
+    def _gate_execute(self, sql: str):
+        # Refusal messages never quote the statement: it may carry a
+        # credential, and §6 forbids putting one in an error.
+        analysis = self._engine.analyze(sql, self.db)
+        # UNKNOWN first: text that did not parse also counts zero statements,
+        # and "could not classify" is the useful half of that answer.
+        if analysis.query_class == "UNKNOWN":
+            raise ClassificationRefused(
+                "chdb-core could not classify this statement; refusing rather than logging "
+                "something whose effect is unknown")
+        if analysis.statement_count != 1:
+            raise ClassificationRefused(
+                f"execute() takes exactly one statement; chdb-core counted "
+                f"{analysis.statement_count} (a PARALLEL WITH arm counts as one)")
+        if analysis.query_class == "READ_ONLY":
+            raise ClassificationRefused(
+                "this statement changes nothing — use query(), which does not write the WAL")
+        if analysis.query_class == "CONTROL":
+            raise ClassificationRefused(
+                "control statements (USE/SET/SYSTEM/BACKUP/RESTORE, or a write outside the "
+                "engine) are managed by the durable object and cannot be issued through it")
+        if analysis.query_class == "MUTATING_GLOBAL":
+            raise ClassificationRefused(
+                "this statement changes state outside every database, so a checkpoint could "
+                "not carry it; V1 has no preamble and refuses it (see contract §8.1)")
+        if analysis.has_secrets:
+            raise SecretRefused(
+                "this mutation carries a credential, and a WAL segment is stored in plain "
+                "text; compute the result and log literals instead")
+        if analysis.changes_database_lifecycle:
+            raise ClassificationRefused(
+                "creating, dropping or renaming a database changes the object's own "
+                "container; the durable object manages that, and V1 does not log it")
+        if not analysis.writes_only_target_database:
+            raise ClassificationRefused(
+                f"chdb-core could not prove every write lands in {self.db!r}; a write to "
+                f"another database, to system, to a table function or to a file is not "
+                f"part of this object's state")
+        return analysis
+
     def query(self, sql: str, fmt: str = "CSV"):
-        return self.session.query(sql, fmt)
+        """Run one read-only statement. Nothing is added to the WAL.
+
+        Allowed on a fenced writer: the local database is still exactly what
+        this instance restored and wrote, and §5.7 fences writes, not reads.
+        Read-only SQL carrying a credential runs, because it never reaches the
+        WAL — but a failure from it is reported without the statement text.
+        """
+        with self._lock:
+            self._require_open()
+            analysis = self._gate_query(sql)
+            return self._engine.query(sql, fmt, redact=analysis.has_secrets)
 
     def execute(self, sql: str) -> None:
-        if self.read_only:
-            raise RuntimeError("object opened read-only")
-        self.session.query(sql, "CSV")
-        self._buf.append(sql)
-        # Renew the lease before it lapses so a long-lived writer isn't fenced by
-        # another writer while still active. No extra round-trip until near expiry.
-        if self._now() >= self._lease_expires - self.ttl * 0.25:
-            self._write_head()
+        """Run one mutation locally and buffer it for the next `flush()`.
+
+        Returning does **not** mean the statement is durable — it means it ran
+        here and is queued to be published. Wait for `flush()` before telling
+        anyone else it happened.
+        """
+        with self._lock:
+            self._require_writable()
+            # Refuse an over-limit statement *before* running it: executing
+            # something the WAL cannot hold would leave local state that
+            # object storage can never be made to match (§4.4).
+            if self._buf.would_exceed(sql):
+                raise LimitExceeded(
+                    f"WAL segment already holds {self._buf.nbytes} bytes and this statement "
+                    f"would take it over the V1 limit; flush() first")
+            self._gate_execute(sql)
+            self._engine.query(sql, "CSV")
+            self._buf.append(sql)
 
     # -- durability -------------------------------------------------------
-    def _reconcile_committed(self, *, base=None, wal_key=None) -> bool:
-        """After an ambiguous `_write_head` failure (the CAS response may have
-        been lost), re-read the head. Because our keys are unique, if the head
-        now references our key then the CAS *did* commit — adopt its etag and
-        treat the write as durable, instead of rolling back (which would make a
-        retry double-publish the same boundary)."""
-        data, etag = self.backend.get_with_etag(_HEAD)
-        if data is None:
+    def _publish_bytes(self, ref: ObjectRef, payload: bytes) -> None:
+        try:
+            etag = self.backend.put_bytes_if_absent(ref.key, payload)
+        except BackendAmbiguous as exc:
+            self._confirm_immutable(ref, as_file=False, cause=exc)
+            return
+        if etag is None:
+            raise BackendError(
+                f"{ref.key} already exists; every published key is minted unique, so this "
+                f"is a collision the protocol does not expect")
+
+    def _publish_file(self, ref: ObjectRef, local_path: str) -> None:
+        try:
+            etag = self.backend.put_file_if_absent(ref.key, local_path)
+        except BackendAmbiguous as exc:
+            self._confirm_immutable(ref, as_file=True, cause=exc)
+            return
+        if etag is None:
+            raise BackendError(
+                f"{ref.key} already exists; every published key is minted unique, so this "
+                f"is a collision the protocol does not expect")
+
+    def _confirm_immutable(self, ref: ObjectRef, *, as_file: bool, cause: Exception) -> None:
+        """§5.8: settle an indeterminate PUT by reading the unique key back.
+
+        Matching length and digest means the upload landed. A different body
+        under our own unique key is `corrupt`, not a retryable state. Not
+        being able to look at all leaves the commit genuinely unresolved.
+        """
+        try:
+            if as_file:
+                probe = os.path.join(self._scratch, f"confirm-{uuid.uuid4().hex}")
+                try:
+                    if not self.backend.download_to_file(ref.key, probe):
+                        raise CommitAmbiguous(
+                            f"upload of {ref.key} was indeterminate and the key is not "
+                            f"readable: {cause}")
+                    verify_file(probe, ref, what="uploaded checkpoint")
+                finally:
+                    if os.path.exists(probe):
+                        os.unlink(probe)
+            else:
+                data = self.backend.get(ref.key)
+                if data is None:
+                    raise CommitAmbiguous(
+                        f"upload of {ref.key} was indeterminate and the key is not "
+                        f"readable: {cause}")
+                verify_bytes(data, ref, what="uploaded WAL segment")
+        except BackendError as exc:
+            raise CommitAmbiguous(
+                f"upload of {ref.key} was indeterminate and could not be re-read: {exc}") from exc
+
+    def _reconcile(self, expect: Optional[ObjectRef]) -> bool:
+        """Did our head CAS actually commit, despite what the response said?
+
+        Only a *unique* key can answer this, which is why every published key
+        carries a UUID: if the head now references it at the sequence number we
+        intended, and the lease is still ours, the CAS landed and the response
+        was lost. Ownership is not optional — a new writer that kept our key
+        proves durability, not that we may CAS over them.
+        """
+        if expect is None:
             return False
-        head = json.loads(data)
-        m = head.get("manifest", {})
-        lease = head.get("lease", {})
-        key_ok = (base is not None and m.get("base") == base) or \
-                 (wal_key is not None and wal_key in (m.get("wal") or []))
-        # A retained key proves our write is durable — but we must ALSO still
-        # own the lease. If another writer took over (kept the key), adopting
-        # their etag would let us CAS over them and defeat the fence.
-        owns = (lease.get("instance") == self._instance
-                and lease.get("generation") == self.generation)
-        if key_ok and owns:
-            self._head_etag = etag
-            self._buf = []
-            return True
-        return False
+        try:
+            current, etag = self._read_head()
+        except DurableError:
+            return False
+        if current is None:
+            return False
+        manifest = current.manifest
+        referenced = (manifest.base is not None and manifest.base.key == expect.key) \
+            or any(ref.key == expect.key for ref in manifest.wal)
+        if not referenced or manifest.seq != self._head.manifest.seq:
+            return False
+        if not (current.lease.instance == self._instance
+                and current.lease.generation == self._head.lease.generation):
+            return False
+        self._head, self._head_etag = current, etag
+        self._lease_expires = current.lease.expires_at or 0.0
+        return True
+
+    def _cas_head(self, *, expect: Optional[ObjectRef] = None) -> None:
+        """Commit `self._head` by conditional replace, and mean it.
+
+        The CAS is the fence, so a failure is never retried blindly: we look at
+        what the head says, and either prove the write landed, prove we were
+        superseded, or refresh our ETag and try again inside the deadline.
+        """
+        deadline = self._now() + self.commit_deadline
+        saw_ambiguous = False
+        attempt = 0
+        while True:
+            attempt += 1
+            now = self._now()
+            if self._head.lease.owner is not None:
+                self._head.lease.expires_at = now + self.ttl
+            body = self._head.to_bytes()
+            applied = None
+            try:
+                applied = self.backend.replace_if_match(HEAD_KEY, body, self._head_etag)
+            except BackendAmbiguous:
+                saw_ambiguous = True
+            if applied is not None:
+                self._head_etag = applied
+                self._lease_expires = self._head.lease.expires_at or 0.0
+                return
+            if self._reconcile(expect):
+                return
+            current, current_etag = self._read_head()
+            if current is None or not (
+                    current.lease.instance == self._instance
+                    and current.lease.generation == self._head.lease.generation):
+                self._fence()
+                raise LeaseFenced(
+                    f"object {self.oid!r} was taken by another writer; this commit was fenced")
+            # Still ours: our ETag was stale (a heartbeat and a commit crossed,
+            # or an ambiguous write did land and moved it). Refresh and retry.
+            self._head_etag = current_etag
+            if attempt >= COMMIT_MAX_ATTEMPTS or self._now() >= deadline:
+                if saw_ambiguous:
+                    raise CommitAmbiguous(
+                        f"could not determine whether the head commit for {self.oid!r} "
+                        f"landed after {attempt} attempt(s)")
+                raise BackendError(
+                    f"head commit for {self.oid!r} did not apply after {attempt} attempt(s)")
+            time.sleep(min(COMMIT_BACKOFF_BASE * (2 ** (attempt - 1)),
+                           max(deadline - self._now(), 0.0)))
 
     def flush(self) -> Optional[str]:
-        """Cut a WAL segment and commit the head (RPO boundary). One PUT for the
-        segment + one CAS for the head."""
-        if self.read_only or not self._buf:
+        """Publish the buffered statements as one WAL segment (§5.4).
+
+        One conditional PUT for the segment, one CAS for the head. Returning
+        the segment key means the head commit is confirmed — this is the
+        recovery point another process would restore to.
+        """
+        with self._lock:
+            self._require_writable()
+            return self._flush_locked()
+
+    def _flush_locked(self) -> Optional[str]:
+        if not len(self._buf):
             return None
-        from .wal import WalBuffer
-        wb = WalBuffer()
-        for s in self._buf:
-            wb.append(s)
-        new_seq = self.seq + 1
-        # unique suffix so a retry after an ambiguous head CAS (committed but
-        # the response was lost) never overwrites an already-published segment.
-        key = f"wal/{self.generation}-{new_seq}-{uuid.uuid4().hex[:8]}.jsonl"
-        self.backend.put(key, wb.serialize())
-        # Adopt the new manifest state only if the head CAS succeeds; on failure
-        # roll back (keeping _buf) so a retry publishes a fresh unique segment.
-        # The uploaded-but-unreferenced segment is left as an orphan — see the
-        # GC TODO on checkpoint().
-        prev_seq, prev_wal = self.seq, list(self.wal)
-        self.seq, self.wal = new_seq, prev_wal + [key]
+        payload = self._buf.serialize()
+        size, sha256 = bytes_digest(payload)
+        manifest = self._head.manifest
+        new_seq = manifest.seq + 1
+        # A unique key per attempt: a retry after an indeterminate commit must
+        # never overwrite an already-published segment (§4.4).
+        ref = ObjectRef(
+            key=f"wal/{self.generation}-{new_seq}-{uuid.uuid4().hex[:8]}.jsonl",
+            size=size, sha256=sha256)
+        self._publish_bytes(ref, payload)
+        saved = (list(manifest.wal), manifest.seq)
+        manifest.wal = saved[0] + [ref]
+        manifest.seq = new_seq
         try:
-            self._write_head()
-        except Exception:
-            if self._reconcile_committed(wal_key=key):
-                return key  # CAS actually landed; the response was lost
-            self.seq, self.wal = prev_seq, prev_wal
+            self._cas_head(expect=ref)
+        except BaseException:
+            # The old manifest is still authoritative and the buffer is still
+            # ours, so a retry publishes a fresh unique segment. The uploaded
+            # one is left as an orphan — see the GC note on checkpoint().
+            manifest.wal, manifest.seq = saved
             raise
-        self._buf = []
-        return key
+        self._buf.clear()
+        return ref.key
 
     def checkpoint(self) -> str:
-        """Fold base + WAL into a fresh base; truncate the WAL. One PUT for the
-        base + one CAS for the head.
+        """Fold base + WAL into a fresh base and clear the WAL list (§5.5).
 
-        Checkpoints are *full* snapshots. Incremental checkpoints (ClickHouse
-        `base_backup`) are planned once native BACKUP-to-S3 ships in a chdb
-        release (chdb-core #133/#134), to cut cost for larger objects.
+        Checkpoints are *full* snapshots. An incremental backup records its
+        base by local path, which does not survive object storage, so a
+        portable incremental chain is V2 work (contract §8.1).
 
-        TODO(gc): no garbage collection yet. A superseded base checkpoint, the
-        folded WAL segments, and orphan segments/checkpoints left by failed or
-        ambiguous flushes all remain in object storage indefinitely — only the
-        current base + live WAL are referenced by the head. A future
-        compaction/GC pass should delete blobs the head no longer references
-        (guarded so an in-flight reader of an older head isn't cut off).
+        TODO(gc): V1 has no garbage collection, by design — it also has no
+        destroy, so nothing here may delete. A superseded base, the folded WAL
+        segments, and any orphans left by an indeterminate commit all stay in
+        object storage; only the current base and live WAL are referenced. A
+        later compaction pass has to define orphan grace periods and
+        concurrent-reader protection first (§8.1).
         """
+        with self._lock:
+            self._require_writable()
+            manifest = self._head.manifest
+            new_seq = manifest.seq + 1
+            stamp = uuid.uuid4().hex[:8]
+            name = f"{self.generation}-{new_seq}-{stamp}.tar.gz"
+            local = os.path.join(self._scratch, f"ckpt-{name}")
+            # chdb-core builds the BACKUP statement and quotes both the
+            # database and the path itself (§3.2) — no SQL is assembled here.
+            self._engine.backup(self.db, local)
+            try:
+                size, sha256 = file_digest(local)
+                ref = ObjectRef(key=f"checkpoints/{name}", size=size, sha256=sha256)
+                self._publish_file(ref, local)
+            finally:
+                if os.path.exists(local):
+                    os.unlink(local)
+
+            saved = (manifest.base, list(manifest.wal), manifest.seq,
+                     self._head.engine.version, self._head.engine.min_reader,
+                     self._head.engine.backup_format)
+            manifest.base = ref
+            manifest.wal = []
+            manifest.seq = new_seq
+            # This engine wrote the new base, so it is now the oldest engine
+            # that can restore the object (§4.3). Asked of the connection that
+            # produced the archive, not of the process at large.
+            version = self._engine.engine_version()
+            self._head.engine.version = version
+            self._head.engine.min_reader = version
+            self._head.engine.backup_format = BACKUP_FORMAT
+            try:
+                self._cas_head(expect=ref)
+            except BaseException:
+                (manifest.base, manifest.wal, manifest.seq, self._head.engine.version,
+                 self._head.engine.min_reader, self._head.engine.backup_format) = saved
+                raise
+            # The backup was taken from the live database, so it already
+            # contains everything the buffer held (§5.5 step 6).
+            self._buf.clear()
+            return ref.key
+
+    # -- lease upkeep -----------------------------------------------------
+    def _start_heartbeat(self) -> None:
         if self.read_only:
-            raise RuntimeError("object opened read-only")
-        new_seq = self.seq + 1
-        stamp = uuid.uuid4().hex[:8]  # unique key: retry after an ambiguous CAS won't overwrite
-        local = os.path.join(self._bkp, f"ckpt-{self.generation}-{new_seq}-{stamp}.tar.gz")
-        if os.path.exists(local):
-            os.remove(local)
-        self.session.query(f"BACKUP DATABASE {_quote_ident(self.db)} TO File('{local}')", "CSV")
-        with open(local, "rb") as f:
-            data = f.read()
-        key = f"checkpoints/{self.generation}-{new_seq}-{stamp}.tar.gz"
-        self.backend.put(key, data)
-        # Adopt the new base only after the head CAS succeeds (roll back on failure).
-        prev = (self.seq, self.base, list(self.wal))
-        self.seq, self.base, self.wal = new_seq, key, []
-        try:
-            self._write_head()
-        except Exception:
-            if self._reconcile_committed(base=key):
-                self._buf = []
-                return key  # CAS actually landed; the response was lost
-            self.seq, self.base, self.wal = prev
-            raise
-        self._buf = []
-        return key
+            return
+        self._hb_stop = threading.Event()
+        self._hb_thread = threading.Thread(
+            target=self._heartbeat_loop, name=f"chdb-durable-lease-{self.oid}", daemon=True)
+        self._hb_thread.start()
 
-    def suspend(self) -> None:
-        self.flush()
+    def _stop_heartbeat(self) -> None:
+        # Signal and join *without* the lock: the thread takes it to renew, and
+        # joining while holding it would deadlock close().
+        if self._hb_stop is not None:
+            self._hb_stop.set()
+        thread = self._hb_thread
+        if thread is not None and thread is not threading.current_thread():
+            thread.join(timeout=max(self.heartbeat_interval, 1.0) + 5.0)
+        self._hb_thread = None
 
+    def _heartbeat_loop(self) -> None:
+        """Renew the lease on a cadence, and stop writing if renewal fails.
+
+        A renewal is a head CAS like any other, so it queues behind whatever
+        operation is running rather than racing it for the ETag (§5.7). If
+        renewals keep failing until the lease we believe in has run out, the
+        writer fences *itself*: past that instant another writer may legally
+        take over, and writing anyway is how two writers end up believing they
+        own the same object.
+        """
+        while not self._hb_stop.wait(self.heartbeat_interval):
+            try:
+                with self._lock:
+                    if self._state != _OPEN or self._fenced:
+                        return
+                    self._cas_head()
+            except LeaseFenced:
+                return  # _cas_head already fenced us
+            except DurableError:
+                with self._lock:
+                    if self._now() >= self._lease_expires:
+                        self._fence()
+                        return
+
+    # -- close ------------------------------------------------------------
     def close(self) -> None:
-        try:
-            if self.read_only:
+        """Stop accepting operations, publish what is buffered, release the lease.
+
+        A failure to persist or to release is raised, not swallowed: a caller
+        whose buffered writes did not make it needs to know that from `close()`
+        rather than discover it on the next open. Local resources are released
+        either way.
+        """
+        with self._lock:
+            if self._state in (_CLOSED, _CLOSING):
                 return
-            if self.session is not None:
-                # If we've been fenced, flush() raises — let it propagate so the
-                # caller learns their buffered writes were NOT persisted rather
-                # than close() returning normally and silently dropping them.
-                # (The session + temp dir are still reclaimed by the finally.)
-                self.flush()
-            # release the lease (owner="") via CAS so a next writer takes it cleanly
-            if self._head_etag is not None:
-                self.owner = ""
-                try:
-                    self._write_head()
-                except LeaseError:
-                    pass
-        finally:
-            if self.session is not None:
-                self.session.close()
-                self.session = None
-            # reclaim the per-instance temp dir (config + local backup scratch)
-            shutil.rmtree(self._work, ignore_errors=True)
+            was_open = self._state == _OPEN
+            self._state = _CLOSING
+        self._stop_heartbeat()
+        with self._lock:
+            try:
+                if was_open and not self.read_only:
+                    if self._fenced:
+                        if len(self._buf):
+                            raise LeaseFenced(
+                                f"object {self.oid!r} lost its lease; {len(self._buf)} buffered "
+                                f"statement(s) were not persisted")
+                    else:
+                        self._flush_locked()
+                        if self._head_etag is not None:
+                            self._head.lease = Lease(
+                                generation=self._head.lease.generation,
+                                extra=self._head.lease.extra)
+                            self._cas_head()
+            finally:
+                self._teardown_local()
+                self._state = _CLOSED

--- a/chdb/durable/protocol.py
+++ b/chdb/durable/protocol.py
@@ -1,0 +1,141 @@
+"""What V1 freezes: the baseline this implementation claims, the limits it
+enforces, and the two comparisons that decide whether an object can be opened.
+
+Everything here is contract text turned into code, so a reader can check one
+file against `dev-docs/CHDB_DURABLE_V1_CONTRACT.md` §4 rather than hunting
+constants through the state machine.
+"""
+from __future__ import annotations
+
+import re
+from typing import Optional, Tuple
+
+from .errors import Corrupt
+
+#: Protocol baseline. A head declaring a higher version is refused (§4.3).
+PROTOCOL_VERSION = 1
+
+#: V1 defines no feature names, so any name in a head is one we do not know.
+#: An unknown *reader* feature refuses the open outright; an unknown *writer*
+#: feature allows a read-only open but refuses the writer lease.
+SUPPORTED_READER_FEATURES = frozenset()
+SUPPORTED_WRITER_FEATURES = frozenset()
+
+#: `head.engine.name`. An object written by something else is not ours to open.
+ENGINE_NAME = "chdb"
+
+#: chDB backup archive format generation. A head above this cannot be restored
+#: by this engine, so an older reader fails closed instead of guessing (§4.3).
+BACKUP_FORMAT = 1
+
+#: Frozen size limits (§4.4, §4.5). A writer refuses locally before publishing
+#: anything; a reader must cope with objects up to exactly these sizes.
+MAX_SQL_BYTES = 64 * 1024 * 1024
+MAX_WAL_SEGMENT_BYTES = 128 * 1024 * 1024
+MAX_HEAD_BYTES = 1024 * 1024
+
+#: JSON's safe integer range, which every binding has to agree on (§4.2).
+MAX_SAFE_INT = 2 ** 53 - 1
+
+#: Lease defaults. `heartbeat_interval` must not exceed a third of the TTL
+#: (§5.7); `clock_skew` is the allowance a normal (non-force) takeover adds to
+#: an expiry before it believes the lease is really gone.
+DEFAULT_LEASE_TTL = 60.0
+DEFAULT_CLOCK_SKEW = 5.0
+HEARTBEAT_TTL_FRACTION = 1.0 / 3.0
+
+#: How long a commit keeps trying to prove itself before it reports
+#: `commit_ambiguous`, and how the retries back off (§5.8).
+DEFAULT_COMMIT_DEADLINE = 30.0
+COMMIT_MAX_ATTEMPTS = 5
+COMMIT_BACKOFF_BASE = 0.2
+
+HEAD_KEY = "head.json"
+
+_SHA256_RE = re.compile(r"\A[0-9a-f]{64}\Z")
+
+
+def validate_sha256(value: object, where: str) -> str:
+    """A digest is a lowercase 64-character hex string, or the head is corrupt."""
+    if not isinstance(value, str) or not _SHA256_RE.match(value):
+        raise Corrupt(f"{where}: expected a lowercase hex SHA-256, got {value!r}")
+    return value
+
+
+def validate_object_key(key: object, where: str) -> str:
+    """An object reference is a relative key under the object's own prefix.
+
+    §4.1 spells out what that excludes: an absolute key, a backslash, an empty
+    segment, `.` or `..`. Each of those would let a head point outside the
+    object it belongs to, which is how one tenant's manifest ends up naming
+    another tenant's blob.
+    """
+    if not isinstance(key, str) or not key:
+        raise Corrupt(f"{where}: expected a non-empty object key, got {key!r}")
+    if key.startswith("/") or "\\" in key:
+        raise Corrupt(f"{where}: object key must be relative with '/' separators: {key!r}")
+    for segment in key.split("/"):
+        if segment in ("", ".", ".."):
+            raise Corrupt(f"{where}: object key has an empty or dot segment: {key!r}")
+    return key
+
+
+def validate_safe_int(value: object, where: str, *, minimum: int = 0) -> int:
+    """An integer both a 53-bit and a 64-bit binding can round-trip."""
+    if isinstance(value, bool) or not isinstance(value, int):
+        raise Corrupt(f"{where}: expected an integer, got {value!r}")
+    if value < minimum or value > MAX_SAFE_INT:
+        raise Corrupt(f"{where}: integer {value} outside the cross-language safe range")
+    return value
+
+
+# -- engine version comparison --------------------------------------------
+#
+# chDB versions come in two shapes: a release tag ("26.7.2", "26.7.2.59") and
+# a pre-release of one ("26.7.2-rc.2"). The `min_reader` gate has to order
+# both, and get the one case that matters right: a release is newer than its
+# own pre-releases, so 26.7.2 can read what 26.7.2-rc.2 wrote, and rc.2 cannot
+# read what 26.7.2 wrote.
+
+_PRE_RANK = {"alpha": 0, "a": 0, "beta": 1, "b": 1, "pre": 2, "rc": 3}
+_VERSION_RE = re.compile(
+    r"\A(?P<release>[0-9]+(?:\.[0-9]+)*)"
+    r"(?:[-.](?P<pre>[A-Za-z]+)\.?(?P<pre_num>[0-9]+)?)?"
+    r"(?:[-.+].*)?\Z"
+)
+
+
+def parse_version(text: object) -> Optional[Tuple[Tuple[int, ...], int, int]]:
+    """Order-comparable form of a chDB version, or None if it is not one.
+
+    A suffix this function does not recognise as a pre-release marker (say
+    `-stable`) is a plain release: 26.7.2.59-stable orders as 26.7.2.59.
+    """
+    if not isinstance(text, str):
+        return None
+    m = _VERSION_RE.match(text.strip())
+    if not m:
+        return None
+    release = tuple(int(p) for p in m.group("release").split("."))
+    pre = m.group("pre")
+    if pre is None:
+        return (release, len(_PRE_RANK), 0)  # a release outranks every pre-release
+    rank = _PRE_RANK.get(pre.lower())
+    if rank is None:
+        return (release, len(_PRE_RANK), 0)
+    return (release, rank, int(m.group("pre_num") or 0))
+
+
+def version_lt(left: str, right: str) -> Optional[bool]:
+    """Is `left` older than `right`? None when either side is unorderable.
+
+    None is not "no": a caller gating an open on this has to fail closed,
+    because an unreadable version string is not proof of compatibility.
+    """
+    a, b = parse_version(left), parse_version(right)
+    if a is None or b is None:
+        return None
+    width = max(len(a[0]), len(b[0]))
+    a_release = a[0] + (0,) * (width - len(a[0]))
+    b_release = b[0] + (0,) * (width - len(b[0]))
+    return (a_release, a[1], a[2]) < (b_release, b[1], b[2])

--- a/chdb/durable/wal.py
+++ b/chdb/durable/wal.py
@@ -1,66 +1,120 @@
-"""Write-ahead log — the incremental tier between full checkpoints.
+"""The statement WAL — the incremental tier between full checkpoints.
 
-Each write statement is appended to a buffer; `flush()` writes the buffered
-statements as one segment and records it in the manifest, so RPO ≈ the flush
-interval instead of the (larger) checkpoint interval. On open, the base
-checkpoint is restored, then every WAL segment is replayed in order.
+A segment is UTF-8 JSONL, one `{"sql": ...}` object per line, terminated by a
+newline (§4.4). `flush()` publishes the buffered statements as one immutable
+segment and records it in the manifest, so the recovery point is the flush
+interval rather than the (much longer) checkpoint interval. On open, the base
+is restored and then every segment is replayed in manifest order.
 
-V1 is statement-based: each segment is newline-delimited JSON of the write SQL,
-and `open()` replays those statements to reconstruct state since the base.
+**Replay re-executes the SQL, so only log statements that mean the same thing
+twice.** V1 promises to replay the original statements in order; it does not
+promise a non-deterministic statement produces the rows it produced the first
+time (§4.4), and the caller owns that distinction:
 
-**Correct usage — write only deterministic statements between checkpoints.**
-Because recovery *re-executes* the logged SQL, a statement must produce the same
-result on replay as it did originally:
+  - DO log literal values: `INSERT INTO beliefs VALUES ('k', 'v', '2026-01-01')`.
+  - DON'T log `now()`, `today()`, `rand()`, `generateUUIDv4()`, or
+    `INSERT ... SELECT` from anything that can change underneath you. On replay
+    those yield different rows than the ones that were committed.
+  - Compute a timestamp or an id in the caller and log the literal.
+  - A bulk or non-deterministic transformation belongs in a `checkpoint()`,
+    which snapshots the state that resulted, not the statement that caused it.
 
-  - DO log inserts/updates of *literal* values, e.g.
-    `INSERT INTO mem.beliefs VALUES ('k', 'v', '2026-01-01 00:00:00')`.
-  - DON'T log statements whose result depends on evaluation time or randomness —
-    `now()`, `today()`, `rand()`, `generateUUIDv4()`, `INSERT ... SELECT` from a
-    volatile/streaming source, or anything reading external mutable state. On
-    replay these yield *different* rows than were originally committed.
-  - If you need a timestamp/id, compute it in the caller and log the literal.
-  - Non-deterministic or bulk transformations belong in a `checkpoint()` (which
-    snapshots actual state), not in WAL statements.
-  - Unqualified table names replay with the object's database (the manifest's
-    `db`) as the current database. Statements touching any *other* database
-    must qualify it explicitly.
+Unqualified names are safe: the object pins its own database as current, both
+when it runs a statement and when it replays one.
 
-A future V2 may store row data as Parquet segments (so replay is data, not
-re-execution, and `ns.scan()` can read segments via `s3()` without restoring),
-which would remove this determinism requirement.
+A V2 may store row data as Parquet segments, making replay data rather than
+re-execution and removing the determinism requirement entirely (§8.1).
 """
 from __future__ import annotations
 
 import json
-from typing import List
+from typing import Callable, List
+
+from .errors import Corrupt, LimitExceeded
+from .protocol import MAX_SQL_BYTES, MAX_WAL_SEGMENT_BYTES
+
+
+def encode_statement(sql: str) -> bytes:
+    """One WAL line. Raises `limit_exceeded` for SQL over the frozen cap."""
+    size = len(sql.encode("utf-8"))
+    if size > MAX_SQL_BYTES:
+        raise LimitExceeded(
+            f"statement is {size} bytes of UTF-8, over the V1 limit of {MAX_SQL_BYTES}")
+    return json.dumps({"sql": sql}, ensure_ascii=False).encode("utf-8") + b"\n"
 
 
 class WalBuffer:
-    """Accumulates write statements until flushed to a segment."""
+    """Statements executed locally but not yet published.
+
+    The buffer measures itself as it fills, so a writer refuses an oversized
+    segment *before* running the statement it could not log — running it first
+    would leave local state the object storage can never be made to match.
+    """
 
     def __init__(self):
-        self._stmts: List[str] = []
+        self._lines: List[bytes] = []
+        self._bytes = 0
+
+    def would_exceed(self, sql: str) -> bool:
+        return self._bytes + len(encode_statement(sql)) > MAX_WAL_SEGMENT_BYTES
 
     def append(self, sql: str) -> None:
-        self._stmts.append(sql)
+        line = encode_statement(sql)
+        if self._bytes + len(line) > MAX_WAL_SEGMENT_BYTES:
+            raise LimitExceeded(
+                f"WAL segment would reach {self._bytes + len(line)} bytes, over the V1 limit "
+                f"of {MAX_WAL_SEGMENT_BYTES}; flush() before adding more")
+        self._lines.append(line)
+        self._bytes += len(line)
 
     def __len__(self) -> int:
-        return len(self._stmts)
+        return len(self._lines)
+
+    @property
+    def nbytes(self) -> int:
+        return self._bytes
 
     def serialize(self) -> bytes:
-        return b"".join(json.dumps({"sql": s}).encode() + b"\n" for s in self._stmts)
+        return b"".join(self._lines)
 
     def clear(self) -> None:
-        self._stmts = []
+        self._lines = []
+        self._bytes = 0
 
 
-def replay(segment: bytes, run) -> int:
-    """Replay one segment's statements via `run(sql)`. Returns count."""
-    n = 0
-    for line in segment.splitlines():
-        line = line.strip()
-        if not line:
-            continue
-        run(json.loads(line)["sql"])
-        n += 1
-    return n
+def parse_segment(segment: bytes, key: str) -> List[str]:
+    """The statements in one verified segment, in replay order.
+
+    Strict on purpose: a segment whose bytes passed the size and SHA-256 check
+    but whose contents do not parse is `corrupt`, and §4.5 forbids skipping it
+    or falling back to the base. Committed writes are either all replayed or
+    the open fails.
+    """
+    if segment and not segment.endswith(b"\n"):
+        raise Corrupt(f"WAL segment {key} does not end with a newline")
+    statements: List[str] = []
+    for lineno, line in enumerate(segment.split(b"\n")[:-1] if segment else [], start=1):
+        try:
+            record = json.loads(line.decode("utf-8"))
+        except (UnicodeDecodeError, ValueError) as exc:
+            raise Corrupt(f"WAL segment {key} line {lineno} is not valid UTF-8 JSON: {exc}") from exc
+        if not isinstance(record, dict):
+            raise Corrupt(f"WAL segment {key} line {lineno} is not a JSON object")
+        sql = record.get("sql")
+        if not isinstance(sql, str):
+            raise Corrupt(f"WAL segment {key} line {lineno} has no string 'sql' field")
+        statements.append(sql)
+    return statements
+
+
+def replay(segment: bytes, key: str, run: Callable[[str], object]) -> int:
+    """Replay one segment through `run`, returning the statement count.
+
+    `run` is the object's internal execution path, never the public
+    `execute()`: replay must not re-classify, re-log, or re-buffer statements
+    that were already committed (§4.4).
+    """
+    statements = parse_segment(segment, key)
+    for sql in statements:
+        run(sql)
+    return len(statements)

--- a/dev-docs/CHDB_DURABLE_V1_CONTRACT.md
+++ b/dev-docs/CHDB_DURABLE_V1_CONTRACT.md
@@ -1,0 +1,624 @@
+# chDB Durable V1 Contract
+
+> 版本：**V1**  
+> 适用：`chdb-core`、`chdb`（Python）、`chdb-node`、`chdb-go`、`chdb-rust`，以及直接 `dlopen(libchdb)` 的下游 adapter。  
+> 性质：**规范**。V1 只覆盖单数据库、单 writer、statement WAL 和全量 checkpoint。下游产品的业务状态与接入约束不属于本协议。
+
+## 0. 规范标记
+
+| 标记 | 含义 |
+| --- | --- |
+| **[CORE]** | 必须由 `chdb-core` 判断或执行；binding 不得用 SQL 字符串拼接、前缀或正则实现等价逻辑 |
+| **[FROZEN]** | 跨 binding 的数据模型和行为契约；JSON 的语义冻结，不要求空白、键顺序等字节级一致 |
+| **[BINDING]** | 各 binding 自行实现；API 形式可符合语言习惯，但外部可观察行为必须一致 |
+
+`MUST` / `MUST NOT` 为强制要求；`SHOULD` 为强烈建议，偏离时必须在对应 binding 文档中说明。
+
+一个实现只有在满足全部 V1 要求并通过 §7 conformance 后，才能宣称支持 chDB Durable V1。某种语言晚于 V1 发布实现 binding，不会因此成为协议 V2。
+
+---
+
+## 1. V1 冻结的最小能力
+
+V1 的范围只有：
+
+- 一个 durable object 对应一个 chDB database；
+- 一个 writer，任意数量的只读 opener；
+- 公共 `execute()` 一次只接受一条 statement；
+- database 内 mutation 使用 statement WAL；
+- checkpoint 使用完整的 `BACKUP DATABASE`；
+- object storage 中使用 immutable base/WAL object 和一个 CAS 更新的 `head.json`；
+- lease、heartbeat、fencing、超时与歧义提交 reconcile；
+- base/WAL 的长度和 SHA-256 完整性校验；
+- 所有 binding 调用同一个 core backup/restore/query-analysis ABI。
+
+V1 明确不支持：
+
+- preamble、UDF 或其他 database 之外的持久状态；
+- 多语句公共执行；
+- 多 writer 合并；
+- 一个 object 内的多个 database；
+- Parquet/data WAL；
+- 增量 checkpoint；
+- GC、destroy 和跨 object 事务。
+
+这些能力的归属见 §8。
+
+---
+
+## 2. 分层与职责
+
+```text
+                    +-------------------------------------+
+   [BINDING]        | 语言 API、错误类型、资源释放         |
+                    +-------------------------------------+
+   [FROZEN]         | 对象布局、head、WAL、checksum        |
+                    | lease、CAS、fencing、状态机、错误类别 |
+                    +-------------------------------------+
+   [BINDING]        | provider、认证、重试、超时、reconcile |
+                    | 本地 scratch、流式上传下载、编排       |
+                    +-------------------------------------+
+   [CORE]           | backup、restore、query analysis      |
+                    | connection 与 query execution        |
+                    +-------------------------------------+
+```
+
+判据：
+
+- 只有 ClickHouse parser、AST、catalog 或 backup engine 才能可靠回答的问题，归 core；
+- 云 provider、分布式一致性和生命周期策略，归 binding；
+- 决定对象能否被另一种语言恢复的格式与行为，归 frozen contract。
+
+对象存储 SDK、认证、lease、WAL、CAS、fencing 和远端重试 **MUST NOT** 进入 core。
+
+---
+
+## 3. chdb-core 必需调整 **[CORE]**
+
+### 3.1 V1 ABI 总览
+
+`programs/local/chdb.h` 必须导出：
+
+1. database full backup；
+2. database restore；
+3. 带 statement 数量和目标 database 证明的 query analysis；
+4. 已有的 `chdb_version()`，供 binding 写入和校验 engine identity。
+
+所有新增符号必须进入 Linux 与 macOS export allowlist，并由 C ABI 测试直接覆盖；只暴露 Python wrapper 不算完成 core ABI。
+
+### 3.2 backup / restore ABI
+
+现有 RC 形状可以保留可选 `base_file_path` 作为低层 engine 能力：
+
+```c
+chdb_result * chdb_backup_database_n(
+    chdb_connection conn,
+    const char * database,       size_t database_len,
+    const char * file_path,      size_t file_path_len,
+    const char * base_file_path, size_t base_file_path_len);
+
+chdb_result * chdb_restore_database_n(
+    chdb_connection conn,
+    const char * database,  size_t database_len,
+    const char * file_path, size_t file_path_len);
+```
+
+但 Durable V1 binding 调用 backup 时 **MUST** 传 `NULL/0`，只生成 full backup。`base_file_path` 不属于 V1 durable conformance；端到端可移植的增量链属于 V2。
+
+core 必须保证：
+
+- database identifier 与文件路径分别传入，由 core 构造 AST 和安全引用；binding **MUST NOT** 拼接 `BACKUP` / `RESTORE` SQL；
+- `file_path` 为绝对路径，父目录已存在，并受 `backups.allowed_path` 限制；
+- backup 不覆盖已存在文件；
+- restore 不隐式改变连接的 current database；
+- restore 到已有同名表时不得被 binding 当作 replace。V1 binding 必须恢复到全新 scratch 中的空目标 database；
+- 错误通过标准 `chdb_result` 暴露，并使用标准 result destruction ABI 释放；
+- backup/restore 失败不得留下一个可被 binding 当作成功归档或成功恢复的结果。
+
+### 3.3 当前 classify ABI 不足以支持 V1
+
+只返回：
+
+```text
+(query_class, has_secrets)
+```
+
+是不够的，因为 binding 还无法可靠判断：
+
+- 输入究竟包含一条还是多条可执行 statement；
+- `PARALLEL WITH` 是否展开为多条执行分支；
+- mutation 的所有写目标是否都属于该 durable database；
+- 未限定 database 的对象名按当前 session 设置解析后指向哪里；
+- `RENAME`、`EXCHANGE` 等包含多个对象的语句是否跨 database；
+- 一个看似普通的 `INSERT` 是否实际写向 table function、outfile 或 engine 外部状态。
+- 语句是否创建、删除或重命名 durable database 本身；这属于 object lifecycle，不能作为普通 WAL mutation。
+
+这些都必须由 parser/AST 判断，不能下放给 Python、TypeScript、Go 或 Rust 正则。
+
+### 3.4 V1 query-analysis ABI
+
+在首个 RC 冻结前，应将 `chdb_classify_query_n` 扩充为带 target database 的 analysis ABI；如果现有符号已经对外发布，则新增版本化符号而不是原地破坏 ABI。
+
+推荐的最小 C 形状如下，字段使用固定宽度类型并保留 `struct_size`：
+
+```c
+typedef enum chdb_query_class {
+    CHDB_QUERY_READ_ONLY       = 0,
+    CHDB_QUERY_MUTATING        = 1,
+    CHDB_QUERY_MUTATING_GLOBAL = 2,
+    CHDB_QUERY_CONTROL         = 3,
+    CHDB_QUERY_UNKNOWN         = 4
+} chdb_query_class;
+
+typedef enum chdb_query_analysis_flag {
+    CHDB_QUERY_HAS_SECRETS                 = 1u << 0,
+    CHDB_QUERY_WRITES_ONLY_TARGET_DATABASE = 1u << 1,
+    CHDB_QUERY_CHANGES_DATABASE_LIFECYCLE  = 1u << 2
+} chdb_query_analysis_flag;
+
+typedef struct chdb_query_analysis_v1 {
+    uint32_t struct_size;       /* caller sets to sizeof(struct) */
+    uint32_t statement_count;   /* executable statements; PARALLEL arms count */
+    uint32_t flags;             /* chdb_query_analysis_flag */
+    uint32_t query_class;       /* chdb_query_class; fixed-width ABI field */
+} chdb_query_analysis_v1;
+
+chdb_state chdb_classify_query_n(
+    chdb_connection conn,
+    const char * sql,             size_t sql_len,
+    const char * target_database, size_t target_database_len,
+    chdb_query_analysis_v1 * out_analysis);
+```
+
+名字可以在 core PR 中按现有 ABI 规范调整，但以下语义不能减少：
+
+- caller 必须设置 `struct_size`；core 对过小结构返回 `CHDBError`，不得写出 caller 声明的边界，成功时必须初始化所有 V1 字段；
+- `statement_count`：统计可执行 statement；空输入或解析失败为 `0`，多个顶层 statement 大于 `1`，`PARALLEL WITH` 的执行分支也按多 statement 处理；
+- `CHDB_QUERY_HAS_SECRETS`：AST 含凭证时置位；解析失败不得声称已安全识别；
+- `CHDB_QUERY_WRITES_ONLY_TARGET_DATABASE`：只有在 core 能证明全部持久写目标都位于 `target_database` 时置位；只要存在其他 database、`system`、table function、outfile 或其他 engine 外写目标，就不得置位；
+- `CHDB_QUERY_CHANGES_DATABASE_LIFECYCLE`：`CREATE/DROP/RENAME DATABASE` 等改变 database 容器本身时置位；V1 的冷对象建库由 adapter 内部完成，公共 WAL 不得改变容器生命周期；
+- 未限定 database 的目标必须按照该 connection 实际 parser/session 语义解析，再与 `target_database` 比较；
+- `MUTATING_GLOBAL` 在 V1 中只是准确的诊断分类，公共入口一律拒绝，不进入任何 preamble；
+- `CONTROL` 包括 session mutation、BACKUP/RESTORE/SYSTEM 等受管理操作和外部写；
+- 显式启用 async insert、关闭 insert wait 或降低 mutation 同步保证的 statement setting 必须归为 `CONTROL`；公共 SQL 不得绕过 managed connection 的同步完成策略；
+- parse failure 或尚未覆盖的新 AST 返回 `UNKNOWN`，binding fail closed；
+- analysis 不执行 SQL，不改变 current database、setting 或 query log；
+- 必须正确跨过 `INSERT ... VALUES`、`INSERT ... FORMAT` 和 `EXPLAIN INSERT` 的内联数据；数据中的分号或空行不能被误判为下一条 statement。
+
+V1 `execute(sql)` 的 core gate 固定为：
+
+```text
+statement_count == 1
+AND query_class == MUTATING
+AND WRITES_ONLY_TARGET_DATABASE
+AND NOT CHANGES_DATABASE_LIFECYCLE
+AND NOT HAS_SECRETS
+```
+
+V1 `query(sql)` 的 core gate 固定为：
+
+```text
+statement_count == 1
+AND query_class == READ_ONLY
+```
+
+`READ_ONLY` SQL 即使含 secret 也可以执行，因为它不进入 WAL；binding 必须保证 SQL、错误和 tracing 不泄漏原文 secret。
+
+Python `_chdb.Connection` 必须同步暴露 analysis 的全部字段；继续只返回 `(query_class, has_secrets)` 的旧 tuple 不能供 Durable V1 使用。Node、Go、Rust 和直接 FFI adapter 都必须绑定同一个结构，不能从 Python wrapper 反推或补算缺失字段。
+
+### 3.5 core 验收矩阵
+
+首个 core RC 至少必须覆盖：
+
+- quoted database/table identifier；
+- 未限定 database 的目标解析；
+- 写入 target database 与写入其他 database；
+- 跨 database `RENAME` / `EXCHANGE` / 多目标 DDL；
+- `CREATE/DROP/RENAME DATABASE` lifecycle flag；
+- `INSERT INTO TABLE` 与 `INSERT INTO FUNCTION`；
+- `INTO OUTFILE`；
+- `system` database write；
+- `CREATE FUNCTION`、access entity、named collection → `MUTATING_GLOBAL`；
+- `SET` / `USE` / `SYSTEM` / `BACKUP` / `RESTORE` → `CONTROL`；
+- 显式 async insert 或降低 mutation 同步 setting → `CONTROL`；
+- 普通 SELECT 与 secret-bearing read-only query；
+- 单 statement、多个 statement、尾随分号和注释；
+- `PARALLEL WITH`；
+- `VALUES` / 任意 `FORMAT` 内联数据后的边界；
+- parse failure / 新未知 AST → `UNKNOWN`；
+- analysis 前后 session state 和 query log 不变；
+- backup 绝对路径、allowed path、已存在目标、错误 result 生命周期；
+- restore 到全新目录成功，恢复失败后不能被误认为可用；
+- Linux/macOS symbol export 和 Python surface 调用同一 C ABI。
+
+### 3.6 core 的进程约束
+
+V1 继承当前 engine 约束：
+
+- 一个进程只有一个 active EmbeddedServer / data path；
+- 同一物理路径可以有多个 connection；
+- 仍有旧路径 connection 存活时，打开不同路径必须失败；
+- 全部旧 connection 关闭后才可以绑定新路径。
+
+因此同一进程同一时刻只能激活一个 durable object 的 scratch 路径。批量扫描必须顺序打开，或由上层使用多进程 worker。解除该限制属于 core 的后续架构工作，不由 binding 用进程级 registry 伪装解决。
+
+---
+
+## 4. 对象协议 **[FROZEN]**
+
+### 4.1 对象布局
+
+```text
+<namespace>/<object-id>/
+  head.json
+  checkpoints/<generation>-<seq>-<uuid8>.tar.gz
+  wal/<generation>-<seq>-<uuid8>.jsonl
+```
+
+- `generation` 与 `seq` 为无前导零的十进制整数；
+- `uuid8` 为 UUID4 十六进制小写形式的前 8 位；
+- checkpoint 与 WAL key 每次尝试都必须唯一，并用真正的 conditional create 发布；
+- head 中的 object reference 是相对于 `<namespace>/<object-id>/` 的 key，必须使用 `/` 分隔，不得以 `/` 开头，也不得包含空段、`.` 或 `..`；
+- V1 没有 `preamble/` 或 blob 目录。
+
+### 4.2 `head.json`
+
+UTF-8 JSON，无 BOM。键顺序和空白不冻结；字段类型、含义和状态转换冻结。
+
+```json
+{
+  "protocol": {
+    "version": 1,
+    "reader_features": [],
+    "writer_features": []
+  },
+  "engine": {
+    "name": "chdb",
+    "version": "26.7.2-rc.2",
+    "backup_format": 1,
+    "min_reader": "26.7.2-rc.2"
+  },
+  "lease": {
+    "generation": 3,
+    "owner": "worker-visible-name",
+    "instance": "unique-live-instance-id",
+    "expires_at": 1788230400.0
+  },
+  "manifest": {
+    "db": "mem",
+    "base": {
+      "key": "checkpoints/3-8-acde1234.tar.gz",
+      "size": 1048576,
+      "sha256": "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"
+    },
+    "wal": [
+      {
+        "key": "wal/3-9-acde5678.jsonl",
+        "size": 127,
+        "sha256": "abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789"
+      }
+    ],
+    "seq": 9
+  }
+}
+```
+
+已释放 lease 的表示固定为：
+
+```json
+{
+  "generation": 3,
+  "owner": null,
+  "instance": null,
+  "expires_at": null
+}
+```
+
+规则：
+
+- `lease.generation` 每次从无 owner 状态获取、过期接管或显式 force takeover 时递增；heartbeat 和普通 manifest commit 不递增；
+- `manifest.seq` 每次发布新的 WAL 或 checkpoint 引用时递增；heartbeat 不递增；
+- `engine.version` 为写入端 `chdb_version()` 返回的精确值，只用于诊断和审计，不作为 exact-match gate；
+- `engine.backup_format` 为 chDB backup archive 格式代际；V1 baseline 为 `1`；
+- `engine.min_reader` 为能够读取当前 object 的最低 chDB engine 版本；
+- 从首个 Durable V1 archive 开始，后续 chdb-core release 必须能恢复同一 release 或更早 release 经 `chdb_backup_database_n` 创建的 V1 full backup；只有当 archive 格式代际真的不兼容时，才通过提高 `backup_format` 让旧 reader fail closed；
+- `manifest.base` 为 object reference 或 `null`；
+- 每个 object reference 都必须包含 `key`、字节 `size` 和小写完整 SHA-256；
+- `manifest.wal` 按重放顺序排列；
+- 所有整数必须在跨语言安全整数范围内；
+- binding 写回 head 时必须保留顶层、`protocol`、`engine`、`lease` 和 `manifest` 中不认识的字段。
+
+### 4.3 版本和 feature 协商
+
+- 高于本实现基线的 `protocol.version` → 拒绝打开；
+- 未识别的 `reader_features` → 拒绝读取；
+- 未识别的 `writer_features` → 可以在读检查通过后只读打开，但拒绝取得 writer lease；
+- V1 基线不定义任何非空 feature 名；新增可选语义必须先进入 registry、scenario 和 fixture，不能只改某个 binding；
+- JSON 加字段不自动递增 protocol version，但 writer 必须 round-trip 未知字段。
+
+Engine 兼容性不比较 `engine.version` 是否和当前运行版本完全相等，而是使用显式兼容字段：
+
+```text
+head.engine.backup_format > reader backup-format baseline  -> engine_incompatible
+running chdb_version() < head.engine.min_reader             -> engine_incompatible
+otherwise                                                   -> open
+```
+
+这意味着一个由 `26.7.2-rc.2` 写出的 V1 object，可以由满足 `min_reader` 且支持同一 `backup_format`
+的后续 chdb-core release 打开；`engine.version` 仍保留在 head 中，方便排查“这个 object 最初是谁写的”。
+
+### 4.4 WAL
+
+WAL 为 UTF-8 JSONL，每行一个 statement record：
+
+```json
+{"sql":"INSERT INTO t VALUES (1)"}
+```
+
+规则：
+
+- 一行恰好一个 JSON object，必须以 `\n` 结束；
+- `sql` 必须为字符串，恢复时按 manifest 和行顺序执行；
+- 恢复执行走 adapter 的内部 replay 路径，不能再次进入公共 `execute()`；
+- 整个 segment 在上传前计算 `size` 和 SHA-256；下载后、解析前必须校验二者；
+- writer 必须使用唯一 key 和 conditional create，不能覆盖已发布 segment；
+- V1 单条 `sql` UTF-8 最大 64 MiB，未压缩 WAL segment 最大 128 MiB；writer 超限必须在本地拒绝，reader 必须能处理到该上限；checkpoint 不设协议级大小上限，使用 streaming/provider 限制；
+- SQL 中的 `now()`、`rand()`、UUID、外部可变输入等不会被 binding 自动物化。V1 保证按顺序重放原 statement，不保证非确定性 statement 得到相同结果；调用方对此负责；
+- secret-bearing mutation 已由 §3.4 拒绝，不得出现在 WAL。
+
+### 4.5 checksum 与损坏处理
+
+- base 和 WAL 必须在使用前同时校验 `size` 与 SHA-256；
+- immutable object 缺失、长度不符或 checksum 不符均为 `corrupt`；
+- 不得跳过损坏 WAL、退回旧 base 或返回部分恢复的 session；
+- `head.json` 必须经过严格 schema 校验；未知字段保留不等于已知字段可以类型宽松；
+- V1 `head.json` 最大 1 MiB；writer 必须在超过限制前 checkpoint 或返回 `limit_exceeded`，reader 对超限 head fail closed；
+- JSON 比较是语义比较，不要求不同 binding 产生相同键顺序或空白。
+
+---
+
+## 5. Binding 状态机 **[BINDING + FROZEN BEHAVIOR]**
+
+### 5.1 Backend 最小语义
+
+每个 backend 必须提供等价能力：
+
+```text
+get(key)                               -> bytes | missing
+get_with_etag(key)                     -> (bytes | missing, etag | missing)
+put_file_if_absent(key, local_path)    -> created | already-exists | ambiguous
+put_bytes_if_absent(key, bytes)        -> created | already-exists | ambiguous
+replace_if_match(key, bytes, etag)     -> new-etag | not-replaced | ambiguous
+download_to_file(key, local_path)      -> found | missing
+```
+
+具体方法名和 streaming API 可以不同，但必须满足：
+
+- checkpoint 上传/下载不得强制把整个 archive 一次性载入内存；必须支持文件或流式传输；
+- conditional create 和 conditional replace 必须是 provider 的真实原子条件操作，不能用 HEAD + PUT 模拟；
+- ETag 是 opaque CAS token，不得假设为 MD5；
+- 本地目标文件先写唯一临时路径，校验完成后再原子发布到 scratch 中的最终路径；
+- `delete_prefix` 不属于 V1，因为 V1 没有 destroy/GC；
+- 每个宣称支持的 provider 必须独立通过真实后端 conformance，不能用一个内存 mock 推导其他 provider 兼容。
+
+### 5.2 writer open
+
+writer `open` 必须：
+
+1. 读取并严格校验 head；head 不存在时，用一次 conditional create 原子创建冷 manifest 并取得 generation 1 lease；
+2. 检查 protocol feature、`backup_format` 和 `min_reader`；不得因为 `engine.version` 与当前运行版本不同而拒绝；
+3. 已有 head 用 CAS 获取 lease；正常获取只允许无 owner 或已超过过期与时钟偏差窗口的 lease；
+4. 创建 binding 私有、唯一、空的 scratch 目录；
+5. 下载并校验 base，恢复到空目标 database；base 为 `null` 时创建冷 database；
+6. 下载、校验并顺序重放 WAL；
+7. 在返回对象前再次通过 CAS 续租，确认恢复期间没有失去 lease；
+8. 任一步失败都关闭 partial engine、释放或使 lease 尽快失效，并清理 binding 自己拥有的 scratch。
+
+只读 open：
+
+- head 不存在时返回 `not_found`，不得隐式创建；
+- 不取得 lease；
+- 恢复第一次读取到的 manifest 快照；immutable reference 保证该快照在 writer 后续提交时仍可读；
+- 只允许 `READ_ONLY` query。
+
+### 5.3 operation serialization
+
+每个 durable object 必须有一个明确的 operation queue/mutex。至少以下操作与 heartbeat head CAS 必须以一个确定顺序协调：
+
+```text
+execute / query / flush / checkpoint / close / lease renewal
+```
+
+不得依赖“当前语言运行时单线程”或“native 调用现在是同步的”作为串行化保证。异步 provider I/O 期间也必须维持状态机不变量。
+
+Durable object 必须拥有不向调用方暴露的 managed connection，并把 current database 固定为 manifest database。adapter 必须关闭 async insert 或等待其完成，并把 mutation 配置为同步完成；公共 `SET/USE` 和降低这些保证的 statement setting 已由 core analysis 拒绝。
+
+### 5.4 `query` / `execute` / `flush`
+
+- `query()`：只接受 §3.4 的 query gate；不记录 WAL；secret-bearing read-only SQL 可以执行但不得泄漏；
+- `execute()`：只接受 §3.4 的 execute gate；先本地执行，成功后追加到内存 WAL buffer；失败语句不得记录；
+- `execute()` 成功只表示本地执行与 buffer 追加成功，不表示远端 durable；
+- `flush()`：发布 immutable WAL segment，再 CAS 更新 head；只有 CAS 已确认或按 §5.8 reconcile 为已提交时才返回成功；
+- 需要“调用成功即跨进程持久”的产品必须在自己的成功响应前调用并等待 `flush()`；这属于产品/binding 接入策略，不改变通用 `execute()` 语义。
+
+### 5.5 `checkpoint`
+
+checkpoint 必须在 operation queue 中独占执行：
+
+1. 对包含全部已执行 mutation 的当前本地 database 生成 full backup；
+2. 以流或文件方式上传唯一 checkpoint key；
+3. 记录并校验其 `size` / SHA-256；
+4. CAS head，将 `base` 替换为新 reference、清空 `wal`、递增 `manifest.seq`；
+5. CAS 未提交时，旧 base/WAL manifest 仍是权威；本地未提交 WAL buffer 不得丢失；
+6. CAS 成功后，checkpoint 已经包含的本地 WAL buffer 才可清空。
+
+V1 不使用 incremental base，不依赖 provider 原生 `BACKUP TO S3()`。
+
+### 5.6 `close`
+
+writer close 必须：
+
+1. 停止接受新操作；
+2. 等待 operation queue drain；
+3. 尝试 flush；
+4. flush 成功后 CAS 释放 lease；
+5. 无论远端步骤成功或失败，都关闭 native connection 并清理本地 scratch；
+6. 持久化或 lease release 失败必须对调用者可见。
+
+close 后的任何公共操作返回 `closed`。析构器/`Drop` 可以 best effort 回收资源，但不能冒充一个已成功完成 durability barrier 的显式 close。
+
+### 5.7 lease、heartbeat 与 fencing
+
+- writer 必须周期续租；heartbeat interval 不得大于 lease TTL 的三分之一；
+- 所有 head CAS，包括 heartbeat，都必须携带当前 ETag，并在 operation queue 中协调；
+- writer 一旦无法在本地认为的有效期内确认续租，必须进入 self-fenced 状态，拒绝新的 execute/flush/checkpoint；
+- 普通 takeover 只允许 lease 已过期并超过实现声明的最大 clock-skew allowance；
+- 未过期 lease 只能通过显式管理员 `force` 操作接管；不得在普通重试中自动 force；
+- 每次 takeover 递增 generation；旧 writer 的任何后续 head CAS 都必须失败并映射为 `lease_fenced`；
+- force 操作必须返回或记录明确 warning：原 writer 未 flush 的本地写入可能丢失。
+
+默认 TTL、heartbeat 和 clock-skew allowance 可以由 binding API 配置，但其默认值、单位和生效规则必须写入 binding 文档并进入同一 scenario 测试。
+
+### 5.8 超时和歧义提交 reconcile
+
+provider 请求超时不能自动等同于失败：服务端可能已经提交。
+
+- immutable PUT 响应不确定：重新读取同一唯一 key，`size` 与 SHA-256 一致即视为已上传；内容不一致为 `corrupt`；仍无法判断为 `commit_ambiguous`；
+- head CAS 响应不确定：重新读取 head。如果 intended immutable key 已被引用、manifest/seq 符合预期且 lease instance/generation 仍属于当前 writer，则视为成功；
+- reread 仍为旧 ETag/state 时，可以在同一截止时间内重试 CAS；
+- head 已变且所有权丢失 → `lease_fenced`；
+- 截止时间内仍不能证明成功或失败 → `commit_ambiguous`，不得向调用方谎报成功；
+- 所有重试必须有 deadline、退避和最大次数，且不能跨越 self-fence 状态继续写。
+
+---
+
+## 6. 错误类别 **[FROZEN]**
+
+语言可以用异常、error 值或 `Result` 表示，但以下类别必须可编程区分：
+
+| 类别 | 触发 |
+| --- | --- |
+| `not_found` | 只读打开不存在的 object，或明确要求 existing-only 时不存在 |
+| `lease_held` | 另一个未过期 writer 持有 lease |
+| `lease_fenced` | 当前实例已失去 generation/ETag 所有权 |
+| `engine_incompatible` | object 使用了当前 engine 不能恢复的 backup format，或当前 `chdb_version()` 低于 object 声明的 `min_reader`，或 engine 名称不是 `chdb` |
+| `protocol_unsupported` | protocol version 或 feature 不支持 |
+| `corrupt` | head schema 错、immutable object 缺失、长度/checksum 不符或恢复内容不完整 |
+| `classification_refused` | statement count、class 或目标 database 不满足入口 gate |
+| `secret_refused` | mutation 含 secret，不能写入 WAL |
+| `engine` | core query/backup/restore 错误 |
+| `backend` | provider 网络、认证或非条件冲突错误 |
+| `timeout` | 操作明确未提交并超过 deadline |
+| `commit_ambiguous` | reconcile 后仍不能证明远端是否提交 |
+| `limit_exceeded` | SQL、WAL segment、head 或 provider object 超过 V1/实现已声明限制 |
+| `closed` | 对已完成 close 的对象发起操作；self-fenced writer 返回 `lease_fenced` |
+
+provider 的 precondition failed / 412 必须先解释为 CAS 竞争，再结合 lease/state 映射；不得直接混同为普通 `backend`。
+
+错误消息不得包含 secret-bearing SQL、provider credential 或未脱敏连接参数。
+
+---
+
+## 7. V1 conformance
+
+### 7.1 ABI
+
+- [ ] backup/restore/classify 使用同一 core C ABI，不拼 SQL、不维护 SQL 正则表
+- [ ] query analysis 返回 statement count、secret flag 和 target-database-only proof
+- [ ] 所有平台导出相同符号，Python surface 只是同一 ABI 的 wrapper
+- [ ] 互通参与者使用相同 Durable V1 contract/fixtures，并覆盖 producer-version 不同但兼容、reader 低于 `min_reader`、`backup_format` 过新的三类 engine gate
+
+### 7.2 格式 fixtures
+
+- [ ] `empty-object`
+- [ ] read-only open missing object → `not_found`
+- [ ] `checkpoint-only`
+- [ ] `checkpoint-plus-wal`
+- [ ] `quoted-database-name`
+- [ ] `missing-base` / `missing-wal` → `corrupt`
+- [ ] `bad-base-size` / `bad-base-sha256` → `corrupt`
+- [ ] `bad-wal-size` / `bad-wal-sha256` → `corrupt`
+- [ ] `unknown-reader-feature` → 拒绝打开
+- [ ] `unknown-writer-feature` → 允许只读、拒绝 writer lease
+- [ ] `future-protocol-version` → 拒绝打开
+- [ ] `producer-version-differs-but-compatible` → open
+- [ ] `engine-reader-too-old` → `engine_incompatible`
+- [ ] `backup-format-too-new` → `engine_incompatible`
+- [ ] 未知字段经过 `open → execute → flush → checkpoint → close` 后仍保留
+- [ ] 不同 JSON 键顺序和空白可以互读
+
+### 7.3 分类 scenarios
+
+- [ ] query/execute 方法名不能绕过 analysis
+- [ ] 多语句与 `PARALLEL WITH` 被拒绝
+- [ ] 写其他 database、system 或外部 sink 被拒绝
+- [ ] database lifecycle statement 被拒绝
+- [ ] 所有 `MUTATING_GLOBAL` 被拒绝
+- [ ] secret mutation 被拒绝且错误不泄漏 SQL
+- [ ] secret-bearing `READ_ONLY` 可执行但不写 WAL
+- [ ] SQL/WAL/head 超过冻结上限时返回 `limit_exceeded`
+- [ ] UNKNOWN fail closed
+
+### 7.4 fault matrix
+
+- [ ] object/head 条件创建竞争只有一个 writer 成功
+- [ ] WAL PUT 成功、head CAS 失败时旧 manifest 有效且本地 buffer 保留
+- [ ] head CAS 已提交但响应丢失时能 reconcile 为成功
+- [ ] 无法证明 CAS 结果时返回 `commit_ambiguous`
+- [ ] checkpoint PUT 成功、head CAS 失败时旧 base/WAL 仍可恢复
+- [ ] restore/replay 失败时关闭 partial engine，不返回部分 session
+- [ ] heartbeat 与 flush/checkpoint 并发不破坏 ETag/seq
+- [ ] heartbeat 失败至过期时 writer self-fence
+- [ ] force takeover 后旧 writer 下一次提交被 fence
+- [ ] close flush 失败时错误可见且本地资源仍释放
+
+### 7.5 跨 binding
+
+- [ ] 每个 writer 产出的 fixture 至少由另外两个 binding 读取
+- [ ] 至少一个真实 object backend 通过完整条件写和故障测试
+- [ ] 每个额外声明支持的 provider 独立通过 provider conformance
+- [ ] Python、Node、Go 使用相同 protocol/scenario/fixture 权威来源
+- [ ] Rust 在 Session/path lifecycle 完成后加入同一组 V1 测试；它的晚实施不是协议 V2
+
+---
+
+## 8. V2 与后续工作
+
+以下能力不进入 V1；开始实现前必须分别形成 proposal、feature 名、fixtures 和升级/降级策略。
+
+### 8.1 chdb-durable 协议 V2 候选
+
+1. **preamble / global state**：SQL UDF、WASM blob、压缩、删除语义、driver 缺失与重放失败策略。V1 对全部 `MUTATING_GLOBAL` fail closed。
+2. **增量 checkpoint**：解决 base chain 的跨机器寻址、链完整性、压缩、合并、最大链长和 GC 后再进入协议；不能直接持久化本地绝对 `base_file_path`。
+3. **Parquet/data WAL**：定义数据 schema、DDL 与数据顺序、mutation 表达、MV 重放和 statement/data WAL 混用规则后再引入。
+4. **GC / destroy**：安全枚举引用、orphan grace period、并发 reader 保护、恢复窗口和显式危险操作确认。
+5. **多 writer**：需要冲突模型、提交顺序、幂等键和 merge/rebase 语义，不能只放宽 lease。
+6. **多 database / 跨 object 事务**：需要新的 manifest 和原子提交模型。
+7. **engine compatibility matrix 与在线迁移**：V1 已定义后续 engine 读取早期 full backup 的兼容 gate（`backup_format` + `min_reader`）；更复杂的在线迁移、schema migration、非兼容 archive format 切换和回滚策略后续设计。
+
+### 8.2 不属于协议版本的发布顺序
+
+- 具体下游 adapter 的产品策略不进入本 contract；
+- `chdb-rust` 先修复 Session/path registry 与资源生命周期，再实现同一个 Durable V1 binding；
+- 同进程多 durable path 并行必须先改变 chdb-core EmbeddedServer/path 生命周期模型；这是 core 后续能力，不因实现时间自动变成协议 V2；
+- 某个 provider 或语言 binding 晚发布，只表示实现进度，不自动成为 V2；
+- 下游应用数据库以外的 archive、配置或业务事务，应由该应用自己的 binding/integration 规范定义，除非未来证明存在跨应用的通用协议需求。
+
+---
+
+## Appendix A. 相对旧草案的 V1 收敛项
+
+本次冻结前调整如下：
+
+1. 删除 V1 `preamble/`、blob、UDF replay、相关 warning 和 fixtures；所有 `MUTATING_GLOBAL` 改为 fail closed。
+2. 公共 `query()` / `execute()` 都限制为一个可执行 statement；`PARALLEL WITH` 不作为单 statement 绕过。
+3. core classify 从 `(class, has_secrets)` 扩展为 query analysis，新增 statement count 和“全部写目标只属于指定 database”的证明。
+4. `execute()` 只接受单条、无 secret、仅写 durable database 的 `MUTATING`；跨 database、system 和 external sink 拒绝。
+5. JSON 从“跨 binding 字节完全相同”改为严格 schema 下的语义兼容；键顺序与空白不冻结。
+6. base/WAL reference 新增长度和 SHA-256，恢复前强制校验。
+7. checkpoint backend 从整对象 `bytes` 改为必须支持文件或 streaming，避免 full backup 全量驻留内存。
+8. 明确每 object operation queue，heartbeat 也参与同一 CAS 串行化。
+9. 明确 heartbeat、自我 fencing、过期 takeover 与显式未过期 force takeover。
+10. 补充 `not_found`、`engine_incompatible`、`timeout`、`commit_ambiguous` 和 `closed` 错误类别。
+11. 删除 V1 `delete_prefix` / destroy；GC 和销毁留到后续安全设计。
+12. 增量 checkpoint、Parquet/data WAL、多 writer、多 database 和跨版本 migration 明确移入 V2 候选。

--- a/docs/durable/index.mdx
+++ b/docs/durable/index.mdx
@@ -116,12 +116,12 @@ A local TTL limits the logical contents of the current database. V1 does not del
 
 ## Binding status {#binding-status}
 
-Status as of September 4, 2026:
+Status as of September 8, 2026:
 
 | Component | Status |
 | --- | --- |
 | chdb-core | [PR #202](https://github.com/chdb-io/chdb-core/pull/202) is merged; [v26.7.2-rc.2](https://github.com/chdb-io/chdb-core/releases/tag/v26.7.2-rc.2) provides the backup, restore, and query-analysis C ABI |
-| Python | [`chdb.durable`](https://github.com/chdb-io/chdb/pull/616) shipped in v4.3.0; the implementation predates the frozen V1 protocol and still needs full V1 conformance work |
+| Python | [`chdb.durable`](https://github.com/chdb-io/chdb/pull/616) shipped in v4.3.0 and has been brought onto the frozen V1 protocol: it calls the v26.7.2-rc.2 backup, restore, and query-analysis ABI, writes the V1 `head.json`, and passes the §7.2/§7.3/§7.4 fixtures, scenarios, and fault matrix locally. Cross-binding fixture exchange is still pending |
 | Node.js | [PR #90](https://github.com/chdb-io/chdb-node/pull/90) implements the pure TypeScript control plane; the native adapter and npm release are still pending |
 | Go | Planned against the same core ABI and V1 conformance suite |
 | Rust | The Session and path lifecycle comes first, followed by the same Durable V1 protocol |

--- a/tests/test_durable.py
+++ b/tests/test_durable.py
@@ -1,463 +1,1014 @@
-"""chdb.durable V1 tests — runnable as a plain script.
+"""chdb.durable Durable V1 conformance tests — runnable as a plain script.
 
     DAO_TEST_URL=local:/tmp/dao-test python tests/test_durable.py
     DAO_TEST_URL=s3://dao/ns CHDB_DURABLE_S3_ENDPOINT=http://127.0.0.1:9000 \
         AWS_ACCESS_KEY_ID=minioadmin AWS_SECRET_ACCESS_KEY=minioadmin \
         python tests/test_durable.py
+
+The sections mirror `dev-docs/CHDB_DURABLE_V1_CONTRACT.md` §7: format
+fixtures, classification scenarios, and the fault matrix. Everything runs
+sequentially on purpose — chdb-core allows one active data path per process
+(§3.6), so two durable objects are never open at the same time.
 """
+import json
 import os
 import tempfile
 import time
-
-import json
+import warnings
 
 from chdb import durable as cd
+from chdb.durable import protocol, wal as wal_mod
 from chdb.durable.backends import make_backend
-from chdb.durable.errors import LeaseError
+from chdb.durable.engine import engine_has_v1_abi, engine_version
+
+# Durable V1 needs chdb-core's backup / restore / query-analysis ABI (26.7.2-rc.2
+# or newer). On an older engine there is nothing here to test, so skip the module
+# under pytest rather than fail 49 checks for one missing dependency.
+if not engine_has_v1_abi():
+    _REASON = ("chdb-core does not export the Durable V1 ABI "
+               "(backup_database / restore_database / classify_query)")
+    try:
+        import pytest
+
+        pytest.skip(_REASON, allow_module_level=True)
+    except ImportError:
+        raise SystemExit(f"skipped: {_REASON}")
+from chdb.durable.errors import (
+    BackendAmbiguous,
+    BackendError,
+    ClassificationRefused,
+    Closed,
+    CommitAmbiguous,
+    Corrupt,
+    EngineError,
+    EngineIncompatible,
+    LeaseFenced,
+    LeaseHeld,
+    LimitExceeded,
+    NotFound,
+    ProtocolUnsupported,
+    SecretRefused,
+)
 
 URL = os.getenv("DAO_TEST_URL", "local:" + tempfile.mkdtemp(prefix="dao-test-"))
+HEAD = protocol.HEAD_KEY
+
+_PASSED = []
 
 
-def _fresh_ns():
-    ns = cd.Namespace(URL, owner="w1")
-    for oid in ("obj-a", "obj-b", "obj-f"):
-        ns.destroy(oid)
+def _fresh_ns(**kwargs):
+    return cd.Namespace(URL, owner="w1", **kwargs)
+
+
+def _put_head(oid, doc, *, ns=None):
+    """Replace an object with a hand-written head — the fixture mechanism."""
+    ns = ns or _fresh_ns()
+    ns.destroy(oid, force=True)
+    backend = make_backend(URL, oid)
+    assert backend.put_bytes_if_absent(HEAD, json.dumps(doc).encode()) is not None
+    return backend
+
+
+def _head_of(oid):
+    return json.loads(make_backend(URL, oid).get(HEAD))
+
+
+def _valid_head(**overrides):
+    """A schema-valid head for a cold object, before overrides."""
+    doc = {
+        "protocol": {"version": 1, "reader_features": [], "writer_features": []},
+        "engine": {"name": "chdb", "version": engine_version(),
+                   "backup_format": 1, "min_reader": engine_version()},
+        "lease": {"generation": 1, "owner": None, "instance": None, "expires_at": None},
+        "manifest": {"db": "mem", "base": None, "wal": [], "seq": 0},
+    }
+    for section, patch in overrides.items():
+        doc[section].update(patch)
+    return doc
+
+
+def _seeded(oid, rows=100, *, db="mem", checkpoint=True, ns=None):
+    """An object holding `rows` rows in `db`.t, checkpointed by default."""
+    ns = ns or _fresh_ns(db=db)
+    ns.destroy(oid, force=True)
+    obj = ns.open(oid)
+    obj.execute("CREATE TABLE t (n Int64) ENGINE=MergeTree ORDER BY n")
+    obj.execute(f"INSERT INTO t SELECT number FROM numbers({rows})")
+    if checkpoint:
+        obj.checkpoint()
+    else:
+        obj.flush()
+    obj.close()
     return ns
 
 
-def test_checkpoint_roundtrip(ns):
-    o = ns.open("obj-a")
-    assert o.query("SELECT 1", "CSV")  # engine live
-    o.execute("CREATE TABLE mem.t (n Int64) ENGINE=MergeTree ORDER BY n")
-    o.execute("INSERT INTO mem.t SELECT number FROM numbers(1000)")
-    o.checkpoint()
-    o.close()
-
-    r = ns.open("obj-a")
-    got = r.query("SELECT count() FROM mem.t", "CSV").data().strip()
-    r.close()
-    assert got == "1000", f"checkpoint restore: {got}"
-    print("  checkpoint round-trip: 1000 rows restored from base ✓")
-
-
-def test_wal_incremental(ns):
-    # append after checkpoint, flush only (no new checkpoint) -> survives via WAL
-    o = ns.open("obj-a")
-    o.execute("INSERT INTO mem.t SELECT number FROM numbers(1000, 500)")  # +500
-    seg = o.flush()
-    assert seg and seg.startswith("wal/"), seg
-    o.close()
-
-    r = ns.open("obj-a")
-    got = r.query("SELECT count() FROM mem.t", "CSV").data().strip()
-    r.close()
-    assert got == "1500", f"WAL replay: {got}"
-    print("  WAL incremental: 1500 rows (base 1000 + WAL 500 replayed) ✓")
-
-
-def test_checkpoint_folds_wal(ns):
-    o = ns.open("obj-a")
-    key = o.checkpoint()  # fold base+WAL into a new base
-    assert o.base == key and o.wal == []
-    o.close()
-    r = ns.open("obj-a")
-    got = r.query("SELECT count() FROM mem.t", "CSV").data().strip()
-    r.close()
-    assert got == "1500", got
-    print("  checkpoint folds WAL: base=1500, wal=[] ✓")
-
-
-def test_lease_exclusion(ns):
-    o = ns.open("obj-b")
-    o.execute("CREATE TABLE mem.t (n Int64) ENGINE=MergeTree ORDER BY n")
-    other = cd.Namespace(URL, owner="w2")  # a *different* writer
+def _count(ns, oid, *, db="mem"):
+    reader = ns.open(oid, read_only=True)
     try:
-        other.open("obj-b")  # must be refused before any second session opens
-        raise AssertionError("second writer should have raised LeaseError")
-    except LeaseError:
-        pass
-    o.close()
-    print("  lease exclusion: different writer refused ✓")
+        return reader.query(f"SELECT count() FROM `{db}`.t", "CSV").data().strip()
+    finally:
+        reader.close()
 
 
-def test_fencing(ns):
-    o = ns.open("obj-f")
-    o.execute("CREATE TABLE mem.t (n Int64) ENGINE=MergeTree ORDER BY n")
-    # an external writer takes over: overwrite head at a higher generation,
-    # invalidating o's cached etag
-    b = make_backend(ns.url, "obj-f")
-    data, etag = b.get_with_etag("head.json")
-    h = json.loads(data)
-    h["lease"] = {"owner": "w2", "generation": h["lease"]["generation"] + 5,
-                  "expires_at": 9e12}
-    assert b.replace_if_match("head.json", json.dumps(h).encode(), etag) is not None
+def _expect(kind, fn, *args, **kwargs):
     try:
-        o.flush()  # o's commit must fail the compare-and-set
-        raise AssertionError("o should be fenced after takeover")
-    except LeaseError:
-        pass
-    # close() must also surface the fence (buffered writes can't be persisted)
-    # rather than swallow it and return normally.
+        fn(*args, **kwargs)
+    except kind as exc:
+        return exc
+    raise AssertionError(f"expected {kind.__name__}")
+
+
+class FaultyBackend:
+    """A backend that lies about the outcome of a write, on request.
+
+    Every hook is "what the provider told us", not "what happened": that is
+    the whole point of the §5.8 reconcile, and a test that only ever injects
+    clean failures never exercises it.
+    """
+
+    def __init__(self, inner):
+        self._inner = inner
+        self.fail_replace = None      # None | "ambiguous_after" | "lost" | "error"
+        self.fail_create = None       # None | "ambiguous_before" | "ambiguous_after"
+        self.hide_head = False
+
+    def __getattr__(self, name):
+        return getattr(self._inner, name)
+
+    def get_with_etag(self, key):
+        if self.hide_head and key == HEAD:
+            return (None, None)
+        return self._inner.get_with_etag(key)
+
+    def _conditional_create(self, call, key, *rest):
+        mode = self.fail_create
+        if mode == "ambiguous_before":
+            raise BackendAmbiguous(f"injected: create {key} never sent a response")
+        result = call(key, *rest)
+        if mode == "ambiguous_after":
+            raise BackendAmbiguous(f"injected: create {key} landed but the response was lost")
+        return result
+
+    def put_bytes_if_absent(self, key, data):
+        return self._conditional_create(self._inner.put_bytes_if_absent, key, data)
+
+    def put_file_if_absent(self, key, path):
+        return self._conditional_create(self._inner.put_file_if_absent, key, path)
+
+    def replace_if_match(self, key, data, etag):
+        mode = self.fail_replace
+        if mode == "error":
+            raise BackendError(f"injected: replace {key} failed")
+        if mode == "lost":
+            return None  # the CAS did not apply, and the object is still ours
+        result = self._inner.replace_if_match(key, data, etag)
+        if mode == "ambiguous_after":
+            raise BackendAmbiguous(f"injected: replace {key} landed but the response was lost")
+        return result
+
+
+# =====================================================================
+# §7.2 format fixtures
+# =====================================================================
+
+def test_empty_object():
+    ns = _fresh_ns()
+    ns.destroy("f-empty", force=True)
+    obj = ns.open("f-empty")
+    assert obj.base is None and obj.wal == [] and obj.seq == 0
+    assert obj.generation == 1
+    obj.close()
+    doc = _head_of("f-empty")
+    assert doc["protocol"] == {"version": 1, "reader_features": [], "writer_features": []}
+    assert doc["engine"]["name"] == "chdb" and doc["engine"]["backup_format"] == 1
+    # a released lease is one fixed shape, not "owner set to empty string"
+    assert doc["lease"] == {"generation": 1, "owner": None, "instance": None,
+                            "expires_at": None}
+    assert doc["manifest"] == {"db": "mem", "base": None, "wal": [], "seq": 0}
+    _PASSED.append("empty-object: cold create publishes a V1 head, lease released on close")
+
+
+def test_readonly_missing_object():
+    ns = _fresh_ns()
+    ns.destroy("f-absent", force=True)
+    _expect(NotFound, ns.open, "f-absent", read_only=True)
+    # and it must not have created anything on the way past
+    assert make_backend(URL, "f-absent").get(HEAD) is None
+    _PASSED.append("read-only open of a missing object: not_found, nothing created")
+
+
+def test_checkpoint_only():
+    ns = _seeded("f-ckpt", 1000)
+    doc = _head_of("f-ckpt")
+    assert doc["manifest"]["base"]["key"].startswith("checkpoints/")
+    assert doc["manifest"]["wal"] == []
+    assert _count(ns, "f-ckpt") == "1000"
+    _PASSED.append("checkpoint-only: 1000 rows restored from the base alone")
+
+
+def test_checkpoint_plus_wal():
+    ns = _seeded("f-both", 1000)
+    obj = ns.open("f-both")
+    obj.execute("INSERT INTO t SELECT number FROM numbers(1000, 500)")
+    key = obj.flush()
+    assert key.startswith("wal/")
+    obj.close()
+    assert _count(ns, "f-both") == "1500"
+    # a checkpoint folds the WAL away without changing what you can read
+    obj = ns.open("f-both")
+    folded = obj.checkpoint()
+    assert obj.base.key == folded and obj.wal == []
+    obj.close()
+    assert _count(ns, "f-both") == "1500"
+    _PASSED.append("checkpoint-plus-wal: base 1000 + WAL 500 replayed, then folded")
+
+
+def test_quoted_database_name():
+    # 'my-mem-db' is only valid backtick-quoted; unquoted it parses as
+    # subtraction, so every create/backup/restore would fail. chdb-core quotes
+    # the name for us — this proves it does, through the whole round trip.
+    ns = _seeded("f-quoted", 42, db="my-mem-db", checkpoint=False)
+    assert _count(ns, "f-quoted", db="my-mem-db") == "42"
+    _PASSED.append("quoted-database-name: my-mem-db round-trips through backup and replay")
+
+
+def test_missing_base_and_wal():
+    ref = {"key": "checkpoints/nope.tar.gz", "size": 10, "sha256": "0" * 64}
+    _put_head("f-nobase", _valid_head(manifest={"base": ref, "seq": 1}))
+    exc = _expect(Corrupt, _fresh_ns().open, "f-nobase")
+    assert "missing base" in str(exc), exc
+
+    seg = {"key": "wal/nope.jsonl", "size": 10, "sha256": "0" * 64}
+    _put_head("f-nowal", _valid_head(manifest={"wal": [seg], "seq": 1}))
+    exc = _expect(Corrupt, _fresh_ns().open, "f-nowal")
+    assert "missing WAL" in str(exc), exc
+    _PASSED.append("missing-base / missing-wal: corrupt, never a partial open")
+
+
+def test_bad_base_size_and_digest():
+    ns = _seeded("f-badbase", 7)
+    good = _head_of("f-badbase")["manifest"]["base"]
+
+    _put_head("f-badsize", _valid_head(manifest={"base": dict(good, size=good["size"] + 1),
+                                                 "seq": 1}))
+    # the fixture's base key belongs to another object's prefix, so copy the blob across
+    make_backend(URL, "f-badsize").put_bytes_if_absent(
+        good["key"], make_backend(URL, "f-badbase").get(good["key"]))
+    exc = _expect(Corrupt, _fresh_ns().open, "f-badsize")
+    assert "bytes" in str(exc), exc
+
+    _put_head("f-baddigest", _valid_head(manifest={"base": dict(good, sha256="0" * 64),
+                                                   "seq": 1}))
+    make_backend(URL, "f-baddigest").put_bytes_if_absent(
+        good["key"], make_backend(URL, "f-badbase").get(good["key"]))
+    exc = _expect(Corrupt, _fresh_ns().open, "f-baddigest")
+    assert "SHA-256" in str(exc), exc
+    _PASSED.append("bad-base-size / bad-base-sha256: corrupt before the archive is restored")
+
+
+def test_bad_wal_size_and_digest():
+    payload = b'{"sql":"CREATE TABLE t (n Int64) ENGINE=MergeTree ORDER BY n"}\n'
+    import hashlib
+    digest = hashlib.sha256(payload).hexdigest()
+    key = "wal/1-1-deadbeef.jsonl"
+
+    backend = _put_head("f-badwalsize", _valid_head(
+        manifest={"wal": [{"key": key, "size": len(payload) + 5, "sha256": digest}], "seq": 1}))
+    backend.put_bytes_if_absent(key, payload)
+    exc = _expect(Corrupt, _fresh_ns().open, "f-badwalsize")
+    assert "bytes" in str(exc), exc
+
+    backend = _put_head("f-badwaldigest", _valid_head(
+        manifest={"wal": [{"key": key, "size": len(payload), "sha256": "1" * 64}], "seq": 1}))
+    backend.put_bytes_if_absent(key, payload)
+    exc = _expect(Corrupt, _fresh_ns().open, "f-badwaldigest")
+    assert "SHA-256" in str(exc), exc
+    _PASSED.append("bad-wal-size / bad-wal-sha256: corrupt before any statement is replayed")
+
+
+def test_unknown_reader_feature():
+    _put_head("f-rfeat", _valid_head(protocol={"reader_features": ["compressed-wal"]}))
+    ns = _fresh_ns()
+    _expect(ProtocolUnsupported, ns.open, "f-rfeat")
+    _expect(ProtocolUnsupported, ns.open, "f-rfeat", read_only=True)
+    _PASSED.append("unknown-reader-feature: refused for reading and for writing")
+
+
+def test_unknown_writer_feature():
+    ns = _seeded("f-wfeat", 5)
+    doc = _head_of("f-wfeat")
+    doc["protocol"]["writer_features"] = ["multi-writer"]
+    backend = make_backend(URL, "f-wfeat")
+    _, etag = backend.get_with_etag(HEAD)
+    assert backend.replace_if_match(HEAD, json.dumps(doc).encode(), etag)
+    # readable, because nothing about reading it is in doubt...
+    reader = ns.open("f-wfeat", read_only=True)
+    assert reader.query("SELECT count() FROM t", "CSV").data().strip() == "5"
+    reader.close()
+    # ...but writing it would drop semantics we do not implement
+    _expect(ProtocolUnsupported, ns.open, "f-wfeat")
+    _PASSED.append("unknown-writer-feature: read-only allowed, writer lease refused")
+
+
+def test_future_protocol_version():
+    _put_head("f-future", _valid_head(protocol={"version": 2}))
+    ns = _fresh_ns()
+    _expect(ProtocolUnsupported, ns.open, "f-future", read_only=True)
+    _expect(ProtocolUnsupported, ns.open, "f-future")
+    _PASSED.append("future-protocol-version: refused rather than partially understood")
+
+
+def test_producer_version_differs_but_compatible():
+    ns = _seeded("f-prod", 9)
+    doc = _head_of("f-prod")
+    # written by some later core, but declaring a min_reader we satisfy
+    doc["engine"]["version"] = "99.9.9"
+    doc["engine"]["min_reader"] = "1.0.0"
+    backend = make_backend(URL, "f-prod")
+    _, etag = backend.get_with_etag(HEAD)
+    backend.replace_if_match(HEAD, json.dumps(doc).encode(), etag)
+    assert _count(ns, "f-prod") == "9"
+    obj = ns.open("f-prod")
+    obj.close()
+    # the writer records itself, and leaves min_reader where the base put it
+    after = _head_of("f-prod")
+    assert after["engine"]["version"] == engine_version()
+    assert after["engine"]["min_reader"] == "1.0.0"
+    _PASSED.append("producer-version-differs-but-compatible: opens; min_reader is the gate")
+
+
+def test_engine_reader_too_old():
+    ns = _seeded("f-tooold", 3)
+    doc = _head_of("f-tooold")
+    doc["engine"]["min_reader"] = "999.0.0"
+    backend = make_backend(URL, "f-tooold")
+    _, etag = backend.get_with_etag(HEAD)
+    backend.replace_if_match(HEAD, json.dumps(doc).encode(), etag)
+    _expect(EngineIncompatible, ns.open, "f-tooold", read_only=True)
+    _expect(EngineIncompatible, ns.open, "f-tooold")
+    _PASSED.append("engine-reader-too-old: engine_incompatible")
+
+
+def test_backup_format_too_new():
+    ns = _seeded("f-fmt", 3)
+    doc = _head_of("f-fmt")
+    doc["engine"]["backup_format"] = protocol.BACKUP_FORMAT + 1
+    backend = make_backend(URL, "f-fmt")
+    _, etag = backend.get_with_etag(HEAD)
+    backend.replace_if_match(HEAD, json.dumps(doc).encode(), etag)
+    _expect(EngineIncompatible, ns.open, "f-fmt", read_only=True)
+    _PASSED.append("backup-format-too-new: engine_incompatible, fails closed")
+
+
+def test_unknown_fields_round_trip():
+    ns = _fresh_ns()
+    ns.destroy("f-unknown", force=True)
+    obj = ns.open("f-unknown")
+    obj.close()
+    backend = make_backend(URL, "f-unknown")
+    doc, etag = backend.get_with_etag(HEAD)
+    doc = json.loads(doc)
+    doc["future_top"] = {"a": 1}
+    doc["protocol"]["future_protocol"] = 2
+    doc["engine"]["future_engine"] = 3
+    doc["lease"]["future_lease"] = 4
+    doc["manifest"]["future_manifest"] = 5
+    backend.replace_if_match(HEAD, json.dumps(doc).encode(), etag)
+
+    obj = ns.open("f-unknown")
+    obj.execute("CREATE TABLE t (n Int64) ENGINE=MergeTree ORDER BY n")
+    obj.flush()
+    obj.checkpoint()
+    obj.close()
+    after = _head_of("f-unknown")
+    assert after["future_top"] == {"a": 1}, after
+    assert after["protocol"]["future_protocol"] == 2
+    assert after["engine"]["future_engine"] == 3
+    assert after["lease"]["future_lease"] == 4
+    assert after["manifest"]["future_manifest"] == 5
+    _PASSED.append("unknown fields survive open -> execute -> flush -> checkpoint -> close")
+
+
+def test_json_shape_is_not_frozen():
+    # a head written with different key order and indentation must read the same
+    ns = _seeded("f-shape", 11)
+    backend = make_backend(URL, "f-shape")
+    doc, etag = backend.get_with_etag(HEAD)
+    reshaped = json.dumps(json.loads(doc), sort_keys=True, indent=4).encode()
+    assert reshaped != doc
+    backend.replace_if_match(HEAD, reshaped, etag)
+    assert _count(ns, "f-shape") == "11"
+    _PASSED.append("JSON key order and whitespace are not part of the contract")
+
+
+# =====================================================================
+# §7.3 classification scenarios
+# =====================================================================
+
+def test_gates_cannot_be_bypassed_by_method_choice():
+    ns = _fresh_ns()
+    ns.destroy("c-gate", force=True)
+    obj = ns.open("c-gate")
+    obj.execute("CREATE TABLE t (n Int64) ENGINE=MergeTree ORDER BY n")
+    # a mutation through query() is refused, so nothing can write without logging
+    _expect(ClassificationRefused, obj.query, "INSERT INTO t VALUES (1)")
+    # a read through execute() is refused, so the WAL never fills with SELECTs
+    _expect(ClassificationRefused, obj.execute, "SELECT 1")
+    assert obj.pending == 1  # only the CREATE
+    obj.close()
+    _PASSED.append("neither method name bypasses the analysis")
+
+
+def test_multi_statement_and_parallel_with_refused():
+    ns = _fresh_ns()
+    ns.destroy("c-multi", force=True)
+    obj = ns.open("c-multi")
+    exc = _expect(ClassificationRefused, obj.execute,
+                  "CREATE TABLE a (n Int64) ENGINE=Memory; CREATE TABLE b (n Int64) ENGINE=Memory")
+    assert "one statement" in str(exc)
+    _expect(ClassificationRefused, obj.execute,
+            "CREATE TABLE a (n Int64) ENGINE=Memory "
+            "PARALLEL WITH CREATE TABLE b (n Int64) ENGINE=Memory")
+    _expect(ClassificationRefused, obj.query, "SELECT 1; SELECT 2")
+    assert obj.pending == 0
+    obj.close()
+    _PASSED.append("multi-statement and PARALLEL WITH refused (both arms execute)")
+
+
+def test_writes_outside_the_object_refused():
+    ns = _fresh_ns()
+    ns.destroy("c-outside", force=True)
+    obj = ns.open("c-outside")
+    obj.execute("CREATE TABLE t (n Int64) ENGINE=MergeTree ORDER BY n")
+    for sql in ("INSERT INTO other_db.t VALUES (1)",
+                "RENAME TABLE t TO other_db.t2",
+                "INSERT INTO FUNCTION file('/tmp/chdb-durable-should-not-exist.csv') SELECT 1",
+                "SELECT 1 INTO OUTFILE '/tmp/chdb-durable-should-not-exist.csv'"):
+        _expect(ClassificationRefused, obj.execute, sql)
+    _expect(ClassificationRefused, obj.execute, "INSERT INTO system.numbers VALUES (1)")
+    assert obj.pending == 1
+    assert not os.path.exists("/tmp/chdb-durable-should-not-exist.csv")
+    obj.close()
+    _PASSED.append("writes to another database, system, a table function or a file refused")
+
+
+def test_database_lifecycle_refused():
+    ns = _fresh_ns()
+    ns.destroy("c-life", force=True)
+    obj = ns.open("c-life")
+    for sql in ("CREATE DATABASE something", "DROP DATABASE mem",
+                "RENAME DATABASE mem TO mem2"):
+        exc = _expect(ClassificationRefused, obj.execute, sql)
+        assert "container" in str(exc), exc
+    obj.close()
+    _PASSED.append("CREATE/DROP/RENAME DATABASE refused: the object owns its container")
+
+
+def test_mutating_global_refused():
+    ns = _fresh_ns()
+    ns.destroy("c-global", force=True)
+    obj = ns.open("c-global")
+    for sql in ("CREATE FUNCTION addone AS x -> x + 1",
+                "CREATE USER someone",
+                "CREATE NAMED COLLECTION creds AS key = 'value'"):
+        exc = _expect(ClassificationRefused, obj.execute, sql)
+        assert "outside every database" in str(exc), exc
+    obj.close()
+    _PASSED.append("every MUTATING_GLOBAL refused: V1 has no preamble to replay it from")
+
+
+def test_control_statements_refused():
+    ns = _fresh_ns()
+    ns.destroy("c-control", force=True)
+    obj = ns.open("c-control")
+    obj.execute("CREATE TABLE t (n Int64) ENGINE=MergeTree ORDER BY n")
+    for sql in ("USE default", "SET max_threads = 1", "SYSTEM FLUSH LOGS",
+                # a statement setting that would let an insert complete after
+                # execute() returned: chdb-core classifies it CONTROL, so the
+                # durability promise cannot be relaxed from the SQL
+                "INSERT INTO t SETTINGS async_insert = 1 VALUES (1)"):
+        _expect(ClassificationRefused, obj.execute, sql)
+    # and the object's own database is still current afterwards
+    assert obj.query("SELECT currentDatabase()", "CSV").data().strip() == '"mem"'
+    obj.close()
+    _PASSED.append("control statements refused, including async-insert relaxation")
+
+
+def test_secret_mutation_refused_without_leaking():
+    ns = _fresh_ns()
+    ns.destroy("c-secret", force=True)
+    obj = ns.open("c-secret")
+    obj.execute("CREATE TABLE t (n Int64) ENGINE=MergeTree ORDER BY n")
+    secret = "SUPERSECRETKEY123"
+    exc = _expect(SecretRefused, obj.execute,
+                  f"INSERT INTO t SELECT 1 FROM s3('https://x/y.csv', 'AKIAEXAMPLE', '{secret}')")
+    assert secret not in str(exc) and "s3(" not in str(exc), exc
+    assert obj.pending == 1
+    obj.close()
+    _PASSED.append("secret-bearing mutation refused, and the error quotes no SQL")
+
+
+def test_secret_read_only_runs_and_is_not_logged():
+    ns = _fresh_ns()
+    ns.destroy("c-secretread", force=True)
+    obj = ns.open("c-secretread")
+    secret = "SUPERSECRETKEY123"
+    # A malformed URL fails inside the engine immediately, with no network
+    # wait: what is under test is the gate and the redaction, not S3.
+    sql = f"SELECT * FROM s3('not a url', 'AKIAEXAMPLE', '{secret}')"
+    # It passes the gate — a read never reaches the WAL. It then fails, and
+    # that failure must not carry the credential.
+    exc = _expect(EngineError, obj.query, sql)
+    assert secret not in str(exc), exc
+    assert obj.pending == 0
+    assert obj.flush() is None  # nothing to publish
+    obj.close()
+    _PASSED.append("secret-bearing read-only SQL runs, writes no WAL, and redacts failures")
+
+
+def test_unknown_statement_fails_closed():
+    ns = _fresh_ns()
+    ns.destroy("c-unknown", force=True)
+    obj = ns.open("c-unknown")
+    exc = _expect(ClassificationRefused, obj.execute, "this is not sql at all")
+    assert "could not classify" in str(exc), exc
+    _expect(ClassificationRefused, obj.query, "this is not sql at all")
+    obj.close()
+    _PASSED.append("UNKNOWN fails closed for both entry points")
+
+
+def test_limits_report_limit_exceeded():
+    # The frozen limits are 64 MiB of SQL and 128 MiB per segment. Allocating
+    # those to prove an arithmetic comparison is not worth a minute of test
+    # time, so the limits are shrunk and the same code paths exercised.
+    sql_limit, seg_limit = wal_mod.MAX_SQL_BYTES, wal_mod.MAX_WAL_SEGMENT_BYTES
+    head_limit = protocol.MAX_HEAD_BYTES
+    ns = _fresh_ns()
+    ns.destroy("c-limits", force=True)
+    obj = ns.open("c-limits")
+    obj.execute("CREATE TABLE t (n Int64) ENGINE=MergeTree ORDER BY n")
     try:
-        o.close()
-        raise AssertionError("close() should raise when fenced with buffered writes")
-    except LeaseError:
-        pass
-    print("  fencing: superseded writer's commit rejected via head CAS ✓")
-
-
-def test_scan(ns):
-    for oid, k in (("obj-a", 1500), ("obj-b", 0)):
-        pass
-    # obj-a has 1500; give obj-b a table with 7 rows
-    o = ns.open("obj-b")
-    o.execute("INSERT INTO mem.t SELECT number FROM numbers(7)")
-    o.checkpoint()
-    o.close()
-    rows = dict(ns.scan("SELECT count() FROM mem.t", ids=["obj-a", "obj-b"]))
-    a = rows["obj-a"].strip()
-    b = rows["obj-b"].strip()
-    assert a == "1500" and b == "7", (a, b)
-    print(f"  ns.scan across objects: obj-a={a}, obj-b={b} ✓")
-
-
-def test_local_path_traversal():
-    # a caller-controlled object id must not escape the backend root
-    for bad in ("../escape", "../../etc", "/abs/escape", "a/../../escape"):
-        try:
-            make_backend("local:" + tempfile.mkdtemp(prefix="dao-root-"), bad)
-            raise AssertionError(f"expected rejection for id {bad!r}")
-        except ValueError:
-            pass
-    # a symlink id pointing outside the root must also be rejected (realpath)
-    root = tempfile.mkdtemp(prefix="dao-root-")
-    outside = tempfile.mkdtemp(prefix="dao-outside-")
-    os.symlink(outside, os.path.join(root, "link"))
+        wal_mod.MAX_SQL_BYTES = 64
+        exc = _expect(LimitExceeded, obj.execute,
+                      "INSERT INTO t VALUES " + ", ".join("(1)" for _ in range(40)))
+        assert "over the V1 limit" in str(exc)
+        wal_mod.MAX_SQL_BYTES = sql_limit
+        wal_mod.MAX_WAL_SEGMENT_BYTES = 40
+        exc = _expect(LimitExceeded, obj.execute, "INSERT INTO t VALUES (2)")
+        assert "flush()" in str(exc)
+    finally:
+        wal_mod.MAX_SQL_BYTES, wal_mod.MAX_WAL_SEGMENT_BYTES = sql_limit, seg_limit
+    # an over-limit head is the writer's problem to notice, while it can still
+    # checkpoint the WAL list away
+    import chdb.durable.head as head_mod
     try:
-        make_backend("local:" + root, "link")
-        raise AssertionError("symlink escaping root should be rejected")
-    except ValueError:
-        pass
-    # a normal id is fine
-    make_backend("local:" + tempfile.mkdtemp(prefix="dao-root-"), "user-123")
-    print("  local path traversal: escaping object ids (incl. symlink) rejected ✓")
+        head_mod.MAX_HEAD_BYTES = 100
+        _expect(LimitExceeded, obj.flush)
+    finally:
+        head_mod.MAX_HEAD_BYTES = head_limit
+    obj.close()
+    _PASSED.append("SQL, WAL segment and head limits all report limit_exceeded")
 
 
-def test_sibling_isolation(ns):
-    # destroy("foo") must not delete a sibling object whose id shares the prefix
-    for oid in ("foo", "foobar"):
-        ns.destroy(oid)
-    for oid, k in (("foobar", 3), ("foo", 7)):
-        o = ns.open(oid)
-        o.execute("CREATE TABLE mem.t (n Int64) ENGINE=MergeTree ORDER BY n")
-        o.execute(f"INSERT INTO mem.t SELECT number FROM numbers({k})")
-        o.checkpoint()
-        o.close()
-    ns.destroy("foo")
-    r = ns.open("foobar", read_only=True)
-    got = r.query("SELECT count() FROM mem.t", "CSV").data().strip()
-    r.close()
-    assert got == "3", f"sibling clobbered: {got}"
-    print("  sibling isolation: destroy('foo') left 'foobar' intact ✓")
+# =====================================================================
+# §7.4 fault matrix
+# =====================================================================
+
+def test_conditional_create_race():
+    ns = _fresh_ns()
+    ns.destroy("x-race", force=True)
+    obj = ns.open("x-race")            # writer A creates the object
+    obj.close()
+    backend = FaultyBackend(make_backend(URL, "x-race"))
+    backend.hide_head = True           # writer B saw no head, so it will create one
+    loser = cd.DurableObject("x-race", backend, owner="w2", db="mem")
+    _expect(LeaseHeld, loser.open)
+    loser.close()
+    _PASSED.append("conditional create race: only one writer creates the object")
 
 
-def test_object_id_rejects_slash(ns):
-    # ids must be flat keys — no '/', empty, '.', '..', '\\' (else a short id's
-    # prefix could contain another id's, and destroy would delete both)
+def test_wal_put_lands_but_head_cas_fails():
+    ns = _seeded("x-walcas", 10)
+    backend = FaultyBackend(make_backend(URL, "x-walcas"))
+    obj = cd.DurableObject("x-walcas", backend, owner="w1", db="mem", commit_deadline=0.3)
+    obj.open()
+    obj.execute("INSERT INTO t VALUES (999)")
+    before = _head_of("x-walcas")["manifest"]
+    backend.fail_replace = "lost"
+    _expect(BackendError, obj.flush)
+    # the old manifest is still authoritative, and the statement is still ours
+    assert _head_of("x-walcas")["manifest"] == before
+    assert obj.pending == 1
+    backend.fail_replace = None
+    key = obj.flush()                   # a retry publishes a fresh unique segment
+    assert key and obj.pending == 0
+    obj.close()
+    assert _count(ns, "x-walcas") == "11"
+    _PASSED.append("WAL PUT then failed head CAS: old manifest stands, buffer retained")
+
+
+def test_head_cas_committed_but_response_lost():
+    ns = _seeded("x-lostcas", 10)
+    backend = FaultyBackend(make_backend(URL, "x-lostcas"))
+    obj = cd.DurableObject("x-lostcas", backend, owner="w1", db="mem")
+    obj.open()
+    obj.execute("INSERT INTO t VALUES (777)")
+    backend.fail_replace = "ambiguous_after"   # it landed; we just never heard
+    key = obj.flush()
+    backend.fail_replace = None
+    assert key and obj.pending == 0
+    # exactly one segment: reconcile adopted the commit instead of retrying,
+    # which would have published the same boundary twice
+    assert [ref["key"] for ref in _head_of("x-lostcas")["manifest"]["wal"]] == [key]
+    obj.close()
+    assert _count(ns, "x-lostcas") == "11"
+    _PASSED.append("head CAS committed with a lost response: reconciled as success")
+
+
+def test_unprovable_commit_is_ambiguous():
+    ns = _seeded("x-ambig", 10)
+    backend = FaultyBackend(make_backend(URL, "x-ambig"))
+    obj = cd.DurableObject("x-ambig", backend, owner="w1", db="mem")
+    obj.open()
+    obj.execute("INSERT INTO t VALUES (555)")
+    backend.fail_create = "ambiguous_before"   # never sent, but we cannot know
+    exc = _expect(CommitAmbiguous, obj.flush)
+    assert "indeterminate" in str(exc)
+    backend.fail_create = None
+    assert obj.pending == 1                     # nothing was claimed durable
+    obj.close()
+    assert _count(ns, "x-ambig") == "11"
+    _PASSED.append("commit that cannot be proved either way: commit_ambiguous, never success")
+
+
+def test_wal_upload_landed_but_response_lost():
+    ns = _seeded("x-walput", 10)
+    backend = FaultyBackend(make_backend(URL, "x-walput"))
+    obj = cd.DurableObject("x-walput", backend, owner="w1", db="mem")
+    obj.open()
+    obj.execute("INSERT INTO t VALUES (444)")
+    backend.fail_create = "ambiguous_after"    # the segment is there
+    key = obj.flush()                          # re-read proves it by size + digest
+    backend.fail_create = None
+    assert key and obj.pending == 0
+    obj.close()
+    assert _count(ns, "x-walput") == "11"
+    _PASSED.append("WAL upload with a lost response: confirmed by re-reading the unique key")
+
+
+def test_checkpoint_put_lands_but_head_cas_fails():
+    ns = _seeded("x-ckptcas", 10)
+    backend = FaultyBackend(make_backend(URL, "x-ckptcas"))
+    obj = cd.DurableObject("x-ckptcas", backend, owner="w1", db="mem", commit_deadline=0.3)
+    obj.open()
+    # after the open, so the lease CAS the open itself performs is not the
+    # difference we would then be measuring
+    before = _head_of("x-ckptcas")["manifest"]
+    obj.execute("INSERT INTO t VALUES (222)")
+    backend.fail_replace = "lost"
+    _expect(BackendError, obj.checkpoint)
+    assert _head_of("x-ckptcas")["manifest"] == before   # the old base is still the base
+    assert obj.pending == 1                     # and the buffer was not cleared
+    backend.fail_replace = None
+    obj.close()
+    assert _count(ns, "x-ckptcas") == "11"
+    _PASSED.append("checkpoint PUT then failed head CAS: old base/WAL still restore")
+
+
+def test_restore_failure_frees_the_engine():
+    # chdb-core allows one active data path per process, so a failed restore
+    # that leaked its engine would block every later open in the process.
+    ref = {"key": "checkpoints/nope.tar.gz", "size": 5, "sha256": "0" * 64}
+    _put_head("x-partial", _valid_head(manifest={"base": ref, "seq": 1}))
+    ns = _fresh_ns()
+    _expect(Corrupt, ns.open, "x-partial")
+    ns.destroy("x-after", force=True)
+    obj = ns.open("x-after")
+    assert obj.query("SELECT 1", "CSV").data().strip() == "1"
+    obj.close()
+    # the lease the failed open took was released, not stranded until its TTL
+    assert _head_of("x-partial")["lease"]["owner"] is None
+    _PASSED.append("failed restore closes the partial engine and releases the lease")
+
+
+def test_heartbeat_renews_without_moving_generation_or_seq():
+    ns = _seeded("x-hb", 5)
+    backend = make_backend(URL, "x-hb")
+    obj = cd.DurableObject("x-hb", backend, owner="w1", db="mem",
+                           lease_ttl=1.2, heartbeat_interval=0.4)
+    obj.open()
+    first = _head_of("x-hb")["lease"]
+    time.sleep(1.0)                      # several heartbeats, no operations
+    renewed = _head_of("x-hb")["lease"]
+    assert renewed["expires_at"] > first["expires_at"], (first, renewed)
+    # §4.2: a heartbeat renews the expiry and nothing else
+    assert renewed["generation"] == first["generation"]
+    assert _head_of("x-hb")["manifest"]["seq"] == obj.seq
+
+    # ...and its head CAS shares the ETag with flush() rather than racing it
+    for i in range(3):
+        obj.execute(f"INSERT INTO t VALUES ({1000 + i})")
+        obj.flush()
+    doc = _head_of("x-hb")
+    assert doc["manifest"]["seq"] == obj.seq
+    assert len(doc["manifest"]["wal"]) == 3
+    obj.close()
+    assert _count(ns, "x-hb") == "8"
+    _PASSED.append("heartbeat renews the expiry only, and shares the head with flush")
+
+
+def test_writer_self_fences_when_renewal_fails():
+    ns = _seeded("x-selffence", 4)
+    backend = FaultyBackend(make_backend(URL, "x-selffence"))
+    obj = cd.DurableObject("x-selffence", backend, owner="w1", db="mem",
+                           lease_ttl=0.6, heartbeat_interval=0.15, commit_deadline=0.1)
+    obj.open()
+    backend.fail_replace = "error"          # every renewal from here on fails
+    deadline = time.time() + 5.0
+    while not obj.fenced and time.time() < deadline:
+        time.sleep(0.05)
+    assert obj.fenced, "writer should have fenced itself once its lease ran out"
+    _expect(LeaseFenced, obj.execute, "INSERT INTO t VALUES (1)")
+    _expect(LeaseFenced, obj.flush)
+    _expect(LeaseFenced, obj.checkpoint)
+    # reads still work: the local database is what this instance restored
+    assert obj.query("SELECT count() FROM t", "CSV").data().strip() == "4"
+    backend.fail_replace = None
+    obj.close()
+    _PASSED.append("renewal failing past the lease deadline self-fences the writer")
+
+
+def test_takeover_fences_the_previous_writer():
+    ns = _seeded("x-fence", 6)
+    obj = ns.open("x-fence")
+    obj.execute("INSERT INTO t VALUES (1)")
+    # an external takeover: a new generation, written straight to the head
+    backend = make_backend(URL, "x-fence")
+    doc, etag = backend.get_with_etag(HEAD)
+    doc = json.loads(doc)
+    doc["lease"] = {"owner": "w2", "instance": "other-instance",
+                    "generation": doc["lease"]["generation"] + 5,
+                    "expires_at": time.time() + 600}
+    assert backend.replace_if_match(HEAD, json.dumps(doc).encode(), etag)
+    _expect(LeaseFenced, obj.flush)
+    # close() must surface the fence rather than drop the buffered write quietly
+    _expect(LeaseFenced, obj.close)
+    assert obj.closed  # ...and still release local resources
+    _PASSED.append("takeover fences the old writer, and close() says so")
+
+
+def test_close_releases_and_then_refuses():
+    ns = _seeded("x-closed", 3)
+    obj = ns.open("x-closed")
+    obj.execute("INSERT INTO t VALUES (42)")
+    obj.close()
+    assert _head_of("x-closed")["lease"]["owner"] is None
+    for call in (lambda: obj.query("SELECT 1"),
+                 lambda: obj.execute("INSERT INTO t VALUES (1)"),
+                 obj.flush, obj.checkpoint):
+        _expect(Closed, call)
+    obj.close()  # idempotent
+    assert _count(ns, "x-closed") == "4"
+    _PASSED.append("close() flushes, releases the lease, and then refuses everything")
+
+
+# =====================================================================
+# lease exclusion, ids, and namespace behaviour
+# =====================================================================
+
+def test_lease_exclusion_and_same_owner_instance():
+    ns = _seeded("x-excl", 2)
+    obj = ns.open("x-excl")
+    other = cd.Namespace(URL, owner="w2")
+    _expect(LeaseHeld, other.open, "x-excl")
+    # the same owner *string* is not a free pass: it may be another live
+    # instance, and fencing it is what the lease exists to prevent
+    same_owner = cd.DurableObject("x-excl", make_backend(URL, "x-excl"),
+                                  owner="w1", db="mem")
+    _expect(LeaseHeld, same_owner.open)
+    same_owner.close()
+    obj.close()
+    _PASSED.append("an unexpired lease blocks another writer, same owner string or not")
+
+
+def test_expired_lease_is_taken_without_force():
+    ns = _seeded("x-expired", 2)
+    backend = make_backend(URL, "x-expired")
+    doc, etag = backend.get_with_etag(HEAD)
+    doc = json.loads(doc)
+    generation = doc["lease"]["generation"]
+    doc["lease"] = {"owner": "dead", "instance": "dead-instance",
+                    "generation": generation, "expires_at": time.time() - 3600}
+    backend.replace_if_match(HEAD, json.dumps(doc).encode(), etag)
+    obj = ns.open("x-expired")          # expired well past any clock skew
+    assert obj.generation == generation + 1
+    obj.close()
+    _PASSED.append("an expired lease is taken normally, and moves the generation")
+
+
+def test_unexpired_lease_needs_force():
+    ns = _seeded("x-force", 1)
+    backend = make_backend(URL, "x-force")
+    doc, etag = backend.get_with_etag(HEAD)
+    doc = json.loads(doc)
+    doc["lease"] = {"owner": "w1", "instance": "dead-instance",
+                    "generation": doc["lease"]["generation"] + 1,
+                    "expires_at": time.time() + 3600}
+    backend.replace_if_match(HEAD, json.dumps(doc).encode(), etag)
+    _expect(LeaseHeld, ns.open, "x-force")
+    with warnings.catch_warnings(record=True) as caught:
+        warnings.simplefilter("always")
+        obj = ns.open("x-force", force=True)   # the administrative takeover
+    # the cost of a force takeover has to be stated, not just documented
+    assert any("not expired" in str(w.message) for w in caught), [str(w.message) for w in caught]
+    assert obj.query("SELECT count() FROM t", "CSV").data().strip() == "1"
+    obj.close()
+    _PASSED.append("an unexpired lease is only taken by a force takeover, and it warns")
+
+
+def test_object_id_validation_and_path_traversal():
     for bad in ("team/u1", "", "..", "a\\b"):
-        try:
-            ns.open(bad)
-            raise AssertionError(f"object id {bad!r} should be rejected")
-        except ValueError:
-            pass
-    print("  object id validation: rejects '/', empty, '..', '\\\\' ✓")
+        _expect(ValueError, _fresh_ns().open, bad)
+    for bad in ("../escape", "../../etc", "/abs/escape", "a/../../escape"):
+        _expect(ValueError, make_backend,
+                "local:" + tempfile.mkdtemp(prefix="dao-root-"), bad)
+    root = tempfile.mkdtemp(prefix="dao-root-")
+    os.symlink(tempfile.mkdtemp(prefix="dao-outside-"), os.path.join(root, "link"))
+    _expect(ValueError, make_backend, "local:" + root, "link")
+    make_backend("local:" + tempfile.mkdtemp(prefix="dao-root-"), "user-123")
+    _PASSED.append("object ids stay flat keys, and no id escapes the backend root")
 
 
-def test_missing_reference_errors(ns):
-    # a head referencing a base/WAL blob that's missing from storage must fail
-    # loudly, not silently open with committed state omitted
-    ns.destroy("obj-mb")
-    b = make_backend(ns.url, "obj-mb")
-    b.put_if_absent("head.json", json.dumps({
-        "lease": {"owner": "", "generation": 1, "expires_at": 0},
-        "manifest": {"db": "mem", "base": "checkpoints/nope.tar.gz", "wal": [], "seq": 1},
-    }).encode())
+def test_sibling_isolation():
+    ns = _fresh_ns()
+    _seeded("foobar", 3, ns=ns)
+    _seeded("foo", 7, ns=ns)
+    ns.destroy("foo")
+    assert _count(ns, "foobar") == "3"
+    _PASSED.append("destroy('foo') leaves the sibling 'foobar' intact")
+
+
+def test_destroy_refuses_an_active_lease():
+    ns = _seeded("x-destroy", 2)
+    obj = ns.open("x-destroy")
+    _expect(LeaseHeld, ns.destroy, "x-destroy")
+    ns.destroy("x-destroy", force=True)
     try:
-        ns.open("obj-mb")
-        raise AssertionError("expected RuntimeError for missing base")
-    except RuntimeError as e:
-        assert "missing base" in str(e), str(e)
-
-    ns.destroy("obj-mb2")
-    b2 = make_backend(ns.url, "obj-mb2")
-    b2.put_if_absent("head.json", json.dumps({
-        "lease": {"owner": "", "generation": 1, "expires_at": 0},
-        "manifest": {"db": "mem", "base": None, "wal": ["wal/nope.jsonl"], "seq": 1},
-    }).encode())
-    try:
-        ns.open("obj-mb2")
-        raise AssertionError("expected RuntimeError for missing WAL segment")
-    except RuntimeError as e:
-        assert "missing WAL" in str(e), str(e)
-    print("  missing base/WAL reference: fails loudly ✓")
-
-
-def test_wal_keys_unique(ns):
-    # unique segment keys so a retry can't overwrite an already-published segment
-    ns.destroy("obj-uk")
-    o = ns.open("obj-uk")
-    o.execute("CREATE TABLE mem.t (n Int64) ENGINE=MergeTree ORDER BY n")
-    o.execute("INSERT INTO mem.t VALUES (1)")
-    k1 = o.flush()
-    o.execute("INSERT INTO mem.t VALUES (2)")
-    k2 = o.flush()
-    o.close()
-    assert k1 and k2 and k1 != k2, (k1, k2)
-    print("  WAL keys unique across flushes ✓")
-
-
-def test_lease_renewal(ns):
-    # a long-lived writer renews its lease before expiry (not fenced while active)
-    ns.destroy("obj-lr")
-    b = make_backend(ns.url, "obj-lr")
-    o = cd.DurableObject("obj-lr", b, owner="w1", db="mem", lease_ttl=0.4)
-    o.open()
-    o.execute("CREATE TABLE mem.t (n Int64) ENGINE=MergeTree ORDER BY n")
-    exp1 = json.loads(b.get("head.json"))["lease"]["expires_at"]
-    time.sleep(0.35)  # cross the renew threshold (ttl*0.75 = 0.3s before expiry)
-    o.execute("INSERT INTO mem.t VALUES (1)")  # should renew the lease
-    exp2 = json.loads(b.get("head.json"))["lease"]["expires_at"]
-    o.close()
-    assert exp2 > exp1, (exp1, exp2)
-    print("  lease renewal: expires_at advanced on execute near expiry ✓")
-
-
-def test_lease_ttl_validation():
-    b = make_backend("local:" + tempfile.mkdtemp(prefix="dao-ttl-"))
-    for bad in (0, -1, float("inf"), float("nan")):
-        try:
-            cd.DurableObject("x", b, lease_ttl=bad)
-            raise AssertionError(f"lease_ttl {bad} should be rejected")
-        except ValueError:
-            pass
-    print("  lease_ttl validation: rejects 0 / negative / inf / nan ✓")
-
-
-def test_readonly_restore_failure_frees_session(ns):
-    # a failed read-only restore must free the chDB session (one-per-process),
-    # so a subsequent open isn't blocked
-    ns.destroy("obj-ro")
-    b = make_backend(ns.url, "obj-ro")
-    b.put_if_absent("head.json", json.dumps({
-        "lease": {"owner": "", "instance": "", "generation": 1, "expires_at": 0},
-        "manifest": {"db": "mem", "base": "checkpoints/nope.tar.gz", "wal": [], "seq": 1},
-    }).encode())
-    o = cd.DurableObject("obj-ro", b, read_only=True, db="mem")
-    try:
-        o.open()
-        raise AssertionError("expected RuntimeError for missing base")
-    except RuntimeError:
+        obj.close()          # the head is gone; being fenced here is correct
+    except LeaseFenced:
         pass
-    o2 = ns.open("obj-ro2")  # would fail with chDB one-session error if not freed
-    o2.query("SELECT 1")
-    o2.close()
-    print("  read-only restore failure frees the session ✓")
+    _PASSED.append("destroy refuses a leased object unless forced (not a V1 operation)")
 
 
-def test_same_owner_second_instance_blocked(ns):
-    # a second *live* instance with the same owner string must still be refused
-    # (identity is per-instance, not per-owner) — else it would fence the first
-    ns.destroy("obj-so")
-    o = ns.open("obj-so")  # instance A, owner w1
-    o.execute("CREATE TABLE mem.t (n Int64) ENGINE=MergeTree ORDER BY n")
-    b = make_backend(ns.url, "obj-so")
-    o2 = cd.DurableObject("obj-so", b, owner=ns.owner, db="mem")  # same owner, instance B
-    try:
-        o2.open()
-        raise AssertionError("second same-owner live instance should be refused")
-    except LeaseError:
-        pass
-    o.close()
-    print("  same-owner second live instance refused ✓")
+def test_scan_across_objects():
+    ns = _fresh_ns()
+    _seeded("s-a", 1500, ns=ns)
+    _seeded("s-b", 7, ns=ns)
+    rows = dict(ns.scan("SELECT count() FROM t", ids=["s-a", "s-b"]))
+    assert rows["s-a"].strip() == "1500" and rows["s-b"].strip() == "7", rows
+    _expect(NotFound, ns.scan, "SELECT 1", ["s-a", "s-missing"])
+    assert len(ns.scan("SELECT count() FROM t", ["s-a", "s-missing"], missing_ok=True)) == 1
+    _PASSED.append("ns.scan unions read-only results, and says so when an object is absent")
 
 
-def test_put_if_absent_returns_etag(ns):
-    # cold-create adopts this etag directly (no racy second fetch)
-    ns.destroy("obj-pia")
-    b = make_backend(ns.url, "obj-pia")
-    e = b.put_if_absent("head.json", b'{"x":1}')
-    assert e, "put_if_absent should return an etag on create"
-    assert b.put_if_absent("head.json", b'{"x":2}') is None, "should return None if it exists"
-    print("  put_if_absent returns etag on create / None if exists ✓")
+def test_reopen_honors_persisted_db():
+    # the object owns its database name; reopening with a different db argument
+    # must not rewrite it, or the restore builds the wrong database
+    ns = _seeded("x-db", 5)
+    other = cd.Namespace(URL, owner="w1", db="somethingelse")
+    reader = other.open("x-db", read_only=True)
+    assert reader.db == "mem"
+    assert reader.query("SELECT count() FROM mem.t", "CSV").data().strip() == "5"
+    reader.close()
+    # a *writer* has to honour it too: it is the one that would rewrite the
+    # manifest and checkpoint the wrong database
+    writer = other.open("x-db")
+    assert writer.db == "mem"
+    writer.execute("INSERT INTO t VALUES (6)")   # unqualified, into mem
+    writer.checkpoint()
+    writer.close()
+    assert _head_of("x-db")["manifest"]["db"] == "mem"
+    assert _count(ns, "x-db") == "6"
+    _PASSED.append("reopen honors the manifest's database for readers and writers alike")
 
 
-def test_reconcile_detects_committed(ns):
-    # ambiguous CAS: if the head already references our unique key, reconcile
-    # must report "committed" (so a lost-response retry doesn't double-publish)
-    ns.destroy("obj-rec")
-    o = ns.open("obj-rec")
-    o.execute("CREATE TABLE mem.t (n Int64) ENGINE=MergeTree ORDER BY n")
-    o.execute("INSERT INTO mem.t VALUES (1)")
-    k = o.flush()
-    assert o._reconcile_committed(wal_key=k) is True
-    assert o._reconcile_committed(wal_key="wal/nonexistent.jsonl") is False
-    ck = o.checkpoint()
-    assert o._reconcile_committed(base=ck) is True
-    # ownership check: if another writer took over (kept our key), reconcile
-    # must NOT adopt — a retained key proves durability, not ownership
-    b = make_backend(ns.url, "obj-rec")
-    h = json.loads(b.get("head.json"))
-    h["lease"]["instance"] = "other-instance"
-    b.put("head.json", json.dumps(h).encode())
-    assert o._reconcile_committed(base=ck) is False
-    o.close()
-    print("  reconcile detects committed key + still-owned; rejects after takeover ✓")
-
-
-def test_destroy_refuses_active_lease(ns):
-    ns.destroy("obj-de")
-    o = ns.open("obj-de")  # holds an active lease
-    o.execute("CREATE TABLE mem.t (n Int64) ENGINE=MergeTree ORDER BY n")
-    o.flush()
-    try:
-        ns.destroy("obj-de")
-        raise AssertionError("destroy should refuse an actively-leased object")
-    except LeaseError:
-        pass
-    ns.destroy("obj-de", force=True)  # force overrides
-    try:
-        o.close()  # fenced (head gone); tolerate
-    except LeaseError:
-        pass
-    print("  destroy refuses an active lease (force overrides) ✓")
-
-
-def test_force_take(ns):
-    # crash recovery: a new writer force-takes an unexpired foreign lease
-    # (held by a now-dead instance) without waiting out the TTL
-    ns.destroy("obj-ft")
-    o = ns.open("obj-ft")
-    o.execute("CREATE TABLE mem.t (n Int64) ENGINE=MergeTree ORDER BY n")
-    o.execute("INSERT INTO mem.t VALUES (9)")
-    o.checkpoint()
-    o.close()
-    b = make_backend(ns.url, "obj-ft")
-    head = json.loads(b.get("head.json"))  # forge a live-looking foreign lease
-    head["lease"] = {"owner": "w1", "instance": "dead-instance",
-                     "generation": head["lease"]["generation"] + 1, "expires_at": 9e12}
-    b.put("head.json", json.dumps(head).encode())
-    try:
-        ns.open("obj-ft")  # normal open must be blocked by the unexpired lease
-        raise AssertionError("held lease should block a normal open")
-    except LeaseError:
-        pass
-    r = ns.open("obj-ft", force=True)  # force-take + restore
-    got = r.query("SELECT n FROM mem.t", "CSV").data().strip()
-    r.close()
-    assert got == "9", got
-    print("  force-take: bypasses an unexpired foreign lease (crash recovery) ✓")
-
-
-def test_reopen_honors_persisted_db(ns):
-    # the object owns its database name; reopening with a different db arg must
-    # not rewrite it (otherwise restore builds the wrong database)
-    ns.destroy("obj-db")
-    o = ns.open("obj-db")  # ns default db = "mem"
-    o.execute("CREATE TABLE mem.t (n Int64) ENGINE=MergeTree ORDER BY n")
-    o.execute("INSERT INTO mem.t VALUES (5)")
-    o.checkpoint()
-    o.close()
-    ns2 = cd.Namespace(ns.url, owner="w1", db="other")  # different db arg
-    r = ns2.open("obj-db", read_only=True)
-    got = r.query("SELECT n FROM mem.t", "CSV").data().strip()  # persisted "mem" wins
-    r.close()
-    assert got == "5", got
-    print("  reopen honors persisted manifest db ✓")
-
-
-def test_wal_replay_unqualified_db_context(ns):
-    # WAL statements written against the object's current database (set via
-    # `USE`) use unqualified table names; replay must restore that database as
-    # current, or the statements land in `default` and are lost on the next
-    # checkpoint. Note: all other tests qualify names (mem.t), so only this
-    # one exercises the replay database context.
-    ns.destroy("obj-uq")
-    o = ns.open("obj-uq")  # ns default db = "mem"
-    o.query("USE mem", "CSV")  # set current db; USE via query is not logged
-    o.execute("CREATE TABLE t (n Int64) ENGINE=MergeTree ORDER BY n")  # unqualified
-    o.execute("INSERT INTO t VALUES (1), (2), (3)")                    # unqualified
-    o.flush()  # persist to WAL, but do not checkpoint — force a replay on reopen
-    o.close()
-    r = ns.open("obj-uq")  # replays the WAL
-    got = r.query("SELECT count() FROM mem.t", "CSV").data().strip()
-    r.close()
-    assert got == "3", got
-    print("  WAL replay restores the object's database context ✓")
-
-
-def test_cold_open_leaves_session_in_object_db():
-    # After a *cold* open (fresh object), the session must already be in the
-    # object's database, so unqualified writes land where checkpoint()'s
-    # `BACKUP DATABASE {db}` captures them. Uses no manual `USE` — that is the
-    # real consumer path (e.g. a store that just runs CREATE/INSERT). Before the
-    # fix these went to `default` and were dropped on reopen.
+def test_cold_open_lands_in_the_objects_database():
+    # a fresh object must already be in its own database, so unqualified writes
+    # land where `BACKUP DATABASE` will find them
     ns = cd.Namespace(URL, owner="w1", db="analyst")
-    ns.destroy("obj-cold")
-    o = ns.open("obj-cold")
-    o.execute("CREATE TABLE t (n Int64) ENGINE=MergeTree ORDER BY n")  # unqualified
-    o.execute("INSERT INTO t VALUES (7)")
-    o.checkpoint()  # BACKUP DATABASE analyst — must include t
-    o.close()
-    r = ns.open("obj-cold")
-    got = r.query("SELECT n FROM analyst.t", "CSV").data().strip()
-    r.close()
-    assert got == "7", got
-    print("  cold open leaves the session in the object's database ✓")
+    ns.destroy("x-cold", force=True)
+    obj = ns.open("x-cold")
+    assert obj.query("SELECT currentDatabase()", "CSV").data().strip() == '"analyst"'
+    obj.execute("CREATE TABLE t (n Int64) ENGINE=MergeTree ORDER BY n")
+    obj.execute("INSERT INTO t VALUES (7)")
+    obj.checkpoint()
+    obj.close()
+    assert _count(ns, "x-cold", db="analyst") == "1"
+    _PASSED.append("a cold open starts in the object's own database")
 
 
-def test_database_name_needing_quotes():
-    # a db name with '-' is only valid backtick-quoted; unquoted it parses as
-    # subtraction and every CREATE/USE/BACKUP/RESTORE would fail. Exercises the
-    # full create -> backup -> restore -> WAL-replay path under such a name.
-    ns = cd.Namespace(URL, owner="w1", db="my-mem-db")
-    ns.destroy("obj-q")
-    o = ns.open("obj-q")
-    o.query("USE `my-mem-db`", "CSV")
-    o.execute("CREATE TABLE t (n Int64) ENGINE=MergeTree ORDER BY n")
-    o.execute("INSERT INTO t VALUES (42)")
-    o.flush()
-    o.close()
-    r = ns.open("obj-q")  # restore + replay under the quoted db
-    got = r.query("SELECT n FROM `my-mem-db`.t", "CSV").data().strip()
-    r.close()
-    assert got == "42", got
-    print("  database name needing quotes (my-mem-db) round-trips ✓")
+def test_wal_replay_uses_the_objects_database():
+    ns = cd.Namespace(URL, owner="w1", db="mem")
+    ns.destroy("x-replay", force=True)
+    obj = ns.open("x-replay")
+    obj.execute("CREATE TABLE t (n Int64) ENGINE=MergeTree ORDER BY n")  # unqualified
+    obj.execute("INSERT INTO t VALUES (1), (2), (3)")
+    obj.flush()   # no checkpoint: force a replay on reopen
+    obj.close()
+    assert _count(ns, "x-replay") == "3"
+    _PASSED.append("WAL replay restores the object's database context")
+
+
+def test_wal_keys_are_unique():
+    ns = _seeded("x-keys", 1)
+    obj = ns.open("x-keys")
+    obj.execute("INSERT INTO t VALUES (1)")
+    first = obj.flush()
+    obj.execute("INSERT INTO t VALUES (2)")
+    second = obj.flush()
+    obj.close()
+    assert first and second and first != second, (first, second)
+    _PASSED.append("every flush mints a unique WAL key")
+
+
+def test_constructor_validation():
+    backend = make_backend("local:" + tempfile.mkdtemp(prefix="dao-ttl-"))
+    for bad in (0, -1, float("inf"), float("nan")):
+        _expect(ValueError, cd.DurableObject, "x", backend, lease_ttl=bad)
+    _expect(ValueError, cd.DurableObject, "x", backend, clock_skew=-1)
+    # a heartbeat slower than a third of the TTL cannot survive one lost renewal
+    _expect(ValueError, cd.DurableObject, "x", backend, lease_ttl=30, heartbeat_interval=20)
+    cd.DurableObject("x", backend, lease_ttl=30, heartbeat_interval=10)
+    _PASSED.append("lease_ttl, clock_skew and heartbeat_interval are validated")
+
+
+TESTS = [
+    # §7.2 format fixtures
+    test_empty_object,
+    test_readonly_missing_object,
+    test_checkpoint_only,
+    test_checkpoint_plus_wal,
+    test_quoted_database_name,
+    test_missing_base_and_wal,
+    test_bad_base_size_and_digest,
+    test_bad_wal_size_and_digest,
+    test_unknown_reader_feature,
+    test_unknown_writer_feature,
+    test_future_protocol_version,
+    test_producer_version_differs_but_compatible,
+    test_engine_reader_too_old,
+    test_backup_format_too_new,
+    test_unknown_fields_round_trip,
+    test_json_shape_is_not_frozen,
+    # §7.3 classification
+    test_gates_cannot_be_bypassed_by_method_choice,
+    test_multi_statement_and_parallel_with_refused,
+    test_writes_outside_the_object_refused,
+    test_database_lifecycle_refused,
+    test_mutating_global_refused,
+    test_control_statements_refused,
+    test_secret_mutation_refused_without_leaking,
+    test_secret_read_only_runs_and_is_not_logged,
+    test_unknown_statement_fails_closed,
+    test_limits_report_limit_exceeded,
+    # §7.4 fault matrix
+    test_conditional_create_race,
+    test_wal_put_lands_but_head_cas_fails,
+    test_head_cas_committed_but_response_lost,
+    test_unprovable_commit_is_ambiguous,
+    test_wal_upload_landed_but_response_lost,
+    test_checkpoint_put_lands_but_head_cas_fails,
+    test_restore_failure_frees_the_engine,
+    test_heartbeat_renews_without_moving_generation_or_seq,
+    test_writer_self_fences_when_renewal_fails,
+    test_takeover_fences_the_previous_writer,
+    test_close_releases_and_then_refuses,
+    # leases, ids, namespace
+    test_lease_exclusion_and_same_owner_instance,
+    test_expired_lease_is_taken_without_force,
+    test_unexpired_lease_needs_force,
+    test_object_id_validation_and_path_traversal,
+    test_sibling_isolation,
+    test_destroy_refuses_an_active_lease,
+    test_scan_across_objects,
+    test_reopen_honors_persisted_db,
+    test_cold_open_lands_in_the_objects_database,
+    test_wal_replay_uses_the_objects_database,
+    test_wal_keys_are_unique,
+    test_constructor_validation,
+]
+
+
+def main():
+    print(f"backend URL: {URL}")
+    print(f"engine: {engine_version()}  protocol: V{cd.PROTOCOL_VERSION}")
+    for test in TESTS:
+        before = len(_PASSED)
+        test()
+        for line in _PASSED[before:]:
+            print(f"  {line} ✓")
+    print(f"ALL PASS ({len(_PASSED)} checks)")
 
 
 if __name__ == "__main__":
-    print(f"backend URL: {URL}")
-    ns = _fresh_ns()
-    test_wal_replay_unqualified_db_context(ns)
-    test_cold_open_leaves_session_in_object_db()
-    test_database_name_needing_quotes()
-    test_checkpoint_roundtrip(ns)
-    test_wal_incremental(ns)
-    test_checkpoint_folds_wal(ns)
-    test_lease_exclusion(ns)
-    test_fencing(ns)
-    test_scan(ns)
-    test_local_path_traversal()
-    test_sibling_isolation(ns)
-    test_object_id_rejects_slash(ns)
-    test_missing_reference_errors(ns)
-    test_wal_keys_unique(ns)
-    test_lease_renewal(ns)
-    test_same_owner_second_instance_blocked(ns)
-    test_put_if_absent_returns_etag(ns)
-    test_reconcile_detects_committed(ns)
-    test_destroy_refuses_active_lease(ns)
-    test_force_take(ns)
-    test_reopen_honors_persisted_db(ns)
-    test_lease_ttl_validation()
-    test_readonly_restore_failure_frees_session(ns)
-    print("ALL PASS")
+    main()


### PR DESCRIPTION
`chdb.durable` predates the frozen V1 protocol, and chdb-core v26.7.2-rc.2 now exports the ABI that protocol assumes. This brings the Python binding onto both.

**Engine, not string handling.** Backup and restore call `chdb_backup_database_n` / `chdb_restore_database_n`; nothing here assembles `BACKUP` or `RESTORE` text. Every public statement goes through `chdb_classify_query_n` — `query()` takes one `READ_ONLY` statement, `execute()` takes one `MUTATING` statement with no credential that writes only into this object's database and does not change its container. Refusals never quote the SQL.

**The frozen object format.** `head.json` gains `protocol` and `engine` sections; base and WAL references carry length + SHA-256, verified before use; a released lease has one fixed shape; unknown fields round-trip. Opening compares `backup_format` and `min_reader`, not version equality.

**Also.** The 14 error categories as distinguishable types; a per-object operation lock the lease heartbeat queues behind; self-fencing on unconfirmable renewal; §5.8 reconcile that reports `commit_ambiguous` rather than unproven success; checkpoints uploaded/downloaded by file.

Engine identity comes from `SELECT chdb()`, which returns the same `CHDB_VERSION` constant the C `chdb_version()` returns — that function is exported but not bound into Python, and `engine_version()` will prefer the binding if a later core adds one.

**Tests** are rebuilt as the contract's §7.2 fixtures, §7.3 scenarios, and §7.4 fault matrix (49 checks), driven partly by a backend that lies about what the provider said. `ALL PASS` against a locally built v26.7.2-rc.2 core.

**Two things reviewers should weigh in on.**

- `pyproject.toml` still says `chdb-core>=26.7.0`, and only `v26.7.2-rc.2` carries the ABI — a pre-release pip will not pick by default. So on a default install `chdb.durable` refuses at `open()` and this test module skips. Raising the floor needs a stable core release first; not done here.
- Objects written by the pre-V1 prototype are refused as `corrupt` (their checkpoints carry no length or digest, so a V1 reader cannot verify them). The error says so and points at export-and-reload. Community workaround is being tracked separately.

Out of scope, tracked as follow-ups: cross-binding fixture exchange (§7.5) and GC (§8.1). `destroy()` stays as a development convenience, marked as outside V1.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Implement frozen Durable V1 contract in `chdb.durable`
> - Implements the V1 protocol layer: frozen constants and validators in [protocol.py](https://github.com/chdb-io/chdb/pull/635/files#diff-2d45447a0277247a514842e3c9231e6ac99bea23a40ceb7293ac058af06cf364), structured head models in [head.py](https://github.com/chdb-io/chdb/pull/635/files#diff-e4ad16e30a0042e713418d023da8cfc058dcac701f1c1cb3ef925e731d34a422), JSONL WAL encoding/parsing in [wal.py](https://github.com/chdb-io/chdb/pull/635/files#diff-ffbaeaf19ffab5c4e851e2328535e79288ac0ef177d457d9ec61ba1e00a9e7b5), a typed error taxonomy in [errors.py](https://github.com/chdb-io/chdb/pull/635/files#diff-bdb2cc4eb3122b13c53453b9e943261dcbe0dde16aa23415be36188ea7dfc89c), engine ABI gating in [engine.py](https://github.com/chdb-io/chdb/pull/635/files#diff-b6f345c95c93f34ee8ac5e9ebd4fad6c0f9fde56da4d6c0414ccd84a70e60d48), and SHA-256 digest verification in [digest.py](https://github.com/chdb-io/chdb/pull/635/files#diff-78d643233c413e001041bc65ca4804dbc7c7da624094707243783a23abefce7b)
> - Reworks `DurableObject` in [object.py](https://github.com/chdb-io/chdb/pull/635/files#diff-65082cd9f06eff60433e3c7c536498cd1971cf7610af29e5ff6e7584c1aba610) around the V1 lifecycle: generation-based lease CAS fencing, automatic heartbeat renewal, immutable WAL/checkpoint publishing with ambiguous-commit reconciliation, and parser-based statement classification that gates `query()` to single read-only statements and `execute()` to approved single-database mutations
> - Refactors the `Backend` protocol in [backends/__init__.py](https://github.com/chdb-io/chdb/pull/635/files#diff-edf2a4593a6ca5d237c043410bc0506bca8ddfaabb6e878934df53663d42288a): removes `put` and `head_etag`, adds `put_bytes_if_absent`, `put_file_if_absent`, and `download_to_file`; all four backends (S3, GCS, Azure, local) now distinguish CAS misses from `BackendAmbiguous` responses and support atomic file-based transfers
> - Replaces the legacy smoke-test set with a V1 conformance registry in [test_durable.py](https://github.com/chdb-io/chdb/pull/635/files#diff-61099a5feac6fd583615f2a94e5679da8123d9db22b7b104196ae7d2063c6dd4) covering format fixtures, fault injection, lease behavior, and namespace safety; adds a Durable V1 conformance step to all four wheel-build CI workflows and adds the normative contract spec in [CHDB_DURABLE_V1_CONTRACT.md](https://github.com/chdb-io/chdb/pull/635/files#diff-959b4374ee7bea9e8b446b290683884c6309c46332f582b307b8d2de9789d863)
> - Risk: the `Backend` protocol change is breaking — out-of-tree backends must implement `put_bytes_if_absent`, `put_file_if_absent`, `download_to_file`, and `replace_if_match` with ambiguous-response semantics; `DurableObject.suspend()` is removed (callers must use `flush()`); `__version__` changes from `0.1.0` to `1.0`; `Namespace.delete` now treats unparseable heads as lease-free instead of propagating the parse error
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 8f819f1.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->