### PR TITLE
Add a chdb console script so pipx and uvx can run the CLI

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -52,8 +52,6 @@ durable = ["boto3>=1.36"]  # IfMatch/IfNoneMatch conditional writes on PutObject
 durable-gcs = ["google-cloud-storage"]
 durable-azure = ["azure-storage-blob"]
 
-# Expose the `python -m chdb` CLI as a `chdb` command, so `pipx install chdb` and
-# `uvx chdb "SELECT 1"` work. main() lives in chdb-core's chdb/__main__.py.
 [project.scripts]
 chdb = "chdb.__main__:main"
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -52,6 +52,11 @@ durable = ["boto3>=1.36"]  # IfMatch/IfNoneMatch conditional writes on PutObject
 durable-gcs = ["google-cloud-storage"]
 durable-azure = ["azure-storage-blob"]
 
+# Expose the `python -m chdb` CLI as a `chdb` command, so `pipx install chdb` and
+# `uvx chdb "SELECT 1"` work. main() lives in chdb-core's chdb/__main__.py.
+[project.scripts]
+chdb = "chdb.__main__:main"
+
 # chDB registers itself with clickhouse-connect through these entry points. clickhouse-connect
 # discovers them at runtime; it never imports chdb directly.
 [project.entry-points."clickhouse_connect.backends"]


### PR DESCRIPTION
Closes #125.

chdb ships a CLI (`chdb/__main__.py`, from chdb-core) but the wheel declares no
entry point, so it is reachable only through `python -m chdb`. That rules out
the zero-setup installers people reach for first:

```
$ pipx install chdb
No apps associated with package chdb ...
$ uvx chdb "SELECT 1"
error: Failed to spawn: `chdb`
```

One `[project.scripts]` entry fixes both, and `uvx chdb "SELECT 1"` becomes a
one-liner with no virtualenv to manage.

Verified with a wheel built from this branch, installed next to
chdb-core 26.7.0 on Python 3.12:

```
$ chdb "SELECT 1,'abc'" Pretty
   ┏━━━┳━━━━━━━┓
   ┃ 1 ┃ 'abc' ┃
   ┡━━━╇━━━━━━━┩
1. │ 1 │ abc   │
   └───┴───────┘
$ chdb --help | head -1
usage: chdb [-h] "SELECT 1" [format]
```

Needs chdb-io/chdb-core#219 to be released alongside it: `main()` currently
raises `NameError: name '__path__' is not defined` (the same crash that has made
`python -m chdb` unusable since 4.1.8), so the console script would land broken
without it.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add `chdb` console script entry point in `pyproject.toml`
> Registers a `chdb` project script that dispatches to `chdb.__main__:main`. This lets pipx and uvx run the CLI as a standalone command after install.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 588abab.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->