### PR TITLE
Let the durable extra name the engine it needs

### DIFF
--- a/.github/workflows/build_linux_arm64_wheels-gh.yml
+++ b/.github/workflows/build_linux_arm64_wheels-gh.yml
@@ -189,21 +189,13 @@ jobs:
           fi
 
           pyenv shell "$PYTHON_VERSION"
-          python -m pip install dist/*.whl --force-reinstall
-          python -m pip install pytest
 
-          # Move the engine to the pre-release that carries the Durable V1 ABI,
-          # then put the wrapper back on top of it.
-          #
-          # The second install is not redundant. chdb and chdb-core both own
-          # chdb/__init__.py, so whichever lands last wins, and the wrapper's
-          # is the one that has to: chdb-core ships a superset that happens to
-          # work today, which is not a property to build a test job on.
-          #
-          # --no-deps on both keeps pip from re-resolving chdb-core back down
-          # to what PyPI offers.
-          python -m pip install --force-reinstall --no-deps "$CHDB_CORE_ABI_WHEEL"
-          python -m pip install dist/*.whl --force-reinstall --no-deps
+          # With the extra, so the engine floor the durable extra declares is
+          # what decides which chdb-core this runs against -- the same
+          # resolution a user gets, rather than a wheel this file pins by hand.
+          WHEEL=$(ls dist/*.whl)
+          python -m pip install "${WHEEL}[durable]" --force-reinstall
+          python -m pip install pytest
 
           # Name the engine under test before running anything, so the wrong
           # one is one line of output rather than 49 collection errors.
@@ -217,23 +209,9 @@ jobs:
 
           # Exit 5 — pytest collecting nothing — used to be tolerated here,
           # because a module-level skip was the expected outcome on an engine
-          # without the ABI. With the engine pinned there is nothing left for
-          # that tolerance to excuse: collecting nothing now means the suite
-          # stopped running, so the exit status stands on its own.
+          # without the ABI. The durable extra now requires an engine that has
+          # it, so there is nothing left for that tolerance to excuse:
+          # collecting nothing means the suite stopped running, and the exit
+          # status stands on its own.
           python -m pytest tests/test_durable.py -v --tb=short
-        env:
-          # Pinned, and pinned to a pre-release on purpose.
-          #
-          # No chdb-core on PyPI exports backup_database / restore_database /
-          # classify_query — 26.7.0 is the newest published — so resolving
-          # the dependency normally leaves this suite skipping itself, and a
-          # step that is green whether or not it ran is not a check. The wheels
-          # are already attached to the chdb-core release, so pinning one costs
-          # a download and no build.
-          #
-          # This comes out when a chdb-core carrying the ABI is what pip
-          # resolves by default and chdb's floor rises to match. Until then the
-          # pre-release version keeps anything here from reading as a stable
-          # dependency.
-          CHDB_CORE_ABI_WHEEL: https://github.com/chdb-io/chdb-core/releases/download/v26.7.2-rc.2/chdb_core-26.7.2-cp39-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.whl
         continue-on-error: false

--- a/.github/workflows/build_linux_x86_wheels.yml
+++ b/.github/workflows/build_linux_x86_wheels.yml
@@ -216,21 +216,13 @@ jobs:
           fi
 
           pyenv shell "$PYTHON_VERSION"
-          python -m pip install dist/*.whl --force-reinstall
-          python -m pip install pytest
 
-          # Move the engine to the pre-release that carries the Durable V1 ABI,
-          # then put the wrapper back on top of it.
-          #
-          # The second install is not redundant. chdb and chdb-core both own
-          # chdb/__init__.py, so whichever lands last wins, and the wrapper's
-          # is the one that has to: chdb-core ships a superset that happens to
-          # work today, which is not a property to build a test job on.
-          #
-          # --no-deps on both keeps pip from re-resolving chdb-core back down
-          # to what PyPI offers.
-          python -m pip install --force-reinstall --no-deps "$CHDB_CORE_ABI_WHEEL"
-          python -m pip install dist/*.whl --force-reinstall --no-deps
+          # With the extra, so the engine floor the durable extra declares is
+          # what decides which chdb-core this runs against -- the same
+          # resolution a user gets, rather than a wheel this file pins by hand.
+          WHEEL=$(ls dist/*.whl)
+          python -m pip install "${WHEEL}[durable]" --force-reinstall
+          python -m pip install pytest
 
           # Name the engine under test before running anything, so the wrong
           # one is one line of output rather than 49 collection errors.
@@ -244,25 +236,11 @@ jobs:
 
           # Exit 5 — pytest collecting nothing — used to be tolerated here,
           # because a module-level skip was the expected outcome on an engine
-          # without the ABI. With the engine pinned there is nothing left for
-          # that tolerance to excuse: collecting nothing now means the suite
-          # stopped running, so the exit status stands on its own.
+          # without the ABI. The durable extra now requires an engine that has
+          # it, so there is nothing left for that tolerance to excuse:
+          # collecting nothing means the suite stopped running, and the exit
+          # status stands on its own.
           python -m pytest tests/test_durable.py -v --tb=short
-        env:
-          # Pinned, and pinned to a pre-release on purpose.
-          #
-          # No chdb-core on PyPI exports backup_database / restore_database /
-          # classify_query — 26.7.0 is the newest published — so resolving
-          # the dependency normally leaves this suite skipping itself, and a
-          # step that is green whether or not it ran is not a check. The wheels
-          # are already attached to the chdb-core release, so pinning one costs
-          # a download and no build.
-          #
-          # This comes out when a chdb-core carrying the ABI is what pip
-          # resolves by default and chdb's floor rises to match. Until then the
-          # pre-release version keeps anything here from reading as a stable
-          # dependency.
-          CHDB_CORE_ABI_WHEEL: https://github.com/chdb-io/chdb-core/releases/download/v26.7.2-rc.2/chdb_core-26.7.2-cp39-abi3-manylinux2014_x86_64.manylinux_2_17_x86_64.whl
         continue-on-error: false
       - name: Upload wheels to release
         if: startsWith(github.ref, 'refs/tags/v')

--- a/.github/workflows/build_macos_arm64_wheels.yml
+++ b/.github/workflows/build_macos_arm64_wheels.yml
@@ -167,21 +167,13 @@ jobs:
           fi
 
           pyenv shell "$PYTHON_VERSION"
-          python -m pip install dist/*.whl --force-reinstall
-          python -m pip install pytest
 
-          # Move the engine to the pre-release that carries the Durable V1 ABI,
-          # then put the wrapper back on top of it.
-          #
-          # The second install is not redundant. chdb and chdb-core both own
-          # chdb/__init__.py, so whichever lands last wins, and the wrapper's
-          # is the one that has to: chdb-core ships a superset that happens to
-          # work today, which is not a property to build a test job on.
-          #
-          # --no-deps on both keeps pip from re-resolving chdb-core back down
-          # to what PyPI offers.
-          python -m pip install --force-reinstall --no-deps "$CHDB_CORE_ABI_WHEEL"
-          python -m pip install dist/*.whl --force-reinstall --no-deps
+          # With the extra, so the engine floor the durable extra declares is
+          # what decides which chdb-core this runs against -- the same
+          # resolution a user gets, rather than a wheel this file pins by hand.
+          WHEEL=$(ls dist/*.whl)
+          python -m pip install "${WHEEL}[durable]" --force-reinstall
+          python -m pip install pytest
 
           # Name the engine under test before running anything, so the wrong
           # one is one line of output rather than 49 collection errors.
@@ -195,23 +187,9 @@ jobs:
 
           # Exit 5 — pytest collecting nothing — used to be tolerated here,
           # because a module-level skip was the expected outcome on an engine
-          # without the ABI. With the engine pinned there is nothing left for
-          # that tolerance to excuse: collecting nothing now means the suite
-          # stopped running, so the exit status stands on its own.
+          # without the ABI. The durable extra now requires an engine that has
+          # it, so there is nothing left for that tolerance to excuse:
+          # collecting nothing means the suite stopped running, and the exit
+          # status stands on its own.
           python -m pytest tests/test_durable.py -v --tb=short
-        env:
-          # Pinned, and pinned to a pre-release on purpose.
-          #
-          # No chdb-core on PyPI exports backup_database / restore_database /
-          # classify_query — 26.7.0 is the newest published — so resolving
-          # the dependency normally leaves this suite skipping itself, and a
-          # step that is green whether or not it ran is not a check. The wheels
-          # are already attached to the chdb-core release, so pinning one costs
-          # a download and no build.
-          #
-          # This comes out when a chdb-core carrying the ABI is what pip
-          # resolves by default and chdb's floor rises to match. Until then the
-          # pre-release version keeps anything here from reading as a stable
-          # dependency.
-          CHDB_CORE_ABI_WHEEL: https://github.com/chdb-io/chdb-core/releases/download/v26.7.2-rc.2/chdb_core-26.7.2-cp39-abi3-macosx_11_0_arm64.whl
         continue-on-error: false

--- a/.github/workflows/build_macos_x86_wheels.yml
+++ b/.github/workflows/build_macos_x86_wheels.yml
@@ -188,21 +188,13 @@ jobs:
           fi
 
           pyenv shell "$PYTHON_VERSION"
-          python -m pip install dist/*.whl --force-reinstall
-          python -m pip install pytest
 
-          # Move the engine to the pre-release that carries the Durable V1 ABI,
-          # then put the wrapper back on top of it.
-          #
-          # The second install is not redundant. chdb and chdb-core both own
-          # chdb/__init__.py, so whichever lands last wins, and the wrapper's
-          # is the one that has to: chdb-core ships a superset that happens to
-          # work today, which is not a property to build a test job on.
-          #
-          # --no-deps on both keeps pip from re-resolving chdb-core back down
-          # to what PyPI offers.
-          python -m pip install --force-reinstall --no-deps "$CHDB_CORE_ABI_WHEEL"
-          python -m pip install dist/*.whl --force-reinstall --no-deps
+          # With the extra, so the engine floor the durable extra declares is
+          # what decides which chdb-core this runs against -- the same
+          # resolution a user gets, rather than a wheel this file pins by hand.
+          WHEEL=$(ls dist/*.whl)
+          python -m pip install "${WHEEL}[durable]" --force-reinstall
+          python -m pip install pytest
 
           # Name the engine under test before running anything, so the wrong
           # one is one line of output rather than 49 collection errors.
@@ -216,23 +208,9 @@ jobs:
 
           # Exit 5 — pytest collecting nothing — used to be tolerated here,
           # because a module-level skip was the expected outcome on an engine
-          # without the ABI. With the engine pinned there is nothing left for
-          # that tolerance to excuse: collecting nothing now means the suite
-          # stopped running, so the exit status stands on its own.
+          # without the ABI. The durable extra now requires an engine that has
+          # it, so there is nothing left for that tolerance to excuse:
+          # collecting nothing means the suite stopped running, and the exit
+          # status stands on its own.
           python -m pytest tests/test_durable.py -v --tb=short
-        env:
-          # Pinned, and pinned to a pre-release on purpose.
-          #
-          # No chdb-core on PyPI exports backup_database / restore_database /
-          # classify_query — 26.7.0 is the newest published — so resolving
-          # the dependency normally leaves this suite skipping itself, and a
-          # step that is green whether or not it ran is not a check. The wheels
-          # are already attached to the chdb-core release, so pinning one costs
-          # a download and no build.
-          #
-          # This comes out when a chdb-core carrying the ABI is what pip
-          # resolves by default and chdb's floor rises to match. Until then the
-          # pre-release version keeps anything here from reading as a stable
-          # dependency.
-          CHDB_CORE_ABI_WHEEL: https://github.com/chdb-io/chdb-core/releases/download/v26.7.2-rc.2/chdb_core-26.7.2-cp39-abi3-macosx_10_15_x86_64.whl
         continue-on-error: false

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -48,15 +48,16 @@ clickhouse-connect = ["clickhouse-connect>=1.3.0"]
 # whose state lives in object storage you own. The S3-compatible backend
 # (AWS/MinIO/R2, and GCS via its S3 interop endpoint) needs boto3; the native
 # GCS and Azure Blob backends are separate opt-in extras.
-# chdb-core is named here and not only in the base dependency because the base
-# floor is satisfied by engines that cannot run durable at all: the backup,
-# restore and query-analysis ABI arrived in 26.7.2-rc.2, and 26.7.3 is the
-# first release carrying it that reached PyPI. Without this an install that
-# already had 26.7.0 stays there -- pip leaves a satisfied dependency alone --
-# and the first durable call is where the user finds out.
+# chdb-core is named in all three because the base floor is satisfied by
+# engines that cannot run durable at all: the backup, restore and
+# query-analysis ABI arrived in 26.7.2-rc.2, and 26.7.3 is the first release
+# carrying it that reached PyPI. Without it an install that already had 26.7.0
+# stays there -- pip leaves a satisfied dependency alone -- and the first
+# durable call is where the user finds out. The two native-backend extras need
+# it for the same reason and do not imply the S3 one, so each says so itself.
 durable = ["boto3>=1.36", "chdb-core>=26.7.3"]  # boto3: IfMatch/IfNoneMatch conditional writes on PutObject
-durable-gcs = ["google-cloud-storage"]
-durable-azure = ["azure-storage-blob"]
+durable-gcs = ["google-cloud-storage", "chdb-core>=26.7.3"]
+durable-azure = ["azure-storage-blob", "chdb-core>=26.7.3"]
 
 # chDB registers itself with clickhouse-connect through these entry points. clickhouse-connect
 # discovers them at runtime; it never imports chdb directly.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -48,7 +48,13 @@ clickhouse-connect = ["clickhouse-connect>=1.3.0"]
 # whose state lives in object storage you own. The S3-compatible backend
 # (AWS/MinIO/R2, and GCS via its S3 interop endpoint) needs boto3; the native
 # GCS and Azure Blob backends are separate opt-in extras.
-durable = ["boto3>=1.36"]  # IfMatch/IfNoneMatch conditional writes on PutObject
+# chdb-core is named here and not only in the base dependency because the base
+# floor is satisfied by engines that cannot run durable at all: the backup,
+# restore and query-analysis ABI arrived in 26.7.2-rc.2, and 26.7.3 is the
+# first release carrying it that reached PyPI. Without this an install that
+# already had 26.7.0 stays there -- pip leaves a satisfied dependency alone --
+# and the first durable call is where the user finds out.
+durable = ["boto3>=1.36", "chdb-core>=26.7.3"]  # boto3: IfMatch/IfNoneMatch conditional writes on PutObject
 durable-gcs = ["google-cloud-storage"]
 durable-azure = ["azure-storage-blob"]
 


### PR DESCRIPTION
Two things that were waiting on chdb-core v26.7.3 reaching PyPI. It has, so they come off.

## The durable extra names the engine it needs

chdb's base floor is `chdb-core>=26.7.0`, and an engine that satisfies it cannot run durable at all — the backup, restore and query-analysis ABI arrived in 26.7.2-rc.2. So `pip install "chdb[durable]"` resolved an engine the package would refuse to use, and an install that already had 26.7.0 stayed there, since pip leaves a satisfied dependency alone. The first durable call was where the user found out.

The extra now requires `chdb-core>=26.7.3`, the first release carrying the ABI that reached PyPI. Naming it only in the extra keeps every other chdb user off an engine upgrade they have no use for.

## The conformance job stops pinning a pre-release wheel by URL

It downloaded a specific chdb-core by URL and reinstalled the wrapper on top of it. Its own comment recorded why, and when it should stop:

> No chdb-core on PyPI exports `backup_database` / `restore_database` / `classify_query` — 26.7.0 is the newest published […] This comes out when a chdb-core carrying the ABI is what pip resolves by default and chdb's floor rises to match.

Both are now true. The job installs the wheel with its durable extra and tests whatever that resolves — the same engine a user gets, instead of one this file picks by hand and four copies of a URL to keep in step.

## Verified locally

Against the built wheel, exactly as the changed step does it:

```
$ pip install "dist/chdb-3.7.0-py3-none-any.whl[durable]" --force-reinstall
chdb         3.7.0
chdb-core    26.7.3
boto3        1.43.92

$ python - <<'PY'   # the job's own engine check
durable conformance: chdb-core 26.7.3

$ python -m pytest tests/test_durable.py -q
50 passed
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add `chdb-core>=26.7.3` to durable extras and install via extra in CI
> - Adds `chdb-core>=26.7.3` to the `durable`, `durable-gcs`, and `durable-azure` optional dependency groups in [pyproject.toml](https://github.com/chdb-io/chdb/pull/641/files#diff-50c86b7ed8ac2cf95bd48334961bf0530cdc77b5a56f852c5c61b89d735fd711) so each extra pulls the Durable V1 engine ABI it needs
> - Updates the durable-test setup steps in the Linux arm64/x86 and macOS arm64/x86 wheel build workflows to install the locally built wheel with the `durable` extra and normal dependency resolution, instead of installing a hard-coded pre-release `chdb-core` ABI wheel with `--no-deps`
> - Removes the `CHDB_CORE_ABI_WHEEL` environment configuration from those workflow steps
> - Risk: CI now relies on PyPI/registry resolution for `chdb-core` during durable tests; if the registry lacks a compatible `26.7.3+` build for a given platform, the durable-test step will fail at install time
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 0073702.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->