### PR TITLE
Run the durable conformance suite against an engine that has the ABI

### DIFF
--- a/.github/workflows/build_linux_arm64_wheels-gh.yml
+++ b/.github/workflows/build_linux_arm64_wheels-gh.yml
@@ -194,29 +194,48 @@ jobs:
           python -m pip install dist/*.whl --force-reinstall
           python -m pip install pytest
 
-          # Durable V1 needs chdb-core's backup / restore / query-analysis ABI.
-          # Until a chdb-core carrying it is what pip resolves by default, the
-          # module skips itself — and that skip is as much the thing under test
-          # as the checks are, so this step is green either way and turns into
-          # real coverage the day the dependency catches up.
-          set +e
-          python -m pytest tests/test_durable.py -v --tb=short
-          code=$?
-          set -e
-          if [ "$code" -eq 5 ]; then
-            # Exit 5 is pytest's "collected nothing", which is what a
-            # module-level skip looks like from outside. Accepting it blindly
-            # would also swallow a suite that stopped being collected for some
-            # unrelated reason, so make it prove why it skipped.
-            python - <<'PY'
+          # Move the engine to the pre-release that carries the Durable V1 ABI,
+          # then put the wrapper back on top of it.
+          #
+          # The second install is not redundant. chdb and chdb-core both own
+          # chdb/__init__.py, so whichever lands last wins, and the wrapper's
+          # is the one that has to: chdb-core ships a superset that happens to
+          # work today, which is not a property to build a test job on.
+          #
+          # --no-deps on both keeps pip from re-resolving chdb-core back down
+          # to what PyPI offers.
+          python -m pip install --force-reinstall --no-deps "$CHDB_CORE_ABI_WHEEL"
+          python -m pip install dist/*.whl --force-reinstall --no-deps
+
+          # Name the engine under test before running anything, so the wrong
+          # one is one line of output rather than 49 collection errors.
+          python - <<'PY'
           import sys
-          from chdb.durable.engine import engine_has_v1_abi
-          if engine_has_v1_abi():
-              sys.exit("collected nothing even though this chdb-core has the "
-                       "Durable V1 ABI — the suite is no longer running")
-          print("durable suite skipped: this chdb-core has no Durable V1 ABI")
+          from chdb.durable.engine import engine_has_v1_abi, engine_version
+          if not engine_has_v1_abi():
+              sys.exit("chdb-core does not export the Durable V1 ABI")
+          print("durable conformance: chdb-core " + engine_version())
           PY
-          elif [ "$code" -ne 0 ]; then
-            exit "$code"
-          fi
+
+          # Exit 5 — pytest collecting nothing — used to be tolerated here,
+          # because a module-level skip was the expected outcome on an engine
+          # without the ABI. With the engine pinned there is nothing left for
+          # that tolerance to excuse: collecting nothing now means the suite
+          # stopped running, so the exit status stands on its own.
+          python -m pytest tests/test_durable.py -v --tb=short
+        env:
+          # Pinned, and pinned to a pre-release on purpose.
+          #
+          # No chdb-core on PyPI exports backup_database / restore_database /
+          # classify_query — 26.7.0 is the newest published — so resolving
+          # the dependency normally leaves this suite skipping itself, and a
+          # step that is green whether or not it ran is not a check. The wheels
+          # are already attached to the chdb-core release, so pinning one costs
+          # a download and no build.
+          #
+          # This comes out when a chdb-core carrying the ABI is what pip
+          # resolves by default and chdb's floor rises to match. Until then the
+          # pre-release version keeps anything here from reading as a stable
+          # dependency.
+          CHDB_CORE_ABI_WHEEL: https://github.com/chdb-io/chdb-core/releases/download/v26.7.2-rc.2/chdb_core-26.7.2-cp39-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.whl
         continue-on-error: false

--- a/.github/workflows/build_linux_arm64_wheels-gh.yml
+++ b/.github/workflows/build_linux_arm64_wheels-gh.yml
@@ -13,7 +13,6 @@ on:
       - main
     paths-ignore:
       - 'docs/**'
-      - '.github/workflows/build_*_wheels*.yml'
       - '.github/workflows/external_clickhouse_integration.yaml'
   pull_request:
     types: [opened, synchronize, reopened, ready_for_review]
@@ -21,7 +20,6 @@ on:
       - main
     paths-ignore:
       - 'docs/**'
-      - '.github/workflows/build_*_wheels*.yml'
       - '.github/workflows/external_clickhouse_integration.yaml'
 
 jobs:

--- a/.github/workflows/build_linux_x86_wheels.yml
+++ b/.github/workflows/build_linux_x86_wheels.yml
@@ -221,31 +221,50 @@ jobs:
           python -m pip install dist/*.whl --force-reinstall
           python -m pip install pytest
 
-          # Durable V1 needs chdb-core's backup / restore / query-analysis ABI.
-          # Until a chdb-core carrying it is what pip resolves by default, the
-          # module skips itself — and that skip is as much the thing under test
-          # as the checks are, so this step is green either way and turns into
-          # real coverage the day the dependency catches up.
-          set +e
-          python -m pytest tests/test_durable.py -v --tb=short
-          code=$?
-          set -e
-          if [ "$code" -eq 5 ]; then
-            # Exit 5 is pytest's "collected nothing", which is what a
-            # module-level skip looks like from outside. Accepting it blindly
-            # would also swallow a suite that stopped being collected for some
-            # unrelated reason, so make it prove why it skipped.
-            python - <<'PY'
+          # Move the engine to the pre-release that carries the Durable V1 ABI,
+          # then put the wrapper back on top of it.
+          #
+          # The second install is not redundant. chdb and chdb-core both own
+          # chdb/__init__.py, so whichever lands last wins, and the wrapper's
+          # is the one that has to: chdb-core ships a superset that happens to
+          # work today, which is not a property to build a test job on.
+          #
+          # --no-deps on both keeps pip from re-resolving chdb-core back down
+          # to what PyPI offers.
+          python -m pip install --force-reinstall --no-deps "$CHDB_CORE_ABI_WHEEL"
+          python -m pip install dist/*.whl --force-reinstall --no-deps
+
+          # Name the engine under test before running anything, so the wrong
+          # one is one line of output rather than 49 collection errors.
+          python - <<'PY'
           import sys
-          from chdb.durable.engine import engine_has_v1_abi
-          if engine_has_v1_abi():
-              sys.exit("collected nothing even though this chdb-core has the "
-                       "Durable V1 ABI — the suite is no longer running")
-          print("durable suite skipped: this chdb-core has no Durable V1 ABI")
+          from chdb.durable.engine import engine_has_v1_abi, engine_version
+          if not engine_has_v1_abi():
+              sys.exit("chdb-core does not export the Durable V1 ABI")
+          print("durable conformance: chdb-core " + engine_version())
           PY
-          elif [ "$code" -ne 0 ]; then
-            exit "$code"
-          fi
+
+          # Exit 5 — pytest collecting nothing — used to be tolerated here,
+          # because a module-level skip was the expected outcome on an engine
+          # without the ABI. With the engine pinned there is nothing left for
+          # that tolerance to excuse: collecting nothing now means the suite
+          # stopped running, so the exit status stands on its own.
+          python -m pytest tests/test_durable.py -v --tb=short
+        env:
+          # Pinned, and pinned to a pre-release on purpose.
+          #
+          # No chdb-core on PyPI exports backup_database / restore_database /
+          # classify_query — 26.7.0 is the newest published — so resolving
+          # the dependency normally leaves this suite skipping itself, and a
+          # step that is green whether or not it ran is not a check. The wheels
+          # are already attached to the chdb-core release, so pinning one costs
+          # a download and no build.
+          #
+          # This comes out when a chdb-core carrying the ABI is what pip
+          # resolves by default and chdb's floor rises to match. Until then the
+          # pre-release version keeps anything here from reading as a stable
+          # dependency.
+          CHDB_CORE_ABI_WHEEL: https://github.com/chdb-io/chdb-core/releases/download/v26.7.2-rc.2/chdb_core-26.7.2-cp39-abi3-manylinux2014_x86_64.manylinux_2_17_x86_64.whl
         continue-on-error: false
       - name: Upload wheels to release
         if: startsWith(github.ref, 'refs/tags/v')

--- a/.github/workflows/build_linux_x86_wheels.yml
+++ b/.github/workflows/build_linux_x86_wheels.yml
@@ -13,7 +13,6 @@ on:
       - main
     paths-ignore:
       - 'docs/**'
-      - '.github/workflows/build_*_wheels*.yml'
       - '.github/workflows/external_clickhouse_integration.yaml'
   pull_request:
     types: [opened, synchronize, reopened, ready_for_review]
@@ -21,7 +20,6 @@ on:
       - main
     paths-ignore:
       - 'docs/**'
-      - '.github/workflows/build_*_wheels*.yml'
       - '.github/workflows/external_clickhouse_integration.yaml'
 
 jobs:

--- a/.github/workflows/build_macos_arm64_wheels.yml
+++ b/.github/workflows/build_macos_arm64_wheels.yml
@@ -172,29 +172,48 @@ jobs:
           python -m pip install dist/*.whl --force-reinstall
           python -m pip install pytest
 
-          # Durable V1 needs chdb-core's backup / restore / query-analysis ABI.
-          # Until a chdb-core carrying it is what pip resolves by default, the
-          # module skips itself — and that skip is as much the thing under test
-          # as the checks are, so this step is green either way and turns into
-          # real coverage the day the dependency catches up.
-          set +e
-          python -m pytest tests/test_durable.py -v --tb=short
-          code=$?
-          set -e
-          if [ "$code" -eq 5 ]; then
-            # Exit 5 is pytest's "collected nothing", which is what a
-            # module-level skip looks like from outside. Accepting it blindly
-            # would also swallow a suite that stopped being collected for some
-            # unrelated reason, so make it prove why it skipped.
-            python - <<'PY'
+          # Move the engine to the pre-release that carries the Durable V1 ABI,
+          # then put the wrapper back on top of it.
+          #
+          # The second install is not redundant. chdb and chdb-core both own
+          # chdb/__init__.py, so whichever lands last wins, and the wrapper's
+          # is the one that has to: chdb-core ships a superset that happens to
+          # work today, which is not a property to build a test job on.
+          #
+          # --no-deps on both keeps pip from re-resolving chdb-core back down
+          # to what PyPI offers.
+          python -m pip install --force-reinstall --no-deps "$CHDB_CORE_ABI_WHEEL"
+          python -m pip install dist/*.whl --force-reinstall --no-deps
+
+          # Name the engine under test before running anything, so the wrong
+          # one is one line of output rather than 49 collection errors.
+          python - <<'PY'
           import sys
-          from chdb.durable.engine import engine_has_v1_abi
-          if engine_has_v1_abi():
-              sys.exit("collected nothing even though this chdb-core has the "
-                       "Durable V1 ABI — the suite is no longer running")
-          print("durable suite skipped: this chdb-core has no Durable V1 ABI")
+          from chdb.durable.engine import engine_has_v1_abi, engine_version
+          if not engine_has_v1_abi():
+              sys.exit("chdb-core does not export the Durable V1 ABI")
+          print("durable conformance: chdb-core " + engine_version())
           PY
-          elif [ "$code" -ne 0 ]; then
-            exit "$code"
-          fi
+
+          # Exit 5 — pytest collecting nothing — used to be tolerated here,
+          # because a module-level skip was the expected outcome on an engine
+          # without the ABI. With the engine pinned there is nothing left for
+          # that tolerance to excuse: collecting nothing now means the suite
+          # stopped running, so the exit status stands on its own.
+          python -m pytest tests/test_durable.py -v --tb=short
+        env:
+          # Pinned, and pinned to a pre-release on purpose.
+          #
+          # No chdb-core on PyPI exports backup_database / restore_database /
+          # classify_query — 26.7.0 is the newest published — so resolving
+          # the dependency normally leaves this suite skipping itself, and a
+          # step that is green whether or not it ran is not a check. The wheels
+          # are already attached to the chdb-core release, so pinning one costs
+          # a download and no build.
+          #
+          # This comes out when a chdb-core carrying the ABI is what pip
+          # resolves by default and chdb's floor rises to match. Until then the
+          # pre-release version keeps anything here from reading as a stable
+          # dependency.
+          CHDB_CORE_ABI_WHEEL: https://github.com/chdb-io/chdb-core/releases/download/v26.7.2-rc.2/chdb_core-26.7.2-cp39-abi3-macosx_11_0_arm64.whl
         continue-on-error: false

--- a/.github/workflows/build_macos_arm64_wheels.yml
+++ b/.github/workflows/build_macos_arm64_wheels.yml
@@ -13,7 +13,6 @@ on:
       - main
     paths-ignore:
       - 'docs/**'
-      - '.github/workflows/build_*_wheels*.yml'
       - '.github/workflows/external_clickhouse_integration.yaml'
   pull_request:
     types: [opened, synchronize, reopened, ready_for_review]
@@ -21,7 +20,6 @@ on:
       - main
     paths-ignore:
       - 'docs/**'
-      - '.github/workflows/build_*_wheels*.yml'
       - '.github/workflows/external_clickhouse_integration.yaml'
 
 jobs:

--- a/.github/workflows/build_macos_x86_wheels.yml
+++ b/.github/workflows/build_macos_x86_wheels.yml
@@ -193,29 +193,48 @@ jobs:
           python -m pip install dist/*.whl --force-reinstall
           python -m pip install pytest
 
-          # Durable V1 needs chdb-core's backup / restore / query-analysis ABI.
-          # Until a chdb-core carrying it is what pip resolves by default, the
-          # module skips itself — and that skip is as much the thing under test
-          # as the checks are, so this step is green either way and turns into
-          # real coverage the day the dependency catches up.
-          set +e
-          python -m pytest tests/test_durable.py -v --tb=short
-          code=$?
-          set -e
-          if [ "$code" -eq 5 ]; then
-            # Exit 5 is pytest's "collected nothing", which is what a
-            # module-level skip looks like from outside. Accepting it blindly
-            # would also swallow a suite that stopped being collected for some
-            # unrelated reason, so make it prove why it skipped.
-            python - <<'PY'
+          # Move the engine to the pre-release that carries the Durable V1 ABI,
+          # then put the wrapper back on top of it.
+          #
+          # The second install is not redundant. chdb and chdb-core both own
+          # chdb/__init__.py, so whichever lands last wins, and the wrapper's
+          # is the one that has to: chdb-core ships a superset that happens to
+          # work today, which is not a property to build a test job on.
+          #
+          # --no-deps on both keeps pip from re-resolving chdb-core back down
+          # to what PyPI offers.
+          python -m pip install --force-reinstall --no-deps "$CHDB_CORE_ABI_WHEEL"
+          python -m pip install dist/*.whl --force-reinstall --no-deps
+
+          # Name the engine under test before running anything, so the wrong
+          # one is one line of output rather than 49 collection errors.
+          python - <<'PY'
           import sys
-          from chdb.durable.engine import engine_has_v1_abi
-          if engine_has_v1_abi():
-              sys.exit("collected nothing even though this chdb-core has the "
-                       "Durable V1 ABI — the suite is no longer running")
-          print("durable suite skipped: this chdb-core has no Durable V1 ABI")
+          from chdb.durable.engine import engine_has_v1_abi, engine_version
+          if not engine_has_v1_abi():
+              sys.exit("chdb-core does not export the Durable V1 ABI")
+          print("durable conformance: chdb-core " + engine_version())
           PY
-          elif [ "$code" -ne 0 ]; then
-            exit "$code"
-          fi
+
+          # Exit 5 — pytest collecting nothing — used to be tolerated here,
+          # because a module-level skip was the expected outcome on an engine
+          # without the ABI. With the engine pinned there is nothing left for
+          # that tolerance to excuse: collecting nothing now means the suite
+          # stopped running, so the exit status stands on its own.
+          python -m pytest tests/test_durable.py -v --tb=short
+        env:
+          # Pinned, and pinned to a pre-release on purpose.
+          #
+          # No chdb-core on PyPI exports backup_database / restore_database /
+          # classify_query — 26.7.0 is the newest published — so resolving
+          # the dependency normally leaves this suite skipping itself, and a
+          # step that is green whether or not it ran is not a check. The wheels
+          # are already attached to the chdb-core release, so pinning one costs
+          # a download and no build.
+          #
+          # This comes out when a chdb-core carrying the ABI is what pip
+          # resolves by default and chdb's floor rises to match. Until then the
+          # pre-release version keeps anything here from reading as a stable
+          # dependency.
+          CHDB_CORE_ABI_WHEEL: https://github.com/chdb-io/chdb-core/releases/download/v26.7.2-rc.2/chdb_core-26.7.2-cp39-abi3-macosx_10_15_x86_64.whl
         continue-on-error: false

--- a/.github/workflows/build_macos_x86_wheels.yml
+++ b/.github/workflows/build_macos_x86_wheels.yml
@@ -13,7 +13,6 @@ on:
       - main
     paths-ignore:
       - 'docs/**'
-      - '.github/workflows/build_*_wheels*.yml'
       - '.github/workflows/external_clickhouse_integration.yaml'
   pull_request:
     types: [opened, synchronize, reopened, ready_for_review]
@@ -21,7 +20,6 @@ on:
       - main
     paths-ignore:
       - 'docs/**'
-      - '.github/workflows/build_*_wheels*.yml'
       - '.github/workflows/external_clickhouse_integration.yaml'
 
 jobs:


### PR DESCRIPTION
The durable conformance step added with the V1 contract (#635) was green whether or not it ran.

No chdb-core on PyPI exports `backup_database` / `restore_database` / `classify_query` — 26.7.0 is the newest published — so resolving the dependency normally left `tests/test_durable.py` skipping itself at module level, and the step accepted pytest's exit 5 to let that pass. The 49 checks have therefore never run anywhere but the machine they were written on.

The wheels carrying the ABI are already attached to the [chdb-core v26.7.2-rc.2 release](https://github.com/chdb-io/chdb-core/releases/tag/v26.7.2-rc.2), so this pins one per platform and installs it directly. No build, no PyPI release, one download per job.

**Two things about it are less obvious than they look.**

The engine install is followed by a second install of the wrapper wheel, which is not redundant: `chdb` and `chdb-core` both own `chdb/__init__.py`, so whichever lands last wins. Measured, the two orders really do differ — engine-last leaves chdb-core's 10594-byte copy in place instead of the wrapper's 8366-byte one. Both pass today only because chdb-core ships a compatible superset, and that is not a property to build a test job on. `--no-deps` on both installs keeps pip from resolving chdb-core back down to what PyPI offers.

The exit-5 tolerance is **removed** rather than kept as a safety net. It existed to excuse the expected skip; with the engine pinned there is nothing left for it to excuse, and collecting nothing now means the suite stopped running. A one-line assertion ahead of pytest names the engine actually loaded, so a wrong pin reads as one line instead of 49 collection errors.

**Verification** (macOS arm64, against the release wheel this pins rather than a local build):

```
ABI present: True
engine_version(): 26.7.2-rc.2
49 passed in 3.94s
```

All four pinned URLs were checked against the release's asset list, and each workflow gets its own platform's wheel.

**The pin is deliberately a pre-release**, so nothing here reads as a stable dependency. It comes out when a chdb-core carrying the ABI is what pip resolves by default and chdb's floor rises to match.

Not in scope: `_ABI_HINT` in `chdb/durable/engine.py` still says `pip install -U chdb-core`, which lands on 26.7.0 and helps nobody. Fixing it means naming an install channel that does not exist yet, so it belongs with that channel rather than here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Run durable conformance suite against pinned chdb-core 26.7.2 wheel in CI workflows
> - Installs the architecture-specific `chdb-core` 26.7.2 release-candidate wheel before reinstalling the built `chdb` wrapper in the Linux arm64/x86_64 and macOS arm64/x86_64 wheel workflows
> - Adds a preflight check that fails the step when the Durable V1 ABI is missing and prints the engine version
> - Runs the durable pytest suite directly so its real exit status propagates, including exit 5 for no collected tests, instead of tolerating skips or empty runs
> - Removes the wheel-workflow glob from the push and pull_request `paths-ignore` filters so edits to these workflow files can trigger the workflows
> - Risk: the durable step now fails on missing Durable V1 ABI or empty test collection where it previously passed; reviewers should check the preflight check and pytest invocation in each modified workflow file
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized dbf2517.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->