### PR TITLE
datastore: fix from_arrow() producing DataStores that fail every SQL path

### DIFF
--- a/datastore/core.py
+++ b/datastore/core.py
@@ -2864,15 +2864,25 @@ class DataStore(PandasCompatMixin):
                 f"got {type(data).__name__}"
             )
 
-        # Arrow-backed pandas (``pd.ArrowDtype``) keeps the source's Arrow types
-        # faithfully (nullable ints stay nullable, no int->float coercion), which
-        # chDB's Python() table function reads directly. Fall back to the default
-        # numpy-backed conversion if a type has no Arrow-backed mapping.
-        try:
-            df = table.to_pandas(types_mapper=pd.ArrowDtype)
-        except Exception:
-            df = table.to_pandas()
-        return cls.from_df(df, name=name)
+        # chDB's Python() table function rejects ``pd.ArrowDtype`` columns
+        # outright (code 48, NOT_IMPLEMENTED), so materialize into dtypes it can
+        # read. Integers and booleans use pandas' nullable extension dtypes, which
+        # keep nullability without the int->float widening the default conversion
+        # would apply; every other type takes the default NumPy-backed mapping.
+        #
+        # Floats deliberately stay NumPy-backed: pandas nullable Float64/Float32
+        # built by pyarrow leave 0.0 under the validity mask and chDB reads it as
+        # a real 0 (chdb-core#225). NumPy float64 + NaN round-trips correctly.
+        def _pandas_dtype(arrow_type):
+            if pa.types.is_unsigned_integer(arrow_type):
+                return pd.UInt64Dtype()
+            if pa.types.is_signed_integer(arrow_type):
+                return pd.Int64Dtype()
+            if pa.types.is_boolean(arrow_type):
+                return pd.BooleanDtype()
+            return None
+
+        return cls.from_df(table.to_pandas(types_mapper=_pandas_dtype), name=name)
 
     @classmethod
     def uri(cls, uri: str, **kwargs) -> "DataStore":

--- a/datastore/tests/test_arrow_interop.py
+++ b/datastore/tests/test_arrow_interop.py
@@ -200,6 +200,31 @@ class TestFromArrow:
         with pytest.raises(TypeError):
             DataStore.from_arrow(object())
 
+    def test_sql_path_executes(self):
+        """Ingested data must survive the SQL path, not just the to_df() passthrough.
+
+        ``to_df()`` returns the source frame without touching chDB, so it stays
+        green even when every column dtype is unreadable by the Python() engine.
+        Anything that actually builds a query has to be exercised too.
+        """
+        ds = DataStore.from_arrow(pa.table({"n": [1, 2, 3], "s": ["a", "b", "c"]}))
+        assert ds.head(2)["n"].tolist() == [1, 2]
+        assert ds.filter(ds.n > 1).to_df()["s"].tolist() == ["b", "c"]
+        assert ds.sort_values("n", ascending=False).to_df()["n"].tolist() == [3, 2, 1]
+
+    def test_nullable_int_survives_sql_path(self):
+        """Nullable ints must stay ints (no float widening) *and* stay queryable."""
+        tbl = pa.table({"n": pa.array([1, None, 3], pa.int64())})
+        ds = DataStore.from_arrow(tbl)
+        assert str(ds.to_df()["n"].dtype) == "Int64"
+        assert ds.filter(ds.n > 1).to_df()["n"].tolist() == [3]
+
+    def test_unsigned_int_not_narrowed(self):
+        """uint64 above 2**63-1 must not be forced through a signed dtype."""
+        big = 2**64 - 1
+        ds = DataStore.from_arrow(pa.table({"u": pa.array([1, big], pa.uint64())}))
+        assert ds.to_df()["u"].tolist() == [1, big]
+
 
 # --------------------------------------------------------------------------------------
 # Round-trips


### PR DESCRIPTION
Fixes #638.

`from_arrow()` materialized with `types_mapper=pd.ArrowDtype`, which chDB's `Python()` engine rejects outright (code 48, `NOT_IMPLEMENTED`). Only `to_df()` worked — it returns the source frame without touching chDB — so `head()`, `filter()`, `sort_values()` and `sql()` all failed at execution time, for every input type.

## Change

`datastore/core.py` — materialize into dtypes the engine can read:

- signed integers → `Int64`, unsigned → `UInt64`, booleans → `boolean`. These keep nullability without the int→float widening that motivated `ArrowDtype` in the first place, and they stay pandas frames, so `_row_id`, top-N pushdown and the zero-copy column cache all keep working.
- everything else → the default NumPy-backed mapping.
- floats deliberately stay NumPy-backed: pandas nullable `Float64`/`Float32` built by pyarrow leave `0.0` under the validity mask and chDB reads it as a real `0` (chdb-io/chdb-core#225). NumPy `float64` + `NaN` round-trips correctly.

`UInt64` rather than `Int64` for unsigned matters — `Int64` raises `ArrowInvalid` on values above `2**63-1`.

## Tests

Three added to `TestFromArrow`; two of them fail on `main`:

- `test_sql_path_executes` — `head` / `filter` / `sort_values` after `from_arrow`
- `test_nullable_int_survives_sql_path` — nullable ints stay `Int64` *and* stay queryable
- `test_unsigned_int_not_narrowed` — `2**64-1` round-trips

No test previously ran a query after `from_arrow`, which is why this stayed green. The `.filter()` calls at lines 146/152/196 are on the source `from_file` DataStore, before conversion.

Full file green against chdb-core 26.7.0 / pandas 3.0.5 / pyarrow 25.0.1: `52 passed, 1 skipped`.

## Fidelity note

Exotic Arrow types degrade rather than fail — measured through the new path: `decimal128`, `date32`, `binary`, `list`, `struct` and `map` land as strings via `object`; `duration` becomes an integer; `int8`/`uint64` widen to 64-bit. `float32`, timestamps (incl. tz-aware), `large_string`, `dictionary` and `null` are lossless. That is strictly better than today, where all of them raise code 48 — and chdb-io/chdb-core#226 tracks reading `ArrowDtype` natively, which would let this whole workaround be deleted.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix `DataStore.from_arrow()` producing frames that fail every SQL path
> Replaces the Arrow-backed pandas conversion and broad exception fallback in `from_arrow` with a dtype mapper passed to `table.to_pandas`. Unsigned integers map to `UInt64Dtype`, signed integers to `Int64Dtype`, booleans to `BooleanDtype`, and other Arrow types use the default NumPy-backed conversion. The result still feeds `DataStore.from_df`.
>
> - Adds tests in [test_arrow_interop.py](https://github.com/chdb-io/chdb/pull/639/files#diff-5c0bf1d605665ef41df35a5ccbb0521842bd31256cf463254075ab5f53e99af4) covering head/filter/sort via SQL, nullable int64 dtype preservation, and uint64 max-value survival.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 9e9e6a5.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->