### PR TITLE
Give the bindings one local URL and one default database

### DIFF
--- a/chdb/durable/__init__.py
+++ b/chdb/durable/__init__.py
@@ -25,7 +25,7 @@ buffers it; `flush()` is what makes it recoverable elsewhere. A service that
 promises a completed request survives a crash has to await `flush()` before it
 answers.
 
-Requires a chdb-core with the Durable V1 ABI (26.7.2-rc.2 or newer): backup,
+Requires chdb-core 26.7.2-rc.2 or newer (`pip install -U chdb-core`): backup,
 restore and statement classification are the engine's job, and this package
 builds no `BACKUP`/`RESTORE` SQL and runs no regex over a caller's statement.
 

--- a/chdb/durable/backends/__init__.py
+++ b/chdb/durable/backends/__init__.py
@@ -30,7 +30,7 @@ state machine reconciles it (§5.8) into success, `lease_fenced`, or
 `Namespace.destroy`, which is a development convenience outside the protocol.
 
 `make_backend(url, sub)` maps a URL to a backend scoped to `<base>/<sub>`:
-    local:/path/to/root
+    local:/path/to/root         (`file:///path/to/root` and a bare path too)
     s3://bucket/prefix          (endpoint via CHDB_DURABLE_S3_ENDPOINT for MinIO/R2)
     gcs://bucket/prefix
     azure://container/prefix
@@ -39,7 +39,7 @@ from __future__ import annotations
 
 import os
 from typing import Optional, Protocol, runtime_checkable
-from urllib.parse import urlparse
+from urllib.parse import unquote, urlparse
 
 
 @runtime_checkable
@@ -64,9 +64,16 @@ def make_backend(url: str, sub: str = "") -> Backend:
     u = urlparse(url)
     scheme = u.scheme or "local"
 
-    if scheme == "local":
+    # `file:` and `local:` are one backend under two names. Each binding grew
+    # its own spelling -- Node writes `file:`, this one wrote `local:`, Go
+    # takes either -- and a namespace URL is the sort of thing that gets shared
+    # between a Python service and a Node one, so all three answer to both.
+    if scheme in ("local", "file"):
         from .local import LocalFSBackend
         root = (u.netloc + u.path) if u.netloc else u.path
+        # A file: URL is percent-encoded; local: and a bare path are literal.
+        if scheme == "file":
+            root = unquote(root)
         base = os.path.realpath(root)
         # Constrain the object id beneath root — a caller-controlled sub like
         # "../../x", an absolute path, or a symlink to an outside dir would

--- a/chdb/durable/engine.py
+++ b/chdb/durable/engine.py
@@ -29,11 +29,49 @@ from .errors import EngineError, EngineIncompatible
 #: refusal can list what is missing rather than fail on first use.
 _REQUIRED_ABI = ("backup_database", "restore_database", "classify_query")
 
-_ABI_HINT = (
-    "chdb.durable needs a chdb-core with the Durable V1 ABI "
-    "(backup_database / restore_database / classify_query), i.e. 26.7.2-rc.2 "
-    "or newer: pip install -U chdb-core"
-)
+#: Where the wheels that carry the ABI actually are. Not PyPI: a chdb-core
+#: release is about half a gigabyte of wheels against a project quota that only
+#: moves one way, so releases are published to GitHub and only some of them go
+#: on to PyPI. `pip install -U chdb-core` therefore does not reliably get you a
+#: newer engine, and a hint that says it does sends people in a circle.
+_RELEASES_URL = "https://github.com/chdb-io/chdb-core/releases"
+
+#: The first chdb-core that exports backup / restore / classify.
+_ABI_SINCE = "26.7.2-rc.2"
+
+
+def _abi_hint(missing=()) -> str:
+    """Why the engine was refused, which engine it was, and what to install.
+
+    The version is in the message because without it the two failures read
+    identically: an engine too old to have the ABI, and a new engine that the
+    wrapper is not actually loading because something else owns `chdb/`.
+    """
+    try:
+        loaded = engine_version() or "unknown"
+    except Exception:
+        loaded = "unknown"
+
+    lines = [
+        "chdb.durable needs a chdb-core with the Durable V1 ABI "
+        "(backup_database / restore_database / classify_query), added in "
+        f"{_ABI_SINCE}.",
+        f"The engine loaded here reports {loaded}.",
+    ]
+    if missing:
+        lines.append("Missing: " + ", ".join(missing) + ".")
+    lines += [
+        "",
+        "chdb-core wheels are published as release assets, and the newest one "
+        "on PyPI may be older than the newest release, so `pip install -U "
+        "chdb-core` is not enough. Install the wheel for your platform from "
+        f"{_RELEASES_URL}/latest in the same command as chdb, so the wrapper's "
+        "chdb/__init__.py lands on top of the engine's:",
+        "",
+        '    pip install "chdb[durable]" \\',
+        '      "chdb-core @ <the chdb_core-*.whl URL for your platform>"',
+    ]
+    return "\n".join(lines)
 
 #: Settings pinned on the managed connection. A durable object promises that a
 #: statement `execute()` returned from has actually been applied locally, so
@@ -68,7 +106,7 @@ def engine_has_v1_abi() -> bool:
 def require_v1_abi() -> None:
     """Refuse early, with a message that names the fix."""
     if not engine_has_v1_abi():
-        raise EngineIncompatible(_ABI_HINT)
+        raise EngineIncompatible(_abi_hint())
 
 
 #: `chdb_version()` is a compile-time constant, so one reading holds for the
@@ -223,7 +261,7 @@ class ManagedConnection:
         missing = [n for n in _REQUIRED_ABI if not hasattr(self._raw, n)]
         if missing:
             self.close()
-            raise EngineIncompatible(f"{_ABI_HINT} (missing: {', '.join(missing)})")
+            raise EngineIncompatible(_abi_hint(missing))
         # Read the engine identity off the connection we already have, which is
         # both cheaper and more accurate than the fallbacks in engine_version().
         if _ENGINE_VERSION is None:

--- a/chdb/durable/engine.py
+++ b/chdb/durable/engine.py
@@ -29,14 +29,9 @@ from .errors import EngineError, EngineIncompatible
 #: refusal can list what is missing rather than fail on first use.
 _REQUIRED_ABI = ("backup_database", "restore_database", "classify_query")
 
-#: Where the wheels that carry the ABI actually are. Not PyPI: a chdb-core
-#: release is about half a gigabyte of wheels against a project quota that only
-#: moves one way, so releases are published to GitHub and only some of them go
-#: on to PyPI. `pip install -U chdb-core` therefore does not reliably get you a
-#: newer engine, and a hint that says it does sends people in a circle.
-_RELEASES_URL = "https://github.com/chdb-io/chdb-core/releases"
-
-#: The first chdb-core that exports backup / restore / classify.
+#: The first chdb-core that exports backup / restore / classify, as the engine
+#: reports itself. Its distribution is versioned `26.7.2`, without the `rc.2`,
+#: and 26.7.3 is the first release carrying the ABI that is published to PyPI.
 _ABI_SINCE = "26.7.2-rc.2"
 
 
@@ -46,6 +41,11 @@ def _abi_hint(missing=()) -> str:
     The version is in the message because without it the two failures read
     identically: an engine too old to have the ABI, and a new engine that the
     wrapper is not actually loading because something else owns `chdb/`.
+
+    The command names chdb-core rather than chdb on purpose. pip's default
+    upgrade strategy leaves a dependency alone once it is satisfied, and an
+    installed 26.7.0 satisfies chdb's floor, so upgrading chdb would report
+    success and move nothing.
     """
     try:
         loaded = engine_version() or "unknown"
@@ -53,24 +53,13 @@ def _abi_hint(missing=()) -> str:
         loaded = "unknown"
 
     lines = [
-        "chdb.durable needs a chdb-core with the Durable V1 ABI "
-        "(backup_database / restore_database / classify_query), added in "
-        f"{_ABI_SINCE}.",
+        f"chdb.durable needs chdb-core {_ABI_SINCE} or newer, which added "
+        "backup_database / restore_database / classify_query.",
         f"The engine loaded here reports {loaded}.",
     ]
     if missing:
         lines.append("Missing: " + ", ".join(missing) + ".")
-    lines += [
-        "",
-        "chdb-core wheels are published as release assets, and the newest one "
-        "on PyPI may be older than the newest release, so `pip install -U "
-        "chdb-core` is not enough. Install the wheel for your platform from "
-        f"{_RELEASES_URL}/latest in the same command as chdb, so the wrapper's "
-        "chdb/__init__.py lands on top of the engine's:",
-        "",
-        '    pip install "chdb[durable]" \\',
-        '      "chdb-core @ <the chdb_core-*.whl URL for your platform>"',
-    ]
+    lines += ["", "    pip install -U chdb-core"]
     return "\n".join(lines)
 
 #: Settings pinned on the managed connection. A durable object promises that a

--- a/chdb/durable/namespace.py
+++ b/chdb/durable/namespace.py
@@ -17,13 +17,17 @@ from typing import Iterable, List, Optional, Tuple
 from .backends import make_backend
 from .errors import LeaseHeld, NotFound
 from .head import Head
-from .object import DurableObject, validate_oid
+from .object import DEFAULT_DATABASE, DurableObject, validate_oid
 from .protocol import HEAD_KEY
 
 
 class Namespace:
-    def __init__(self, url: str, *, owner: Optional[str] = None, db: str = "mem", **object_kwargs):
-        """`object_kwargs` are passed to every `DurableObject` this namespace
+    def __init__(self, url: str, *, owner: Optional[str] = None,
+                 db: str = DEFAULT_DATABASE, **object_kwargs):
+        """`db` names the one database a cold object is created with, and is
+        ignored for an object that already exists — its head is authoritative.
+
+        `object_kwargs` are passed to every `DurableObject` this namespace
         opens — `lease_ttl`, `clock_skew`, `heartbeat_interval`,
         `commit_deadline`."""
         self.url = url

--- a/chdb/durable/object.py
+++ b/chdb/durable/object.py
@@ -67,6 +67,7 @@ from .protocol import (
     COMMIT_MAX_ATTEMPTS,
     DEFAULT_CLOCK_SKEW,
     DEFAULT_COMMIT_DEADLINE,
+    DEFAULT_DATABASE,
     DEFAULT_LEASE_TTL,
     HEAD_KEY,
     HEARTBEAT_TTL_FRACTION,
@@ -109,7 +110,7 @@ class DurableObject:
     """
 
     def __init__(self, oid: str, backend, *, owner: Optional[str] = None,
-                 db: str = "mem", read_only: bool = False,
+                 db: str = DEFAULT_DATABASE, read_only: bool = False,
                  lease_ttl: float = DEFAULT_LEASE_TTL,
                  clock_skew: float = DEFAULT_CLOCK_SKEW,
                  heartbeat_interval: Optional[float] = None,

--- a/chdb/durable/protocol.py
+++ b/chdb/durable/protocol.py
@@ -52,6 +52,12 @@ COMMIT_BACKOFF_BASE = 0.2
 
 HEAD_KEY = "head.json"
 
+#: The database a cold object is created with when the caller names none. The
+#: head is authoritative once an object exists, so this only decides what a new
+#: one is stamped with -- but it decides it identically in Python, Node and Go,
+#: so the same code ported between them addresses the same table.
+DEFAULT_DATABASE = "default"
+
 _SHA256_RE = re.compile(r"\A[0-9a-f]{64}\Z")
 
 

--- a/dev-docs/CHDB_DURABLE_V1_CONTRACT.md
+++ b/dev-docs/CHDB_DURABLE_V1_CONTRACT.md
@@ -285,7 +285,7 @@ UTF-8 JSON，无 BOM。键顺序和空白不冻结；字段类型、含义和状
     "expires_at": 1788230400.0
   },
   "manifest": {
-    "db": "mem",
+    "db": "default",
     "base": {
       "key": "checkpoints/3-8-acde1234.tar.gz",
       "size": 1048576,
@@ -322,6 +322,7 @@ UTF-8 JSON，无 BOM。键顺序和空白不冻结；字段类型、含义和状
 - `engine.backup_format` 为 chDB backup archive 格式代际；V1 baseline 为 `1`；
 - `engine.min_reader` 为能够读取当前 object 的最低 chDB engine 版本；
 - 从首个 Durable V1 archive 开始，后续 chdb-core release 必须能恢复同一 release 或更早 release 经 `chdb_backup_database_n` 创建的 V1 full backup；只有当 archive 格式代际真的不兼容时，才通过提高 `backup_format` 让旧 reader fail closed；
+- `manifest.db` 为该 object 持有的唯一 database；冷建时取调用方给的名字，调用方不给时所有 binding 一律用 `default`；写入之后 head 即为权威，再次打开时传入的 database 参数必须被忽略；
 - `manifest.base` 为 object reference 或 `null`；
 - 每个 object reference 都必须包含 `key`、字节 `size` 和小写完整 SHA-256；
 - `manifest.wal` 按重放顺序排列；

--- a/docs/durable/index.mdx
+++ b/docs/durable/index.mdx
@@ -13,6 +13,16 @@ It is not a remote database or a live copy of the chDB data directory. Queries a
 
 For the cross-binding contract, see the [Durable V1 protocol](/chdb/durable/protocol-v1). For use cases and Python examples, see the [durable agent memory cookbook](https://github.com/chdb-io/cookbook/tree/main/durable-agent-memory).
 
+## Installation {#installation}
+
+```bash
+pip install "chdb[durable]"
+```
+
+Durable needs chdb-core 26.7.2-rc.2 or newer, for the backup, restore and query-analysis ABI it is built on. A fresh install resolves one; an install that already has an older chdb-core needs `pip install -U chdb-core`, because pip leaves a dependency alone once it is satisfied.
+
+The S3-compatible backend comes with the `durable` extra. Native Google Cloud Storage and Azure Blob are `chdb[durable-gcs]` and `chdb[durable-azure]`.
+
 ## How it works {#how-it-works}
 
 ```mermaid

--- a/tests/test_durable.py
+++ b/tests/test_durable.py
@@ -12,12 +12,14 @@ sequentially on purpose — chdb-core allows one active data path per process
 """
 import json
 import os
+import pathlib
 import tempfile
 import time
 import warnings
 
 from chdb import durable as cd
 from chdb.durable import protocol, wal as wal_mod
+from chdb.durable.protocol import DEFAULT_DATABASE
 from chdb.durable.backends import make_backend
 from chdb.durable.engine import engine_has_v1_abi, engine_version
 
@@ -87,7 +89,7 @@ def _valid_head(**overrides):
     return doc
 
 
-def _seeded(oid, rows=100, *, db="mem", checkpoint=True, ns=None):
+def _seeded(oid, rows=100, *, db=DEFAULT_DATABASE, checkpoint=True, ns=None):
     """An object holding `rows` rows in `db`.t, checkpointed by default."""
     ns = ns or _fresh_ns(db=db)
     ns.destroy(oid, force=True)
@@ -102,7 +104,7 @@ def _seeded(oid, rows=100, *, db="mem", checkpoint=True, ns=None):
     return ns
 
 
-def _count(ns, oid, *, db="mem"):
+def _count(ns, oid, *, db=DEFAULT_DATABASE):
     reader = ns.open(oid, read_only=True)
     try:
         return reader.query(f"SELECT count() FROM `{db}`.t", "CSV").data().strip()
@@ -184,7 +186,7 @@ def test_empty_object():
     # a released lease is one fixed shape, not "owner set to empty string"
     assert doc["lease"] == {"generation": 1, "owner": None, "instance": None,
                             "expires_at": None}
-    assert doc["manifest"] == {"db": "mem", "base": None, "wal": [], "seq": 0}
+    assert doc["manifest"] == {"db": DEFAULT_DATABASE, "base": None, "wal": [], "seq": 0}
     _PASSED.append("empty-object: cold create publishes a V1 head, lease released on close")
 
 
@@ -478,7 +480,10 @@ def test_mutating_global_refused():
 
 
 def test_control_statements_refused():
-    ns = _fresh_ns()
+    # Deliberately not the default database: "USE default" has to be refused
+    # rather than merely be a no-op, and only an object living somewhere else
+    # can tell those apart.
+    ns = _fresh_ns(db="mem")
     ns.destroy("c-control", force=True)
     obj = ns.open("c-control")
     obj.execute("CREATE TABLE t (n Int64) ENGINE=MergeTree ORDER BY n")
@@ -874,7 +879,7 @@ def test_scan_across_objects():
 def test_reopen_honors_persisted_db():
     # the object owns its database name; reopening with a different db argument
     # must not rewrite it, or the restore builds the wrong database
-    ns = _seeded("x-db", 5)
+    ns = _seeded("x-db", 5, db="mem")
     other = cd.Namespace(URL, owner="w1", db="somethingelse")
     reader = other.open("x-db", read_only=True)
     assert reader.db == "mem"
@@ -888,7 +893,7 @@ def test_reopen_honors_persisted_db():
     writer.checkpoint()
     writer.close()
     assert _head_of("x-db")["manifest"]["db"] == "mem"
-    assert _count(ns, "x-db") == "6"
+    assert _count(ns, "x-db", db="mem") == "6"
     _PASSED.append("reopen honors the manifest's database for readers and writers alike")
 
 
@@ -915,7 +920,7 @@ def test_wal_replay_uses_the_objects_database():
     obj.execute("INSERT INTO t VALUES (1), (2), (3)")
     obj.flush()   # no checkpoint: force a replay on reopen
     obj.close()
-    assert _count(ns, "x-replay") == "3"
+    assert _count(ns, "x-replay", db="mem") == "3"
     _PASSED.append("WAL replay restores the object's database context")
 
 
@@ -929,6 +934,19 @@ def test_wal_keys_are_unique():
     obj.close()
     assert first and second and first != second, (first, second)
     _PASSED.append("every flush mints a unique WAL key")
+
+
+def test_local_and_file_urls_name_the_same_directory():
+    # A namespace URL travels between bindings, so the local backend answers to
+    # both spellings: this one wrote `local:`, Node wrote `file:`. A file: URL
+    # is percent-encoded and a local: path is not, which is the only difference.
+    root = tempfile.mkdtemp(prefix="dao-scheme-")
+    nested = os.path.join(root, "a b")
+    os.makedirs(nested, exist_ok=True)
+    assert make_backend("local:" + nested, "o").root == make_backend(
+        pathlib.Path(nested).as_uri(), "o").root
+    _expect(ValueError, make_backend, "carrierpigeon://bucket/prefix")
+    _PASSED.append("local: and file:// reach one backend; an unknown scheme is refused")
 
 
 def test_constructor_validation():
@@ -995,6 +1013,7 @@ TESTS = [
     test_cold_open_lands_in_the_objects_database,
     test_wal_replay_uses_the_objects_database,
     test_wal_keys_are_unique,
+    test_local_and_file_urls_name_the_same_directory,
     test_constructor_validation,
 ]
 


### PR DESCRIPTION
Two things the same durable object needed different code for depending on which language opened it, and neither difference was anything the contract asked for.

**One URL.** The local backend answered only to `local:`, chdb-node only to `file:`, chdb-go to either — so no single namespace URL could be handed to all three. It now takes both here (chdb-node takes both as of chdb-io/chdb-node#94). A `file:` URL is percent-encoded and a `local:` path is not; that is the only difference between them.

**One default database.** A cold object was created in `mem` here and `default` in Node and Go. The head is authoritative once an object exists, so this never broke interop — but the same application ported between bindings addressed a differently-named table. `default` wins because two of three bindings already had it and it is what an unqualified statement means in chDB anyway. The contract now states it, so there is one answer rather than three implementations.

**The refusal says which engine is loaded.** It named the ABI it needed and nothing else, so its two causes read identically: an engine too old to have the ABI, and a new engine that the wrapper is not loading because something else owns `chdb/`. And the command it printed only became true with chdb-core 26.7.3 — the first release carrying the ABI that is published to PyPI. It names `chdb-core` rather than `chdb` because pip leaves a satisfied dependency alone, so upgrading `chdb` reports success and moves no engine.

```
chdb.durable needs chdb-core 26.7.2-rc.2 or newer, which added backup_database / restore_database / classify_query.
The engine loaded here reports 26.7.0.

    pip install -U chdb-core
```

## Verified

**Cross-binding recovery, contract §7.5 — the item no repository had implemented.** Every writer produces a 100-row checkpointed base plus a 50-row WAL tail that is flushed and not checkpointed, so a reader has to restore the base *and* replay the WAL. 3×3, on the local backend and again on real AWS S3, every cell 150 rows / `sum(id)` 11175 / `base` 100 + `wal` 50, each reader taking the database name from `head.json`:

| writer \ reader | Python | Node | Go |
|---|---|---|---|
| Python | ✓ | ✓ | ✓ |
| Node | ✓ | ✓ | ✓ |
| Go | ✓ | ✓ | ✓ |

After this change all three take the same URL string and the same database name.

Also: `tests/test_durable.py` 50 passed against chdb-core 26.7.2-rc.2, and the whole suite again against real AWS S3 (`DAO_TEST_URL=s3://…`, 49 passed in 7 minutes). The refusal message was checked from where a user actually is — `chdb` on PyPI's newest chdb-core, 26.7.0 — and it names 26.7.0.

## Two tests changed rather than being added to

`test_control_statements_refused` and `test_reopen_honors_persisted_db` both relied on the default being `mem`. With the default moved, the first one's `USE default` would have been a no-op instead of a refusal, and the second would have had nothing to disagree with. Both now name `mem` explicitly, which is what they were really testing.

## Follow-ups, once 26.7.3 is on PyPI

- add `chdb-core>=26.7.3` to the `durable` extra, so `pip install "chdb[durable]"` resolves an ABI-carrying engine deterministically
- drop the `CHDB_CORE_ABI_WHEEL` pin from the durable conformance step in the four wheel workflows; it exists only because no chdb-core on PyPI exported the ABI

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Standardize durable bindings on `default` database and add `file:` URL support to `make_backend`
> - Adds the shared `DEFAULT_DATABASE` constant (value `default`) in [protocol.py](https://github.com/chdb-io/chdb/pull/640/files#diff-2d45447a0277247a514842e3c9231e6ac99bea23a40ceb7293ac058af06cf364) and switches `DurableObject`, `Namespace`, and contract docs from the old `mem` default to it. Persisted head data remains authoritative on reopen.
> - Updates `make_backend` in [backends/__init__.py](https://github.com/chdb-io/chdb/pull/640/files#diff-edf2a4593a6ca5d237c043410bc0506bca8ddfaabb6e878934df53663d42288a) to route `file:` URLs into the local filesystem backend, percent-decoding the path before resolution; `local:` and bare paths stay literal.
> - Improves ABI mismatch errors in [engine.py](https://github.com/chdb-io/chdb/pull/640/files#diff-b6f345c95c93f34ee8ac5e9ebd4fad6c0f9fde56da4d6c0414ccd84a70e60d48) to report the loaded engine version and, for `ManagedConnection`, the missing required attributes.
> - Adds installation docs and bumps the documented minimum `chdb-core` to 26.7.2-rc.2.
> - Behavioral Change: cold-created durable objects without an explicit `db` now land in `default` instead of `mem`; existing tests that relied on the implicit `mem` default are updated to pass it explicitly.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 0dad0fc.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->